### PR TITLE
Added ability for wakes to have different lengths

### DIFF
--- a/source/opencopter/python.d
+++ b/source/opencopter/python.d
@@ -600,14 +600,14 @@ extern(C) void PydMain() {
 	wrap_struct!(
 		PyWake,
 		PyName!"Wake",
-		Init!(size_t, size_t, size_t, size_t, size_t),
+		Init!(size_t, size_t, size_t[], size_t, size_t),
 		Member!("rotor_wakes", Docstring!q{An array of :class:`RotorWake`})
 	);
 
 	wrap_struct!(
 		PyWakeHistory,
 		PyName!"WakeHistory",
-		Init!(size_t, size_t, size_t, size_t, size_t, size_t),
+		Init!(size_t, size_t, size_t[], size_t, size_t, size_t),
 		Member!("history", Docstring!q{An array of :class:`Wake` s, one for each timestep}),
 		Docstring!("Top level structure for holding the wake and its history")
 	);


### PR DESCRIPTION
The wake constructor now has an overload that takes in an array of wake lengths. This allows for upstream rotors to trail more wake than downstream rotor. This also necessitated changes in the vtu export functions. I also had to remove the extern(C++)
tag as c++ integration doesn't support d style dynamic arrays. I think this is fine as the extern(C++) stuff never really gave good
c++ interop out of the box. I think using something like SWIG in the future is probably the best way to go.

There was also some work done to perform some memory cleanup of the vtu stuff so that we don't constantly leak out vtk objects.