### PR TITLE
Support Python 3.11, 3.12, and 3.13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ fort.*
 __pycache__
 DebugInfoForProc_0.dat
 cases_*.nam
+
+.DS_Store

--- a/dub.json
+++ b/dub.json
@@ -231,6 +231,81 @@
 			}
 		},
 		{
+			"name": "library-python311",
+			"targetName": "opencopter",
+			"targetType": "dynamicLibrary",
+			"postBuildCommands-osx": [ "cp libopencopter.dylib libopencopter.so" ],
+			"dependencies": {
+				"pyd": { "path": "./dependencies/pyd" },
+				"vtkd": { "path": "./dependencies/vtkd" }
+			},
+			"subConfigurations": {
+				"pyd": "python311"
+			}
+		},
+		{
+			"name": "library-python311-novtk",
+			"targetName": "opencopter",
+			"targetType": "dynamicLibrary",
+			"postBuildCommands-osx": [ "cp libopencopter.dylib libopencopter.so" ],
+			"dependencies": {
+				"pyd": { "path": "./dependencies/pyd" }
+			},
+			"subConfigurations": {
+				"pyd": "python312"
+			}
+		},
+		{
+			"name": "library-python312",
+			"targetName": "opencopter",
+			"targetType": "dynamicLibrary",
+			"postBuildCommands-osx": [ "cp libopencopter.dylib libopencopter.so" ],
+			"dependencies": {
+				"pyd": { "path": "./dependencies/pyd" },
+				"vtkd": { "path": "./dependencies/vtkd" }
+			},
+			"subConfigurations": {
+				"pyd": "python311"
+			}
+		},
+		{
+			"name": "library-python312-novtk",
+			"targetName": "opencopter",
+			"targetType": "dynamicLibrary",
+			"postBuildCommands-osx": [ "cp libopencopter.dylib libopencopter.so" ],
+			"dependencies": {
+				"pyd": { "path": "./dependencies/pyd" }
+			},
+			"subConfigurations": {
+				"pyd": "python312"
+			}
+		},
+		{
+			"name": "library-python313",
+			"targetName": "opencopter",
+			"targetType": "dynamicLibrary",
+			"postBuildCommands-osx": [ "cp libopencopter.dylib libopencopter.so" ],
+			"dependencies": {
+				"pyd": { "path": "./dependencies/pyd" },
+				"vtkd": { "path": "./dependencies/vtkd" }
+			},
+			"subConfigurations": {
+				"pyd": "python313"
+			}
+		},
+		{
+			"name": "library-python313-novtk",
+			"targetName": "opencopter",
+			"targetType": "dynamicLibrary",
+			"postBuildCommands-osx": [ "cp libopencopter.dylib libopencopter.so" ],
+			"dependencies": {
+				"pyd": { "path": "./dependencies/pyd" }
+			},
+			"subConfigurations": {
+				"pyd": "python313"
+			}
+		},
+		{
 			"name": "library_huang",
 			"targetName": "opencopter_huang",
 			"targetType": "dynamicLibrary",


### PR DESCRIPTION
Updates pyd dependency to support more recent Python versions, and adds associated configurations to OpenCOPTER's dub JSON.