### PR TITLE
Some more changes added. Changes in the previous commit were producing incorrect results.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,5 +28,8 @@ DebugInfoForProc_0.dat
 cases_*.nam
 oc_fly/example/hart_ii/*.pdf
 oc_fly/example/helinovi/*.pdf
+oc_fly/example/test_evtol/
+oc_fly/example/test_evtol_no_symm/
 *.svg
 .DS_Store
+

--- a/oc_fly/example/test_evtol.json5
+++ b/oc_fly/example/test_evtol.json5
@@ -5,6 +5,6 @@
 		// y points out the starboard side,
 		// z points up (we aren't control nerds here)
 		name: "test_evtol",
-		vsp: "test_evtol.vsp3",
+		vsp: "test_evtol_no_symm.vsp3",
 	}
 ]

--- a/oc_fly/example/test_evtol_no_symm.vsp3
+++ b/oc_fly/example/test_evtol_no_symm.vsp3
@@ -1,0 +1,8942 @@
+<?xml version="1.0"?>
+<Vsp_Geometry>
+  <Version>5</Version>
+  <Vehicle>
+    <ParmContainer>
+      <ID>UKSANXNZKM</ID>
+      <Name>Vehicle</Name>
+      <AdjustView>
+        <CORX Value="0.000000000000000000e+00" ID="EYCZRNHGVZX"/>
+        <CORY Value="0.000000000000000000e+00" ID="CSKITJYKPEP"/>
+        <CORZ Value="0.000000000000000000e+00" ID="HRFVHQMFGIS"/>
+        <PanX Value="-2.365490436553955078e+00" ID="PNYDMBNQQXD"/>
+        <PanY Value="-5.517776608467102051e-01" ID="HJHSSHFFQWK"/>
+        <RotationX Value="2.548887945408607436e+01" ID="LDTVNWQNCUZ"/>
+        <RotationY Value="-6.710314568946607494e+01" ID="CVFHXKTISHP"/>
+        <RotationZ Value="-7.374313458166149360e+01" ID="NTKVXOTVXBG"/>
+        <ViewportX Value="0.000000000000000000e+00" ID="SYVDGIAFUUB"/>
+        <ViewportY Value="0.000000000000000000e+00" ID="SIVYKMTNTWB"/>
+        <Zoom Value="7.781898602843284607e-03" ID="SIZTPQKZXPW"/>
+      </AdjustView>
+      <AdvLinkSettings>
+        <AdvLinkDefNameContainer Value="1.000000000000000000e+00" ID="NTGAJAQTZKC"/>
+        <AdvLinkDefNameGroup Value="0.000000000000000000e+00" ID="WFUYFQGQIDN"/>
+        <AdvLinkGenDefName Value="0.000000000000000000e+00" ID="JLYKTNOVFLC"/>
+      </AdvLinkSettings>
+      <AirfoilExport>
+        <AFAppendGeomIDFlag Value="1.000000000000000000e+00" ID="VKCYCCJJYYM"/>
+        <AFExportType Value="0.000000000000000000e+00" ID="TUKBESXPVXC"/>
+        <AFWTessFactor Value="1.000000000000000000e+01" ID="JTJEMLEGGJT"/>
+      </AirfoilExport>
+      <Axis>
+        <AxisLength Value="1.000000000000000000e+00" ID="VTCBBSFRPHG"/>
+      </Axis>
+      <BBox>
+        <X_Len Value="5.500000000000001776e+00" ID="HCDOZKCMSHH"/>
+        <X_Min Value="0.000000000000000000e+00" ID="VBPBFPJALGM"/>
+        <Y_Len Value="4.608522517016348630e+00" ID="UOPVIXZDCIJ"/>
+        <Y_Min Value="-2.304261258508174315e+00" ID="GBKBQJFKNUP"/>
+        <Z_Len Value="1.586677369343602706e+00" ID="JACAPESAFDH"/>
+        <Z_Min Value="-4.338156574105050955e-01" ID="LBZAHBJOEEG"/>
+      </BBox>
+      <Background>
+        <HeightScale Value="1.000000000000000000e+00" ID="HQMXHAZNESH"/>
+        <WidthScale Value="1.000000000000000000e+00" ID="GRXYHCNUDFL"/>
+        <XOffset Value="0.000000000000000000e+00" ID="HLUYZCKKANV"/>
+        <YOffset Value="0.000000000000000000e+00" ID="GGSFIYYFYYO"/>
+      </Background>
+      <DXFSettings>
+        <BottomLeftRotation Value="0.000000000000000000e+00" ID="AQSBTKYYZJS"/>
+        <BottomLeftView Value="4.000000000000000000e+00" ID="MCMZHQABUIJ"/>
+        <BottomRightRotation Value="0.000000000000000000e+00" ID="SBHOMSHTKEX"/>
+        <BottomRightView Value="0.000000000000000000e+00" ID="BKMYAKYNOBL"/>
+        <DXFAllXSecFlag Value="0.000000000000000000e+00" ID="FRKSYFQBKTW"/>
+        <DXFColorFlag Value="0.000000000000000000e+00" ID="KBCPQQIIOKW"/>
+        <DXFProjectionFlag Value="0.000000000000000000e+00" ID="XTHTIJLPFSB"/>
+        <DXFTessFactor Value="2.000000000000000000e+00" ID="ZIHROKSNWZY"/>
+        <DimFlag Value="0.000000000000000000e+00" ID="KQOCSFEPPUX"/>
+        <LenUnit Value="4.000000000000000000e+00" ID="GEQJMKYNYPT"/>
+        <TopLeftRotation Value="1.000000000000000000e+00" ID="TOYUVEDGIBF"/>
+        <TopLeftView Value="2.000000000000000000e+00" ID="SXJNKOINDOL"/>
+        <TopRightRotation Value="0.000000000000000000e+00" ID="LINPXRIAOSP"/>
+        <TopRightView Value="6.000000000000000000e+00" ID="YEWHSRVSOAR"/>
+        <ViewType Value="3.000000000000000000e+00" ID="CWNSGIESZRF"/>
+      </DXFSettings>
+      <Design>
+        <Working_XDDM_Type Value="0.000000000000000000e+00" ID="BOPHBNTSCAL"/>
+      </Design>
+      <ExportFlag>
+        <CompGeom_CSV_Export Value="1.000000000000000000e+00" ID="TMWBVADNCKI"/>
+        <DegenGeom_CSV_Export Value="1.000000000000000000e+00" ID="VIUKDIDVONS"/>
+        <DegenGeom_M_Export Value="1.000000000000000000e+00" ID="ISSXEMZJWFL"/>
+      </ExportFlag>
+      <FeaStructure>
+        <StructModelUnit Value="6.000000000000000000e+00" ID="KZRROSVKVTZ"/>
+        <StructUnit Value="3.000000000000000000e+00" ID="SYEICBAIQCR"/>
+      </FeaStructure>
+      <FitModel>
+        <Select_Box_Flag Value="0.000000000000000000e+00" ID="GQRIKLBTZLA"/>
+        <Select_One_Flag Value="0.000000000000000000e+00" ID="KCXERLQHHCG"/>
+        <U_TargetPt Value="0.000000000000000000e+00" ID="KXDXEDVBFLW"/>
+        <U_Type Value="1.000000000000000000e+00" ID="AKBKDKFUQJY"/>
+        <W_TargetPt Value="0.000000000000000000e+00" ID="NHCZWWMFAWN"/>
+        <W_Type Value="1.000000000000000000e+00" ID="SGLZBDUGUCP"/>
+      </FitModel>
+      <IGESSettings>
+        <ExportPropMainSurf Value="0.000000000000000000e+00" ID="GNGDZXLBJSH"/>
+        <LabelAirfoilPart Value="1.000000000000000000e+00" ID="KBCPWBKRWJS"/>
+        <LabelDelim Value="0.000000000000000000e+00" ID="WPNWOKFAPWG"/>
+        <LabelID Value="1.000000000000000000e+00" ID="SLVDRRPFHKL"/>
+        <LabelName Value="1.000000000000000000e+00" ID="EHNISXCAKPF"/>
+        <LabelSplitNo Value="1.000000000000000000e+00" ID="WFEUXRPLPIN"/>
+        <LabelSurfNo Value="1.000000000000000000e+00" ID="MBJUFDPFBEQ"/>
+        <LenUnit Value="4.000000000000000000e+00" ID="MOHLYDFPYIE"/>
+        <MergeLETE Value="0.000000000000000000e+00" ID="AFMQRUJAEPL"/>
+        <SplitSubSurfs Value="0.000000000000000000e+00" ID="NPPEDSXYEHV"/>
+        <SplitSurfs Value="1.000000000000000000e+00" ID="VJWKDHKDOSD"/>
+        <StructureExportIndex Value="0.000000000000000000e+00" ID="TDZZGNVGUPV"/>
+        <StructureLabelAirfoilPart Value="1.000000000000000000e+00" ID="SRBUNYQNZNI"/>
+        <StructureLabelDelim Value="0.000000000000000000e+00" ID="IPAOZOQZSKY"/>
+        <StructureLabelID Value="1.000000000000000000e+00" ID="WKXDWOAMWIH"/>
+        <StructureLabelName Value="1.000000000000000000e+00" ID="MAZMIQGPNUA"/>
+        <StructureLabelSplitNo Value="1.000000000000000000e+00" ID="HLIQUMBLKDZ"/>
+        <StructureLabelSurfNo Value="1.000000000000000000e+00" ID="EHHCKUTKOQJ"/>
+        <StructureSplitSurfs Value="1.000000000000000000e+00" ID="BTPSBCUCTHQ"/>
+        <StructureToCubic Value="0.000000000000000000e+00" ID="TNLYPGECWXZ"/>
+        <StructureToCubicTol Value="9.999999999999999547e-07" ID="FMVYYOXEGEG"/>
+        <ToCubic Value="0.000000000000000000e+00" ID="RSAVVIVIJZT"/>
+        <ToCubicTol Value="9.999999999999999547e-07" ID="QPGRHXCNZLQ"/>
+        <TrimTE Value="0.000000000000000000e+00" ID="NEEAKWUBZOG"/>
+      </IGESSettings>
+      <MassProperties>
+        <DrawCgFlag Value="1.000000000000000000e+00" ID="VHOMKMVFQED"/>
+        <MassSliceDir Value="0.000000000000000000e+00" ID="TFWFUIYCRME"/>
+        <NumMassSlices Value="2.000000000000000000e+01" ID="EKYDJFHJKOU"/>
+      </MassProperties>
+      <Measure>
+        <LenUnit Value="6.000000000000000000e+00" ID="ZIJBVQLIDOH"/>
+      </Measure>
+      <PSlice>
+        <AutoBoundsFlag Value="1.000000000000000000e+00" ID="HOXYLINIPYR"/>
+        <MeasureDuctFlag Value="0.000000000000000000e+00" ID="SABUIMOTVNM"/>
+        <NumPlanerSlices Value="1.000000000000000000e+01" ID="HQLRFCEDBHJ"/>
+        <PlanarAxisType Value="0.000000000000000000e+00" ID="JAWXLNOANXQ"/>
+        <PlanarEndLocation Value="1.000000000000000000e+01" ID="LLQEXHFTCSH"/>
+        <PlanarStartLocation Value="0.000000000000000000e+00" ID="RUPNXMYPRYO"/>
+      </PSlice>
+      <Projection>
+        <BoundaryType Value="0.000000000000000000e+00" ID="KLJASDOMNWT"/>
+        <DirectionType Value="0.000000000000000000e+00" ID="OEKIFSLPVOB"/>
+        <TargetType Value="0.000000000000000000e+00" ID="XQPCAWQNZIJ"/>
+        <XComp Value="0.000000000000000000e+00" ID="DZPBHBFSJSA"/>
+        <YComp Value="0.000000000000000000e+00" ID="HDURMVFLGPL"/>
+        <ZComp Value="0.000000000000000000e+00" ID="OGTNHWOQYEQ"/>
+      </Projection>
+      <STEPSettings>
+        <ExportPropMainSurf Value="0.000000000000000000e+00" ID="EGGQSXYXMKE"/>
+        <LabelAirfoilPart Value="1.000000000000000000e+00" ID="DXUTHTSJTIP"/>
+        <LabelDelim Value="0.000000000000000000e+00" ID="WCOFBOINIKF"/>
+        <LabelID Value="1.000000000000000000e+00" ID="SWZPAZVSJXT"/>
+        <LabelName Value="1.000000000000000000e+00" ID="JXGPNNOSUWS"/>
+        <LabelSplitNo Value="1.000000000000000000e+00" ID="NNLPBNCEFCT"/>
+        <LabelSurfNo Value="1.000000000000000000e+00" ID="VSZCBXICAXT"/>
+        <LenUnit Value="4.000000000000000000e+00" ID="WQCATOKQUZS"/>
+        <MergeLETE Value="0.000000000000000000e+00" ID="MVZXJDTMLLM"/>
+        <MergePoints Value="0.000000000000000000e+00" ID="PXUDNHGHJHZ"/>
+        <SplitSubSurfs Value="0.000000000000000000e+00" ID="SGRUIROJVUA"/>
+        <SplitSurfs Value="1.000000000000000000e+00" ID="FOFCPVCJSOY"/>
+        <StructureExportIndex Value="0.000000000000000000e+00" ID="FDBSDPKYSRY"/>
+        <StructureLabelAirfoilPart Value="1.000000000000000000e+00" ID="XREYSEUWVND"/>
+        <StructureLabelDelim Value="0.000000000000000000e+00" ID="QCDJCMBUOSF"/>
+        <StructureLabelID Value="1.000000000000000000e+00" ID="EPRHALDBRGO"/>
+        <StructureLabelName Value="1.000000000000000000e+00" ID="QRFGZHLZUXI"/>
+        <StructureLabelSplitNo Value="1.000000000000000000e+00" ID="LQVPAOKNABB"/>
+        <StructureLabelSurfNo Value="1.000000000000000000e+00" ID="RUEKTREXSEL"/>
+        <StructureMergePoints Value="0.000000000000000000e+00" ID="GMRRSXUBTAP"/>
+        <StructureSplitSurfs Value="1.000000000000000000e+00" ID="NHSIDVIVRUK"/>
+        <StructureToCubic Value="0.000000000000000000e+00" ID="MUYNGWECEPW"/>
+        <StructureToCubicTol Value="9.999999999999999547e-07" ID="MHURVNHRYDW"/>
+        <StructureTolerance Value="9.999999999999999547e-07" ID="BTNVUXJRZGX"/>
+        <ToCubic Value="0.000000000000000000e+00" ID="GMMQBGRJEKE"/>
+        <ToCubicTol Value="9.999999999999999547e-07" ID="HNYNDOTREXX"/>
+        <Tolerance Value="9.999999999999999547e-07" ID="NCROOJZRPBV"/>
+        <TrimTE Value="0.000000000000000000e+00" ID="UXLBXZANKLG"/>
+      </STEPSettings>
+      <STLSettings>
+        <ExportPropMainSurf Value="0.000000000000000000e+00" ID="HMOMMONJNEU"/>
+        <MultiSolid Value="0.000000000000000000e+00" ID="PQPLRCMUNDQ"/>
+      </STLSettings>
+      <SVGSettings>
+        <BottomLeftRotation Value="0.000000000000000000e+00" ID="KCUIOPIQAHV"/>
+        <BottomLeftView Value="4.000000000000000000e+00" ID="AJIURYLAHLT"/>
+        <BottomRightRotation Value="0.000000000000000000e+00" ID="EFSQHGTXPQK"/>
+        <BottomRightView Value="0.000000000000000000e+00" ID="QCCBJTNLNUE"/>
+        <LenUnit Value="4.000000000000000000e+00" ID="AOVVTCVONUZ"/>
+        <SVGAllXSecFlag Value="0.000000000000000000e+00" ID="XQPFXUONOMA"/>
+        <SVGProjectionFlag Value="0.000000000000000000e+00" ID="KDPONCBCCVK"/>
+        <SVGSet Value="0.000000000000000000e+00" ID="GAZHEMGHLZK"/>
+        <SVGTessFactor Value="2.000000000000000000e+00" ID="BPDPZGGOFKN"/>
+        <Scale Value="0.000000000000000000e+00" ID="FMCWSQOTQSP"/>
+        <TopLeftRotation Value="1.000000000000000000e+00" ID="LWHHLOGLUHT"/>
+        <TopLeftView Value="2.000000000000000000e+00" ID="IKGVRULDBBV"/>
+        <TopRightRotation Value="0.000000000000000000e+00" ID="JYAMUMWWQSU"/>
+        <TopRightView Value="6.000000000000000000e+00" ID="MPJWUERDXXD"/>
+        <ViewType Value="3.000000000000000000e+00" ID="GMWNILCOHLW"/>
+      </SVGSettings>
+      <Screenshot>
+        <AutoCropFlag Value="0.000000000000000000e+00" ID="WTDVRZWPVDF"/>
+        <Height Value="1.104000000000000000e+03" ID="LHFQKCTWRZP"/>
+        <Ratio Value="1.000000000000000000e+00" ID="NUXURBPZFDY"/>
+        <TransparentBGFlag Value="1.000000000000000000e+00" ID="ZGQBIEZNPVZ"/>
+        <Width Value="1.331000000000000000e+03" ID="YZSHHGATPNI"/>
+      </Screenshot>
+      <SetEditor>
+        <CopySetsWithGeomsFlag Value="1.000000000000000000e+00" ID="FQRPKTWYPAK"/>
+      </SetEditor>
+      <Sets>
+        <NumUserSets Value="2.000000000000000000e+01" ID="LBQIBSFHMRI"/>
+      </Sets>
+      <Text>
+        <TextSize Value="2.000000000000000000e+00" ID="GJTZUHAFIWT"/>
+      </Text>
+      <UserParm>
+        <Max Value="1.000000000000000000e+05" ID="TJDYVKSQIOX"/>
+        <Min Value="-1.000000000000000000e+05" ID="AFNQSZWKCWF"/>
+        <Val Value="0.000000000000000000e+00" ID="DFGSIZTKFAO"/>
+      </UserParm>
+    </ParmContainer>
+    <Lights>
+      <Num_of_Lights>8</Num_of_Lights>
+      <Light0>
+        <ParmContainer>
+          <ID>NTAAGVCEMH</ID>
+          <Name>Default</Name>
+          <Light_Parm>
+            <ActiveFlag Value="1.000000000000000000e+00" ID="RHZUKLIJLCL"/>
+            <Ambient Value="5.000000000000000000e-01" ID="LZRWVKJVZMS"/>
+            <Diffuse Value="3.499999999999999778e-01" ID="NUVQLPFKZJW"/>
+            <Specular Value="1.000000000000000000e+00" ID="YOKBTCDCINX"/>
+            <X Value="1.000000000000000000e+01" ID="PTCQZMPLGNB"/>
+            <Y Value="-5.000000000000000000e+01" ID="QFRMXSGDLQG"/>
+            <Z Value="2.000000000000000000e+01" ID="MCNJDQEWTLR"/>
+          </Light_Parm>
+        </ParmContainer>
+      </Light0>
+      <Light1>
+        <ParmContainer>
+          <ID>UJHSSNGSVR</ID>
+          <Name>Default</Name>
+          <Light_Parm>
+            <ActiveFlag Value="1.000000000000000000e+00" ID="FJYVVBZBIYM"/>
+            <Ambient Value="5.000000000000000000e-01" ID="FBBBSIMNWZI"/>
+            <Diffuse Value="5.000000000000000000e-01" ID="OWTTBRFXELP"/>
+            <Specular Value="1.000000000000000000e+00" ID="DBZIDINSYXU"/>
+            <X Value="1.000000000000000000e+01" ID="ZOQKJVAAZBH"/>
+            <Y Value="1.500000000000000000e+01" ID="MWIMWELQIXF"/>
+            <Z Value="3.000000000000000000e+01" ID="JHOKJZHWSTW"/>
+          </Light_Parm>
+        </ParmContainer>
+      </Light1>
+      <Light2>
+        <ParmContainer>
+          <ID>YIPPYTYCPB</ID>
+          <Name>Default</Name>
+          <Light_Parm>
+            <ActiveFlag Value="1.000000000000000000e+00" ID="UOYIQPUFQWK"/>
+            <Ambient Value="0.000000000000000000e+00" ID="HETFKEFTDWH"/>
+            <Diffuse Value="5.000000000000000000e-01" ID="XOUSWQEXWQQ"/>
+            <Specular Value="5.000000000000000000e-01" ID="OBRRDWLKIHM"/>
+            <X Value="-5.000000000000000000e+01" ID="JSYIIKGUBCV"/>
+            <Y Value="3.000000000000000000e+01" ID="EKWRSBSLWPH"/>
+            <Z Value="1.000000000000000000e+01" ID="SESZCCZITVQ"/>
+          </Light_Parm>
+        </ParmContainer>
+      </Light2>
+      <Light3>
+        <ParmContainer>
+          <ID>HYZEMSQRLG</ID>
+          <Name>Default</Name>
+          <Light_Parm>
+            <ActiveFlag Value="0.000000000000000000e+00" ID="XJMIRMAAJRF"/>
+            <Ambient Value="0.000000000000000000e+00" ID="KENJQFYLVKT"/>
+            <Diffuse Value="0.000000000000000000e+00" ID="ZOTXOXIXWLP"/>
+            <Specular Value="0.000000000000000000e+00" ID="BAMQQLMAEEM"/>
+            <X Value="0.000000000000000000e+00" ID="PWIPFIWOSUW"/>
+            <Y Value="0.000000000000000000e+00" ID="BCZHPTMKZUH"/>
+            <Z Value="0.000000000000000000e+00" ID="KXPNVHFZWDT"/>
+          </Light_Parm>
+        </ParmContainer>
+      </Light3>
+      <Light4>
+        <ParmContainer>
+          <ID>QXMBGAVCIO</ID>
+          <Name>Default</Name>
+          <Light_Parm>
+            <ActiveFlag Value="0.000000000000000000e+00" ID="GYQJOEWXPPK"/>
+            <Ambient Value="0.000000000000000000e+00" ID="ATHQUOPYELA"/>
+            <Diffuse Value="0.000000000000000000e+00" ID="KGKGASSLPKC"/>
+            <Specular Value="0.000000000000000000e+00" ID="YQIAEKUXYVA"/>
+            <X Value="0.000000000000000000e+00" ID="SAKTFPUYHTX"/>
+            <Y Value="0.000000000000000000e+00" ID="UPEFNJCMAVF"/>
+            <Z Value="0.000000000000000000e+00" ID="RSVPLKEOBVV"/>
+          </Light_Parm>
+        </ParmContainer>
+      </Light4>
+      <Light5>
+        <ParmContainer>
+          <ID>NTEVERZTWK</ID>
+          <Name>Default</Name>
+          <Light_Parm>
+            <ActiveFlag Value="0.000000000000000000e+00" ID="VKQQXHDGQSI"/>
+            <Ambient Value="0.000000000000000000e+00" ID="CBCYQVNKSNP"/>
+            <Diffuse Value="0.000000000000000000e+00" ID="FHWIDHRNDTW"/>
+            <Specular Value="0.000000000000000000e+00" ID="ZUCCQHBOGIW"/>
+            <X Value="0.000000000000000000e+00" ID="JEPFYAUXZAJ"/>
+            <Y Value="0.000000000000000000e+00" ID="KPOSHEQNHGG"/>
+            <Z Value="0.000000000000000000e+00" ID="AMINCWHRAYH"/>
+          </Light_Parm>
+        </ParmContainer>
+      </Light5>
+      <Light6>
+        <ParmContainer>
+          <ID>LFNJWFSJDP</ID>
+          <Name>Default</Name>
+          <Light_Parm>
+            <ActiveFlag Value="0.000000000000000000e+00" ID="OURAFCMZSHK"/>
+            <Ambient Value="0.000000000000000000e+00" ID="GFMKLOKTMOW"/>
+            <Diffuse Value="0.000000000000000000e+00" ID="ZUZMMLYEYYB"/>
+            <Specular Value="0.000000000000000000e+00" ID="WNWQSQEILOT"/>
+            <X Value="0.000000000000000000e+00" ID="RGBMYHPMZPB"/>
+            <Y Value="0.000000000000000000e+00" ID="YQIUDSOHDFD"/>
+            <Z Value="0.000000000000000000e+00" ID="KJVRTCTYPBO"/>
+          </Light_Parm>
+        </ParmContainer>
+      </Light6>
+      <Light7>
+        <ParmContainer>
+          <ID>TYRREKOQGN</ID>
+          <Name>Default</Name>
+          <Light_Parm>
+            <ActiveFlag Value="0.000000000000000000e+00" ID="FRGQBKPOPHJ"/>
+            <Ambient Value="0.000000000000000000e+00" ID="AFWTTHSVKDF"/>
+            <Diffuse Value="0.000000000000000000e+00" ID="SCREEYIOVXH"/>
+            <Specular Value="0.000000000000000000e+00" ID="NOUQUCQHJWV"/>
+            <X Value="0.000000000000000000e+00" ID="PSSCQNERVWJ"/>
+            <Y Value="0.000000000000000000e+00" ID="OMCEUNOMJZD"/>
+            <Z Value="0.000000000000000000e+00" ID="SYUYJVOLQMP"/>
+          </Light_Parm>
+        </ParmContainer>
+      </Light7>
+    </Lights>
+    <Measure>
+      <Num_of_Protractors>0</Num_of_Protractors>
+      <Num_of_Rulers>0</Num_of_Rulers>
+      <Num_of_Probes>0</Num_of_Probes>
+      <Num_of_RSTprobes>0</Num_of_RSTprobes>
+    </Measure>
+    <Geom>
+      <ParmContainer>
+        <ID>OHEAIBPMDY</ID>
+        <Name>Fuselage</Name>
+        <Attach>
+          <Eta_Attach_Location Value="0.000000000000000000e+00" ID="VVTIXHDHGDH"/>
+          <L_01 Value="1.000000000000000000e+00" ID="QIXPVVCMHLZ"/>
+          <L_Attach_Location Value="0.000000000000000000e+00" ID="IFPGOYIDGUA"/>
+          <L_Attach_Location0Len Value="0.000000000000000000e+00" ID="MXBEPVMKVZQ"/>
+          <M_Attach_Location Value="5.000000000000000000e-01" ID="BXLYGVDAASR"/>
+          <N_Attach_Location Value="5.000000000000000000e-01" ID="SHFEXBUWCXL"/>
+          <R_01 Value="1.000000000000000000e+00" ID="AVWYEWIQNIL"/>
+          <R_Attach_Location Value="0.000000000000000000e+00" ID="RQHEUWWUUNA"/>
+          <R_Attach_Location0N Value="0.000000000000000000e+00" ID="WRZLQDSAHGA"/>
+          <Rots_Attach_Flag Value="0.000000000000000000e+00" ID="ABCIOVWAPTH"/>
+          <S_Attach_Location Value="5.000000000000000000e-01" ID="IYYVNCPMAUA"/>
+          <T_Attach_Location Value="5.000000000000000000e-01" ID="UHVZACNMYAU"/>
+          <Trans_Attach_Flag Value="0.000000000000000000e+00" ID="EVZIYFHRZJJ"/>
+          <U_01 Value="1.000000000000000000e+00" ID="MBAFASPMOXC"/>
+          <U_Attach_Location Value="0.000000000000000000e+00" ID="YAWYNDRGWLC"/>
+          <U_Attach_Location0N Value="0.000000000000000000e+00" ID="ZKYFHWTAOVI"/>
+          <V_Attach_Location Value="0.000000000000000000e+00" ID="OIQCYJMQHDD"/>
+        </Attach>
+        <BBox>
+          <X_Len Value="5.500000000000001776e+00" ID="LJBQFKBKBYZ"/>
+          <X_Min Value="0.000000000000000000e+00" ID="CIZXVMMAKXF"/>
+          <Y_Len Value="6.250000454774038428e-01" ID="NSBDCWHQHMI"/>
+          <Y_Min Value="-3.125000227387018659e-01" ID="QSUMNUSVGRF"/>
+          <Z_Len Value="1.085150552944857516e+00" ID="PTKINPBWEHN"/>
+          <Z_Min Value="-4.338156574105050955e-01" ID="EURFTRAUTSL"/>
+        </BBox>
+        <Design>
+          <Length Value="5.500000000000000000e+00" ID="ZYDUOYRVTOM"/>
+          <OrderPolicy Value="0.000000000000000000e+00" ID="KTUTAMYIVNT"/>
+        </Design>
+        <EndCap>
+          <CapUMaxLength Value="1.000000000000000000e+00" ID="SQEYKETDIYN"/>
+          <CapUMaxOffset Value="0.000000000000000000e+00" ID="YNVTMCVRZXY"/>
+          <CapUMaxOption Value="0.000000000000000000e+00" ID="UOSCKCRHADP"/>
+          <CapUMaxStrength Value="5.000000000000000000e-01" ID="JYYHVACSSHK"/>
+          <CapUMaxSweepFlag Value="0.000000000000000000e+00" ID="VQBDFYMTEUU"/>
+          <CapUMinLength Value="1.000000000000000000e+00" ID="BFMOQAIIWIQ"/>
+          <CapUMinOffset Value="0.000000000000000000e+00" ID="ZXGXAEZPHAH"/>
+          <CapUMinOption Value="0.000000000000000000e+00" ID="OVOPYJEHXMI"/>
+          <CapUMinStrength Value="5.000000000000000000e-01" ID="ALVMQDSPPNY"/>
+          <CapUMinSweepFlag Value="0.000000000000000000e+00" ID="HPHEVEAOFPW"/>
+          <CapUMinTess Value="3.000000000000000000e+00" ID="QWNWTEWBYWI"/>
+        </EndCap>
+        <EngineModel>
+          <AutoExtensionFlag Value="0.000000000000000000e+00" ID="BPAONTMTWQK"/>
+          <AutoExtensionSet Value="1.000000000000000000e+00" ID="WTFCKLJWIRP"/>
+          <ExtensionDistance Value="2.500000000000000000e+00" ID="DHYJGIEEGMD"/>
+          <GeomIOType Value="0.000000000000000000e+00" ID="KOWIHFDIQHT"/>
+          <GeomInType Value="0.000000000000000000e+00" ID="EXOEKWYXUTE"/>
+          <GeomOutType Value="1.000000000000000000e+00" ID="CDCIXHXDHDU"/>
+          <InletFaceIndex Value="0.000000000000000000e+00" ID="ZNXJINROXZE"/>
+          <InletFaceMode Value="0.000000000000000000e+00" ID="IZLTCBKBHXO"/>
+          <InletFaceU Value="0.000000000000000000e+00" ID="QJJXLATJRWD"/>
+          <InletLipIndex Value="0.000000000000000000e+00" ID="RKFDUOTGGUJ"/>
+          <InletLipMode Value="0.000000000000000000e+00" ID="CNHFNQZPOQE"/>
+          <InletLipU Value="0.000000000000000000e+00" ID="BZKCHNNJXOY"/>
+          <InletModeType Value="2.000000000000000000e+00" ID="ORNBFTUYFJD"/>
+          <OutletFaceIndex Value="0.000000000000000000e+00" ID="DWMKSWZXXIQ"/>
+          <OutletFaceMode Value="0.000000000000000000e+00" ID="MAFKFQXEDAV"/>
+          <OutletFaceU Value="0.000000000000000000e+00" ID="AWSMFHNCKNM"/>
+          <OutletLipIndex Value="0.000000000000000000e+00" ID="EANFTNGSMLN"/>
+          <OutletLipMode Value="0.000000000000000000e+00" ID="MRGUYOQHOIG"/>
+          <OutletLipU Value="0.000000000000000000e+00" ID="TTCZLHHYONM"/>
+          <OutletModeType Value="2.000000000000000000e+00" ID="GRYGFPAJRWP"/>
+        </EngineModel>
+        <Index>
+          <ActiveXSec Value="4.000000000000000000e+00" ID="KJVILLSICAX"/>
+        </Index>
+        <Mass_Props>
+          <CGx Value="0.000000000000000000e+00" ID="RRUSGNNCMKB"/>
+          <CGy Value="0.000000000000000000e+00" ID="SUUJTKKTNIC"/>
+          <CGz Value="0.000000000000000000e+00" ID="PFQMVYTTGDZ"/>
+          <Density Value="1.000000000000000000e+00" ID="XKADDOQAWII"/>
+          <Ixx Value="0.000000000000000000e+00" ID="GQXUYINCLCA"/>
+          <Ixy Value="0.000000000000000000e+00" ID="KRXJFUJEWRX"/>
+          <Ixz Value="0.000000000000000000e+00" ID="OTGHNZWPSKL"/>
+          <Iyy Value="0.000000000000000000e+00" ID="MIOBWCDXOQI"/>
+          <Iyz Value="0.000000000000000000e+00" ID="VCYBLLWHYDF"/>
+          <Izz Value="0.000000000000000000e+00" ID="TLKZDHWSJPR"/>
+          <Mass_Area Value="1.000000000000000000e+00" ID="STFVULOQMTY"/>
+          <Mass_Prior Value="0.000000000000000000e+00" ID="MYQYNLNJTBT"/>
+          <PointMass Value="0.000000000000000000e+00" ID="PLWKFHTECDP"/>
+          <Shell_Flag Value="0.000000000000000000e+00" ID="LTKHCMYKIPL"/>
+        </Mass_Props>
+        <Negative_Volume_Props>
+          <Negative_Volume_Flag Value="0.000000000000000000e+00" ID="UFXQGTHPCSA"/>
+        </Negative_Volume_Props>
+        <ParasiteDragProps>
+          <ExpandedList Value="0.000000000000000000e+00" ID="ZQOULHEMMLT"/>
+          <FFBodyEqnType Value="3.000000000000000000e+00" ID="GMAYNFJSVCD"/>
+          <FFUser Value="1.000000000000000000e+00" ID="WJIFWIEAUBS"/>
+          <FFWingEqnType Value="3.000000000000000000e+00" ID="IHPMEMGXYIJ"/>
+          <IncorporatedGen Value="0.000000000000000000e+00" ID="VQFDPMGDAPR"/>
+          <PercLam Value="0.000000000000000000e+00" ID="BKKBKWGIKGB"/>
+          <Q Value="1.000000000000000000e+00" ID="SPUWJOTVEOS"/>
+          <Roughness Value="0.000000000000000000e+00" ID="QCCKYFIMCAV"/>
+          <TawTwRatio Value="1.000000000000000000e+00" ID="NPLTGXMXYMO"/>
+          <TeTwRatio Value="1.000000000000000000e+00" ID="ZQCCYMFYTFH"/>
+        </ParasiteDragProps>
+        <Shape>
+          <Tess_U Value="1.600000000000000000e+01" ID="ZYFBONVGRGF"/>
+          <Tess_W Value="1.700000000000000000e+01" ID="CTTXFVUXUUF"/>
+          <Wake Value="0.000000000000000000e+00" ID="BGZIYCLOZHU"/>
+        </Shape>
+        <Sym>
+          <Sym_Ancestor Value="1.000000000000000000e+00" ID="MHTUNQUATCY"/>
+          <Sym_Ancestor_Origin_Flag Value="1.000000000000000000e+00" ID="AHYXQACEGEQ"/>
+          <Sym_Axial_Flag Value="0.000000000000000000e+00" ID="DMSGCXJYRAJ"/>
+          <Sym_Planar_Flag Value="0.000000000000000000e+00" ID="XEQJYGXAZAR"/>
+          <Sym_Rot_N Value="2.000000000000000000e+00" ID="ECAWLJABHJL"/>
+        </Sym>
+        <WakeSettings>
+          <WakeAngle Value="0.000000000000000000e+00" ID="EQCKFSGJWIM"/>
+          <WakeScale Value="2.000000000000000000e+00" ID="IYMCFTTWQGT"/>
+        </WakeSettings>
+        <XForm>
+          <Abs_Or_Relitive_flag Value="1.000000000000000000e+00" ID="RIWXHZSBHXF"/>
+          <Last_Scale Value="2.500000000000000000e-01" ID="ZNMOVQHXTGY"/>
+          <Origin Value="0.000000000000000000e+00" ID="QBDGNSVVXVF"/>
+          <Scale Value="2.500000000000000000e-01" ID="YPMAOGGVZYY"/>
+          <X_Location Value="0.000000000000000000e+00" ID="XXQJBXIYVZR"/>
+          <X_Rel_Location Value="0.000000000000000000e+00" ID="RSYXBRQEACM"/>
+          <X_Rel_Rotation Value="0.000000000000000000e+00" ID="WMSDWTFMLAC"/>
+          <X_Rotation Value="0.000000000000000000e+00" ID="ZWGMLJKVQMI"/>
+          <Y_Location Value="0.000000000000000000e+00" ID="LGWWZOVHWVU"/>
+          <Y_Rel_Location Value="0.000000000000000000e+00" ID="MANCDKJKCDG"/>
+          <Y_Rel_Rotation Value="0.000000000000000000e+00" ID="VWNSTULSCXF"/>
+          <Y_Rotation Value="0.000000000000000000e+00" ID="RBFYIHPMMWW"/>
+          <Z_Location Value="0.000000000000000000e+00" ID="YZEODTUKJTM"/>
+          <Z_Rel_Location Value="0.000000000000000000e+00" ID="DJJXCJDIOMP"/>
+          <Z_Rel_Rotation Value="0.000000000000000000e+00" ID="EHWFALNNBDF"/>
+          <Z_Rotation Value="0.000000000000000000e+00" ID="VYTOXZWMXOA"/>
+        </XForm>
+      </ParmContainer>
+      <GeomBase>
+        <TypeName>Fuselage</TypeName>
+        <TypeID>4</TypeID>
+        <TypeFixed>0</TypeFixed>
+        <ParentID>NONE</ParentID>
+        <Child_List>
+          <Child>
+            <ID>LOENSIWPJA</ID>
+          </Child>
+        </Child_List>
+      </GeomBase>
+      <Material>
+        <Name>Default</Name>
+      </Material>
+      <Wire_Color>
+        <ParmContainer>
+          <ID>XTPRPGJYAM</ID>
+          <Name>Default</Name>
+          <Color_Parm>
+            <Alpha Value="2.550000000000000000e+02" ID="YZDUCTRCDOO"/>
+            <Blue Value="2.550000000000000000e+02" ID="YMOWVNVEOKY"/>
+            <Green Value="0.000000000000000000e+00" ID="QMBTJYAFILS"/>
+            <Red Value="0.000000000000000000e+00" ID="RVKLYPSGTJH"/>
+          </Color_Parm>
+        </ParmContainer>
+      </Wire_Color>
+      <Textures>
+        <Num_of_Tex>0</Num_of_Tex>
+      </Textures>
+      <Geom>
+        <Set_List>1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, </Set_List>
+        <SubSurfaces/>
+        <FeaStructures/>
+      </Geom>
+      <FuselageGeom>
+        <ParmContainer>
+          <ID>ACLQUXSAEE</ID>
+          <Name>Default</Name>
+        </ParmContainer>
+        <XSecSurf>
+          <XSec>
+            <ParmContainer>
+              <ID>LOVUMOTRFO</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="YTKUCRFEJWT"/>
+                <AllSym Value="0.000000000000000000e+00" ID="EIFVGNZBSWZ"/>
+                <BottomLAngle Value="4.500000000000000000e+01" ID="GTQAJOZVHJT"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="AGGOESNMJNO"/>
+                <BottomLCurve Value="1.552158019779665610e+00" ID="PTJZXBEULGV"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="USCXUHNTTPA"/>
+                <BottomLRAngleEq Value="1.000000000000000000e+00" ID="OYFVFRCLGVW"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="XZYUTJBGYSV"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="EKCGJHGCMJK"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="OTLIXRTQSEY"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="NHLTXRGEBRB"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="ZMGYAWRVTJJ"/>
+                <BottomLStrength Value="7.500000000000000000e-01" ID="RSBHWKMVQOI"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="TAWGTHDRTFJ"/>
+                <BottomRAngle Value="4.500000000000000000e+01" ID="QPGYQKALLLY"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="ZIQQUMPJAZO"/>
+                <BottomRCurve Value="1.552158017797747869e+00" ID="BCNVDWOFDAK"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="LIXJOLSVMVD"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="VHHCZUCDQFC"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="SSHKPMMUIBA"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="ATLCJSWGBJU"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="QNXLWBMNXCZ"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="FZBSRBWZIFT"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="XGGKZJYSFJO"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="WDLCFJTKLDV"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="KEPDBXCOPNP"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="WOLUNDPLDZX"/>
+                <LeftLAngle Value="4.500000000000000000e+01" ID="QGSUULVOFJO"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="DPZWGTMPGOA"/>
+                <LeftLCurve Value="1.771696010776087737e+00" ID="QTKCPIIZDMK"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="RSQSBZEMCZS"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="KKFORGZSIST"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="XQSODHTVAQF"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="AIIXZAXSKHI"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="GUUNLGVFZPZ"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="SGUOKZJUJSP"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="SUWUKSIPGWB"/>
+                <LeftLStrength Value="7.500000000000000000e-01" ID="YYAOERRBBSZ"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="AUQVVXVPCIS"/>
+                <LeftRAngle Value="4.500000000000000000e+01" ID="XMGQTJPJOZI"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="EFHNQIGXVQE"/>
+                <LeftRCurve Value="1.771696008511606024e+00" ID="BXBGFGAKOWH"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="PZKLKDNZUYR"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="BOBNMZHFKWX"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="FRWNUYXAJBJ"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="PHPLUJHQUEH"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="QPPGJSSUBZP"/>
+                <RLSym Value="1.000000000000000000e+00" ID="UPMFYESGRJA"/>
+                <RefLength Value="5.500000000000000000e+00" ID="XVLSHZQULRR"/>
+                <RightLAngle Value="4.500000000000000000e+01" ID="WCDCIOYXPBG"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="FEHQZADLMKI"/>
+                <RightLCurve Value="1.771696010776087737e+00" ID="HYSFMFHCBHB"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="FRXQXGUXNPD"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="WDBOYKGKLHT"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="KIXQXARBTWR"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="AGOPJIGVHQA"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="GOLKYKVOVET"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="HDKVGCSIVKM"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="FNMTDYPSNTT"/>
+                <RightLStrength Value="7.500000000000000000e-01" ID="IMJAXAQQHDQ"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="OTQOWPUTAZK"/>
+                <RightRAngle Value="4.500000000000000000e+01" ID="QACQIUAVDGX"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="NHDUSSJZLIV"/>
+                <RightRCurve Value="1.771696008511606024e+00" ID="CQWCLZJIGOQ"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="MOGUKXMCAZF"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="FHIVLWLMDCE"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="YPTJUYVKJOM"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="VLJEZOKNEAL"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="RMNRCXXHBBI"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="LWVPAKJQXBX"/>
+                <Spin Value="0.000000000000000000e+00" ID="LWFNTGUZWYN"/>
+                <TBSym Value="1.000000000000000000e+00" ID="KWXYIONKGSD"/>
+                <TopLAngle Value="4.500000000000000000e+01" ID="LKWHYCIEIKJ"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="OIPNWQEYPYH"/>
+                <TopLCurve Value="1.557471903086940168e+00" ID="AIOVKTNXURN"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="IPIZVIJAEMV"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="DYAPUBRTNSU"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="FQWNZZDTIVM"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="KENMPGJVLDH"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="AKGOILXVHCZ"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="CQXQWDDHFCX"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="WKJKRZOSBTA"/>
+                <TopLStrength Value="7.500000000000000000e-01" ID="HWIEMAOWMIH"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="KEGVUFHFKBS"/>
+                <TopRAngle Value="4.500000000000000000e+01" ID="RUEQKLYYOOI"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="BENTEUGEIXH"/>
+                <TopRCurve Value="1.557471900590749803e+00" ID="PAESBGVARNS"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="QQDQRQGBHJT"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="RCIBWXZPKAU"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="CQWYUTICCKQ"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="PBAPINUOAMH"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="HYZVMKGFLIQ"/>
+                <XLocPercent Value="0.000000000000000000e+00" ID="MRYCSUIYIPX"/>
+                <XRotate Value="0.000000000000000000e+00" ID="YWITMEPCILR"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="TUMFUREWQIQ"/>
+                <YRotate Value="0.000000000000000000e+00" ID="BKYZYSDLFYO"/>
+                <ZLocPercent Value="0.000000000000000000e+00" ID="UJRGNUIYWYY"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="RNXVPBXRBRJ"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>EKNWDRWCBK</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="RIVAGSWTSXV"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="GAAPPDKLFKY"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="VIZXQDXXSXQ"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="YSNZGKHIOFD"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="YJAAIEOEIMG"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="VXZSHEXVPNR"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="NUJTUHEBOXW"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="DRISFESLWPT"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="MGOZOWKSDCE"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="ALDHGSNPZNL"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="WJQODHWHJCH"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="TDSKKMIUEGC"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="JBOGEBICUUG"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="UWUCCHMZPCG"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="IUWPTLFSFUU"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="ZAOWTSHDSDF"/>
+                    <Number Value="8.000000000000000000e+00" ID="XSGXKPCLZQF"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="FPLBBZCDYHH"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="RIEZDGQMJOH"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="OTGWHUKSDMT"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="IWEAVXVGQJH"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="RFYWNIJDPOC"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="DFZPPRLUJHW"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="WQDREUERCPA"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="LCWYQAGAUJX"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="UHPPPOOSAMD"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="ESRSVYHIQFQ"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="EFHSQACSRJG"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="BSOWOPWFOGJ"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="RZYNBDZKZNI"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="JVFHECHUVNI"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="UBJBOYGFCHB"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="GBQSVGMGCUN"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="HVIQVOYSTPQ"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="BJLVNDSDDWL"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="CDEHYXZRITO"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="XSACBAXKWPR"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="FHYPCZQEHSZ"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="CHMIHODJUSL"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="COTHZCDRLVI"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="LYHOHVJFYRA"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="OLKDXQWOVWQ"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="NHGYQZRXDEI"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="TBBBWORFZQY"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="OQOACRRRLYZ"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="BCZGQXWPBIC"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="VDVFUMHENHB"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="QEDZVJRKTAA"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="PQMQLFYZSRL"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="JJCATVBPHUL"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="IKECIZRNMWN"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="IEZFSRTZFVX"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="HBBHVIHTHPA"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="XORWYTDBGJJ"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="MOKSKBQIPNR"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="BJFZVWOYZLA"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="KAXWRYITHVK"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="0.000000000000000000e+00" ID="ATQTOKQTDWV"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="VANSQQQXSKD"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="OFIXRMDQXRE"/>
+                    <HWRatio Value="1.000000000000000000e+00" ID="ZZODTSAMTKK"/>
+                    <Scale Value="1.000000000000000000e+00" ID="JXVYFXCGBIK"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="IXTHISXAAJZ"/>
+                    <Theta Value="0.000000000000000000e+00" ID="RVKPELRAKYL"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="CVXKHKHJJPM"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="TCMYXTUZGBM"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="OJITAMAGEES"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="DUOUMZFMSZD"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="NMOVBBFQWKC"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="TZJBJHIIFDW"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="ZYKMKOWZSKZ"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="OJLAFYSVANG"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>0</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>EWLSBMKSHZ</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="HOSLAKJEUCB"/>
+                <AllSym Value="0.000000000000000000e+00" ID="LETEFGCOTJR"/>
+                <BottomLAngle Value="0.000000000000000000e+00" ID="CAETQPRVVXK"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="FZNZYAMCWQM"/>
+                <BottomLCurve Value="-9.476306023561759106e-01" ID="MOZFGXBYTSU"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="OLSSMWEJCAT"/>
+                <BottomLRAngleEq Value="1.000000000000000000e+00" ID="FCPOSOWCBGT"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="SBMZQSUBAME"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="QTLKJDPEDQX"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="DQRXFOTUBNV"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="WUUGISRLTWH"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="LXCCAJEVZQE"/>
+                <BottomLStrength Value="1.000000000000000000e+00" ID="FIUHQEPSVVC"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="JTBPDMGCYMS"/>
+                <BottomRAngle Value="0.000000000000000000e+00" ID="WFBMCBTVBMU"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="EYCUNYXBQAS"/>
+                <BottomRCurve Value="-2.662448600516031938e+00" ID="ACYRWEFWGIT"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="JGPUMTPWHSW"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="JMKCZLQGLCA"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="CBFBCZKHPVI"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="PTDCXDCKTKA"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="ETBPVCVXCEK"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="LQDQRGPCRRF"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="ETFQJPELXSR"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="NUYPXQLCLYO"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="VTVXXQRZGZU"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="IRCDPYTYNIZ"/>
+                <LeftLAngle Value="0.000000000000000000e+00" ID="BLYZRCLSEZJ"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="JGZZWVZADYI"/>
+                <LeftLCurve Value="-7.540358789161997199e-01" ID="MWFOEJFDKED"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="ATPYPWBTVFI"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="BXUFDDHGIFQ"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="GNPEEAILWZU"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="TAOCUQYYGTJ"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="WEZDAJDAENS"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="VCBTXLJYNDW"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="CNWSKNJPZDW"/>
+                <LeftLStrength Value="1.000000000000000000e+00" ID="ULDFGYKJVIC"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="NCNLRQSDMAX"/>
+                <LeftRAngle Value="0.000000000000000000e+00" ID="LLJESJXNHKG"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="CEYTVEFCJQB"/>
+                <LeftRCurve Value="-1.479051210186512755e+00" ID="JIHWSJIRMUK"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="GWFDZNWQVTJ"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="EIEWNFCUMNJ"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="DAEFEHKQQPR"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="UBFQQNEWFYD"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="ZHPXGQYMVHG"/>
+                <RLSym Value="1.000000000000000000e+00" ID="QPNRPKUFUAA"/>
+                <RefLength Value="5.500000000000000000e+00" ID="XMYWGAJNPDM"/>
+                <RightLAngle Value="0.000000000000000000e+00" ID="EKBHIPZEVMK"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="XWGMJASNFCF"/>
+                <RightLCurve Value="-7.540358789161997199e-01" ID="SZCHGFHQQVZ"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="IYMYHCNGMMF"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="SPDOUMUSANW"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="TUJXGMSWFJV"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="THNSXCGOOJX"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="CMRDJTLSRZG"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="JCDPBGJGNDG"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="LBUVGYPUJQJ"/>
+                <RightLStrength Value="1.000000000000000000e+00" ID="GMHKWFFIXWX"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="DJBXUAOHRCE"/>
+                <RightRAngle Value="0.000000000000000000e+00" ID="ZEGFRYUVBTR"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="LOQWWUWDBWJ"/>
+                <RightRCurve Value="-1.479051210186512755e+00" ID="LHCCVCUJETR"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="JXFRZGYYBIA"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="OERAHGGCXQZ"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="MTKADLPGUYV"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="MTMYZAJBJRL"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="AXQSPSTJSPY"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="DXLVMKCPCJN"/>
+                <Spin Value="0.000000000000000000e+00" ID="HFHTAPEQNUQ"/>
+                <TBSym Value="1.000000000000000000e+00" ID="OVOPZQHRKBN"/>
+                <TopLAngle Value="0.000000000000000000e+00" ID="CRNAJROFARC"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="BSLJXXQGAUW"/>
+                <TopLCurve Value="-1.590466989870326531e+00" ID="XKJAYZVVMKB"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="BUTBEGBVCME"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="CDFQYKEVWRJ"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="HSJTPMPZDFP"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="ZSYXNHGZRRG"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="IBHPNBHYISH"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="CTYKIAOKQXW"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="XGUYKJNPWST"/>
+                <TopLStrength Value="1.000000000000000000e+00" ID="XQJEQSWHMKT"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="WWHWXVXFEKC"/>
+                <TopRAngle Value="0.000000000000000000e+00" ID="YANGLHRNLHS"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="YHQTPOVDUPB"/>
+                <TopRCurve Value="-2.046354834150040658e-01" ID="WZXWJNITJLU"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="UAKWORJKLLE"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="LWLXHAJGCZE"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="SVIUQWBLUCB"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="OAACIUTAKGK"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="TRXMISSNOXN"/>
+                <XLocPercent Value="2.500000000000000000e-01" ID="BRDIUDDXQLH"/>
+                <XRotate Value="0.000000000000000000e+00" ID="KNBUJLVWWAC"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="DPJESSLLPRW"/>
+                <YRotate Value="0.000000000000000000e+00" ID="ZNKYYXJRCYM"/>
+                <ZLocPercent Value="1.639344262295083787e-02" ID="KEMLFXJYKSQ"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="CRBCBIJIWOK"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>BGCDNOKLNS</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="RLSVOTJMFRM"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="GQMVSMTMLZD"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="ZMDPVFGBFBM"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="DWEQRNLZKNZ"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="NEKLSIQMOIO"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="NQZOIJKAZLN"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="ERHGVDASWME"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="HNCNMABFKFP"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="GYCCCQNUVLW"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="GTKNADLNMHM"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="MWQSYQIBBPF"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="HOGAKOQOGQX"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="VBDNKWYESYE"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="JOOPWBQPEIH"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="ORNARYUBQZR"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="UYUIONJCXHM"/>
+                    <Number Value="8.000000000000000000e+00" ID="DSZIJLXFLLG"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="KOFROBQBQAY"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="WNKOEPVNEUK"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="DFENHAQCCXX"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="PTMTUVGFIUL"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="ZICPMNBMPFZ"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="OIDSIKBLUHK"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="CUPHZIMTHNA"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="MXMGVCXOZBG"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="JNRZSGALUTD"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="UXDCXQTZBSS"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="JSROYMYYMDO"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="XSWVZNKNDAV"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="KGTOENQOTFT"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="NXKPWZKRADD"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="JRYLBTBPNCC"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="JTGPCKZDYUE"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="AYOXOHTLEFJ"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="VWKUTIXRXZR"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="OIPUBKJXMHS"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="DINSKNYTOJL"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="MIQBGNCZEKR"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="RIXCHOLXYMM"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="THWRYICWJSU"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="EUWIBDVQIKZ"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="WUUVPSESUOQ"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="SWBBMXWHTXG"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="LNZABDZKGYT"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="MDGADSIEHJL"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="MWWNRCXDVOP"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="GCATGJMQHVQ"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="WSWTTYXVZQY"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="LJNNAUFWCYM"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="KONFKUYIRYC"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="YFRAHDVRUMX"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="HKUZCELFKGX"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="VAXMYLRNWHP"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="MGIAZBLHFBM"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="AHGWICHCEXV"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="DWCYILCDULW"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="UCDBSAAEMFV"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="6.030629184368910822e-01" ID="PJJJECGQFVE"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="NSCCISHTWGD"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="JCIFKIFSZOG"/>
+                    <HWRatio Value="1.676734693877551141e+00" ID="JLWVYYKENRK"/>
+                    <RoundRectXSec_KeyCorner Value="1.000000000000000000e+00" ID="RFWXNEATMOO"/>
+                    <RoundRectXSec_Radius Value="2.458928571428571352e-01" ID="YVQZDWJVZHZ"/>
+                    <RoundRectXSec_RadiusBL Value="2.458928571428571352e-01" ID="QEXJFVZDVLA"/>
+                    <RoundRectXSec_RadiusBR Value="2.458928571428571352e-01" ID="TPMZNTCQZPI"/>
+                    <RoundRectXSec_RadiusTL Value="2.458928571428571352e-01" ID="IWRHCLHUKIL"/>
+                    <RoundRect_Keystone Value="5.000000000000000000e-01" ID="EQSIYMQOAFG"/>
+                    <RoundRect_Skew Value="0.000000000000000000e+00" ID="GGYPABVHGCO"/>
+                    <RoundRect_VSkew Value="0.000000000000000000e+00" ID="ZTPOUBZYBLQ"/>
+                    <RoundedRect_Height Value="1.047959183673469408e+00" ID="IUHIDDNOFMY"/>
+                    <RoundedRect_RadiusSymmetryType Value="3.000000000000000000e+00" ID="JENECCFGCYZ"/>
+                    <RoundedRect_Width Value="6.250000000000000000e-01" ID="PMDIUVOOQGY"/>
+                    <Scale Value="1.000000000000000000e+00" ID="JXXXGQHUEPH"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="ZJPPZOGDXHH"/>
+                    <Theta Value="0.000000000000000000e+00" ID="AVJKNFLBNIE"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="IJEBTXXCSIT"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="ZIBADBPOLJJ"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="ACVCNABMMAJ"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="ZUEFQMWWEMT"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="RLEPZAAALPG"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="HXDCMXOPTPC"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="AETBJOWLKNI"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="OAJFTKTTFXU"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>4</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>NUYIOJIDYN</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="WIHWVYPDXZH"/>
+                <AllSym Value="0.000000000000000000e+00" ID="RKJRWSCQPHH"/>
+                <BottomLAngle Value="0.000000000000000000e+00" ID="KBTNKGBBMKQ"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="DVYUSHPXGMS"/>
+                <BottomLCurve Value="2.797230517093613589e+00" ID="QMEACKQKXMC"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="XTYJLPSKKPH"/>
+                <BottomLRAngleEq Value="1.000000000000000000e+00" ID="CLFKCFVDITJ"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="QUYRUTHIJCR"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="GCQXDGTKAMT"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="BGUFSLDWHNQ"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="SKCOXZKURFZ"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="HVTCPLXBMKW"/>
+                <BottomLStrength Value="1.000000000000000000e+00" ID="GDPTXOICRLP"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="RYLTVDKCCWZ"/>
+                <BottomRAngle Value="0.000000000000000000e+00" ID="XWEUHFOJIJC"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="QGHCBBFMYQI"/>
+                <BottomRCurve Value="1.180327866402717518e-05" ID="OLRDVMYBPGB"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="JGKZQEYNZXC"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="OMTNXBYIEXA"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="FMBASMZURRI"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="FUWHDYUMQVW"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="ZJRRPZBRKDA"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="SXYILIDHIGY"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="GKTPOFRTUQF"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="NZZCCDUTVPN"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="EIXTGUSCCQD"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="AMEYWULJXDZ"/>
+                <LeftLAngle Value="0.000000000000000000e+00" ID="AQCBQLUKSMV"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="AOVVJIPWHVR"/>
+                <LeftLCurve Value="1.546444593322866767e+00" ID="SPNCPGBQUKC"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="VGPRILZGBPD"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="CWVAHOYLZIS"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="ADFAMOMZQTL"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="FSKXCQOFZSP"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="AVRWPAPFHZJ"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="JTYZHRHHINR"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="QGEXNZNLWXO"/>
+                <LeftLStrength Value="1.000000000000000000e+00" ID="ZFLHOQWNFYY"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="MKQBTABMDAX"/>
+                <LeftRAngle Value="0.000000000000000000e+00" ID="TBHMUPRSXMZ"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="ZBLZYEFQMHJ"/>
+                <LeftRCurve Value="1.180327866414828564e-05" ID="GNAFOBMUSTX"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="TBTHAXHRQGZ"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="IZQLZCYCRCB"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="ILJYHBBPNFZ"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="IDQSZLXACAH"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="UEUSEHQAHCL"/>
+                <RLSym Value="1.000000000000000000e+00" ID="IEMYDBMGEFP"/>
+                <RefLength Value="5.500000000000000000e+00" ID="XGOWPYHCBFD"/>
+                <RightLAngle Value="0.000000000000000000e+00" ID="URISIRNLZNR"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="SWJDZRONRXL"/>
+                <RightLCurve Value="1.546444593322866767e+00" ID="XBQESDMZOGC"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="DZOCVLBKNQS"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="IVTQXFRMIRZ"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="YEIOIUHKTQD"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="FEWXDYEKXTH"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="AQUDDDMEOIM"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="KLKJFDUUZBH"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="DYCJPSWNROB"/>
+                <RightLStrength Value="1.000000000000000000e+00" ID="MQOBQLKCJBF"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="MPYACAFOZUC"/>
+                <RightRAngle Value="0.000000000000000000e+00" ID="AOVNQRNLIWS"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="ZAVLVTEYHTS"/>
+                <RightRCurve Value="0.000000000000000000e+00" ID="QRLJRKFVSZE"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="NSPSMNWEGVH"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="WWWUNANZHJQ"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="LYWJIXRAJUY"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="EEJJQXKWNMZ"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="UBWSKCRMBFW"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="LAGYJBSPHCK"/>
+                <Spin Value="0.000000000000000000e+00" ID="OCXBBZEINIB"/>
+                <TBSym Value="1.000000000000000000e+00" ID="WENJWJXSSHC"/>
+                <TopLAngle Value="0.000000000000000000e+00" ID="QTZNCGWRWTC"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="GWGGNWMTPJG"/>
+                <TopLCurve Value="1.134643375863051140e-01" ID="FWPDXFNIGTP"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="IEADWJAJZDT"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="XNOZRCMTLYS"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="OIIGSXLDAXB"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="UWIGEARIIZW"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="GWNAOSDHNQS"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="EXTQYVJOWVV"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="ALGQRCYWSJD"/>
+                <TopLStrength Value="1.000000000000000000e+00" ID="WBRZFCKHGNY"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="FLBTHLNFPEA"/>
+                <TopRAngle Value="0.000000000000000000e+00" ID="HDZGFYJCXMV"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="MCRZSZMEDBY"/>
+                <TopRCurve Value="-1.180327866439052182e-05" ID="CESAYJXVUXN"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="ZIASOAQUAER"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="PUNHKBTYFRK"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="ZRCCKCDPILV"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="JCMUNJIIFIB"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="ZRGQIGUKREQ"/>
+                <XLocPercent Value="5.000000000000000000e-01" ID="XTTIANAXIWZ"/>
+                <XRotate Value="0.000000000000000000e+00" ID="PZMJEIPCSIK"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="REQPUYOHONO"/>
+                <YRotate Value="0.000000000000000000e+00" ID="AGBQZKFIBSP"/>
+                <ZLocPercent Value="7.377049180327865940e-02" ID="YWMFIBKWFWB"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="RAOIEMAENWB"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>QPRZOIVPOY</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="ASTHQUYVLIP"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="RTVPVSHSIZW"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="HUDSCYTEHCT"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="NYIPMOLYOOB"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="MFHIDPYFRGX"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="MWPFVTJPCSL"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="DIWDBNUDYHP"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="GJPKAHNSKQF"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="GRSWRRDPBQP"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="DUXAMYVGSFY"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="GEBBLMNZUEA"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="BPGVDKBDIOJ"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="WXZQMWSLOYS"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="TJTBOJZNDSP"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="WYOMPBRIBMZ"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="ZDVQZUGHFIT"/>
+                    <Number Value="8.000000000000000000e+00" ID="DDBTXVYFLDI"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="VQFIHIBWLQS"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="UHQTOZZTBLC"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="LOSAJHBZNGG"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="OSSCDODSQYV"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="VGRQLADDRRT"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="ULTMFHRCWJT"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="SGANOFYZLKR"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="MOAZDANLEKC"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="DSYXPFMJUCI"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="PERJAHWIQSV"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="EXKAKDJBJSW"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="NIKEYTGFVYR"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="JMARQHTWBEA"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="TMTWQQDOZGR"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="YDUSJZQBALO"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="ARGRULTEHQQ"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="ZKRVKLZWQDL"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="ZSEKWDSQCNE"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="LJMPBAVNMDI"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="YGMKGQRCBSV"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="JWSDSRKWCKV"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="YBURDZISROG"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="IXMJFZQKFYE"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="JIHHSSGLYQL"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="NPRLMHSYYNG"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="QZKILTTQCJU"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="QUZPWGUXMNZ"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="FLZFWWOTYWJ"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="QQVWKBRWEXP"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="PDBRLTJEIXJ"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="AYVLJFVTBXF"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="GBCFHDWZRKA"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="IFYXEHVNQXN"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="NMXQEXLGZRB"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="VUIVYMWZTEH"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="GWBYSYXHWSW"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="HXZFKEKNPSZ"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="ZYYAHWTXLKQ"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="QOJKXNFLRIC"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="HZIJNNEKGRF"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="9.568776115176186314e-02" ID="QCRFXBYLRUC"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="MGPGPBNYWGF"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="LMADYEJALAQ"/>
+                    <Ellipse_Height Value="3.979591836734693855e-01" ID="BXJRMBSLDFT"/>
+                    <Ellipse_Width Value="3.061224489795918435e-01" ID="ONCWHABBVXK"/>
+                    <HWRatio Value="1.300000000000000044e+00" ID="DEZBVOMLOCB"/>
+                    <Scale Value="1.000000000000000000e+00" ID="SLAZOYODRSA"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="SUZOPAWTGCV"/>
+                    <Theta Value="0.000000000000000000e+00" ID="DVFNYGAADZB"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="DQZYBBGUXAT"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="XJHLWRAIXLS"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="NDWHADPDGUP"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="IITEHVNPUAL"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="URVOJNAFNTL"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="ZLKNINOWXCF"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="JRWSNMLHFJZ"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="BUZXALFYDXZ"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>2</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>BYQHWMCYUL</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="DJZJBOLIZMA"/>
+                <AllSym Value="0.000000000000000000e+00" ID="JECRKEEEALU"/>
+                <BottomLAngle Value="0.000000000000000000e+00" ID="CDSZRWXNRCJ"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="JBCBIONLZRW"/>
+                <BottomLCurve Value="-1.180327866414829073e-05" ID="JIAYKFBMOER"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="YPFSETEVVDA"/>
+                <BottomLRAngleEq Value="1.000000000000000000e+00" ID="UEISQJPYNHH"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="VLIZRIGWNKI"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="JDSXTLGJZAF"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="QOCOOKCEFWB"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="PGWKWSWWUZZ"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="PJWDOADZJQE"/>
+                <BottomLStrength Value="1.000000000000000000e+00" ID="DMQRJMKXHVK"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="XQPPVLOJYIY"/>
+                <BottomRAngle Value="0.000000000000000000e+00" ID="HZYOESJCCSB"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="VWPVEQWKFOJ"/>
+                <BottomRCurve Value="9.503211384317842292e-01" ID="IBJSWUYYUJJ"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="BDMMJCXTMXF"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="FIVPCGZAISR"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="WTZLBRGMPHL"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="CZQBIRIMNUD"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="FDALQHBALAZ"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="QJPJNWWCJUI"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="UEBVXMYUBTU"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="KSGETWGKJIY"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="QVNEAKEUWIJ"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="MESCFDALHTW"/>
+                <LeftLAngle Value="0.000000000000000000e+00" ID="XKSPDCIWNIH"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="PMGYKCJLEKT"/>
+                <LeftLCurve Value="-1.180327866414828903e-05" ID="DBUTYZDXULS"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="MSCZDJNMVIT"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="KDECPKTKPUU"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="YAPGXBFBGRA"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="RWECURCAEFY"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="FMFATUKBCAS"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="LZDYIBFZMWI"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="HBVMBGZRBWQ"/>
+                <LeftLStrength Value="1.000000000000000000e+00" ID="XUCGZKUZXWB"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="QLCYMNVWZWA"/>
+                <LeftRAngle Value="0.000000000000000000e+00" ID="LWWGJGPZLOC"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="NLKMPOOZHXW"/>
+                <LeftRCurve Value="1.012315868881790593e+00" ID="JADYXCMYRTX"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="JVGORJCSZHV"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="PRFRIYTZNSW"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="UNUJWETQSHM"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="PSSDXTNCEBK"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="QJTVPUPAEKH"/>
+                <RLSym Value="1.000000000000000000e+00" ID="UYMDDNSXMWL"/>
+                <RefLength Value="5.500000000000000000e+00" ID="DRFTSLSTQHN"/>
+                <RightLAngle Value="0.000000000000000000e+00" ID="ANGHGKHBBAT"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="OORTKKJIQYF"/>
+                <RightLCurve Value="0.000000000000000000e+00" ID="NJQOIUAQODE"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="OTGPLDXTGON"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="TAGKIEUGUSQ"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="QORJWXGHXNF"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="RUHZYLPVSWJ"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="LXFWUXCEKDR"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="YYMHKWGIQTS"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="QZKEOYZGIJS"/>
+                <RightLStrength Value="1.000000000000000000e+00" ID="XBSGKFEANAI"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="MXIGTYXIQFM"/>
+                <RightRAngle Value="0.000000000000000000e+00" ID="UHEQYPUMWKC"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="PFTVCAWWRYL"/>
+                <RightRCurve Value="1.012315868881790593e+00" ID="TNGJYYAUQBG"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="ULLFKGKRTRC"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="ZTZYQTMYVCS"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="PSLJSBMJOYC"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="XUIZTTJKYPW"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="WERAMWXHDZZ"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="GKHQHJCHJTD"/>
+                <Spin Value="0.000000000000000000e+00" ID="JDGAFPCMCCY"/>
+                <TBSym Value="1.000000000000000000e+00" ID="LWFZQQHXOKL"/>
+                <TopLAngle Value="0.000000000000000000e+00" ID="UWBTGWFROHV"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="EDOLHAPYCFG"/>
+                <TopLCurve Value="1.180327866439052182e-05" ID="VQBRLBJNYNB"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="MUAFDEQSIUH"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="BGDYIJPRGYM"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="NUMBYDBKXOV"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="RCHEQJBYECF"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="SCCHANPJTDZ"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="DNXDYPNLYWT"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="HYOAJXJDDUE"/>
+                <TopLStrength Value="1.000000000000000000e+00" ID="BWZHHECBFWG"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="PRUFSVZXUVC"/>
+                <TopRAngle Value="0.000000000000000000e+00" ID="JBTCJKUXPIB"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="UPWGTBFFXLS"/>
+                <TopRCurve Value="9.503211384317843402e-01" ID="TXQRIESLVVV"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="MVNQAJMOQNH"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="MBYDFLJMPED"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="JIIWJWCWKCS"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="ENCFJBCRAOP"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="ASSNIVXPDRC"/>
+                <XLocPercent Value="7.500000000000000000e-01" ID="FSZNBKICMUF"/>
+                <XRotate Value="0.000000000000000000e+00" ID="CHVUEWOYFBP"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="BQROJLPNOSB"/>
+                <YRotate Value="0.000000000000000000e+00" ID="LVZXRALTLFJ"/>
+                <ZLocPercent Value="7.377000000000000224e-02" ID="YFCZJBPIOXK"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="ITJSANXMBLG"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>EHLCJBPBXR</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="OWDHMLCSCBC"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="LSEVTLXKLSM"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="OKQSMWGTBIF"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="MKPIXJTGYPL"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="PKQMTKCDHEN"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="NUYAHRFCXUA"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="BUVFHCFEYWH"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="QAGKDYGKIFG"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="QAZJXTQIUAX"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="GXJSXPEOVPS"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="CSNGGMVNXXY"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="ETCASWNUJJH"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="PSKCITSWXFK"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="FAOJQECTCVG"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="EXCCCKVVSEP"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="VMDOJLVFPLP"/>
+                    <Number Value="8.000000000000000000e+00" ID="VTMWTGOTXWW"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="XOQNVPEUMHP"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="MDCTAQNBWCR"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="RWUBSIZHYKT"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="MHWQPGRHNEW"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="FXWWMSOCPYQ"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="ZXHZMCMSNYH"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="MLADVCBJWSF"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="UUCSFCUZENH"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="IVFCHQLHGKH"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="MEHJHGWWNHI"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="OWQTPLPOVYU"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="YUDYVOZFYRR"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="UZUXRQKOLQY"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="DJKKTANLUDZ"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="ELNFDVLRLBY"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="TPFDCXNCQCS"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="PEYZQUZDAJS"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="YQXYGEYYNLL"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="NTUZKOFWFTA"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="LQOFMHNHBPG"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="KYRBYZJUCJI"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="EFGZWOZAZSB"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="UMKVFEMXKMR"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="YNUGZZBUEAP"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="VZDZJLJUSUO"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="LAEXZLQZZHO"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="QIMENFHPKOI"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="TEQDXUNSFRY"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="CBSNWYJORBS"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="HNATYBTHRFC"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="VAQXJDSEAXI"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="COPFNNJIECK"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="KFCAVCOAPUO"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="RPSMVMDAZNM"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="KVWSWAZQHHH"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="RUPLONHJOTO"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="IWHTYVVFMFN"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="MVGRREZWNAN"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="UYMFEDBXDIU"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="SNRHYABQYUW"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="9.568776115176186314e-02" ID="NKQOOLGSURS"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="ZQGZSWLTCUI"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="KZQSRZMEEGT"/>
+                    <Ellipse_Height Value="3.979591836734693855e-01" ID="ISEUPJOIWQX"/>
+                    <Ellipse_Width Value="3.061224489795918435e-01" ID="MDEZXNKEVQL"/>
+                    <HWRatio Value="1.300000000000000044e+00" ID="KFIUPQQPRZS"/>
+                    <Scale Value="1.000000000000000000e+00" ID="QXWPWXSOYLE"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="XMMENCMTCEP"/>
+                    <Theta Value="0.000000000000000000e+00" ID="PMAOBBAFALC"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="BHXKZCLGZUF"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="PSQTIMVAWEA"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="EJAFIWAPIVQ"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="AEXCWDJDEIE"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="CBMBOCNISVU"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="ODNHZLTJFHN"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="IJLSEELMBXH"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="JWZDKVOMOPN"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>2</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>VHDLAEMUEG</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="RWIFPSGKULJ"/>
+                <AllSym Value="0.000000000000000000e+00" ID="FZSLILUCJTL"/>
+                <BottomLAngle Value="-4.500000000000000000e+01" ID="QHPGUFUPTKR"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="LYFJFXJHKFZ"/>
+                <BottomLCurve Value="2.229087829970556101e+00" ID="JLQEKHBPHTR"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="JZUBUCLQAKD"/>
+                <BottomLRAngleEq Value="1.000000000000000000e+00" ID="XFKIWFERWHC"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="NVRXTUPBUIC"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="JVTUKJTYSHB"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="POFRXJNKYGK"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="PSXMWBWHMIB"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="XAIGXJHOSFE"/>
+                <BottomLStrength Value="7.500000000000000000e-01" ID="SFYBGDIESQW"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="VVAVDEHNOQV"/>
+                <BottomRAngle Value="-4.500000000000000000e+01" ID="LLHXQGVMEHM"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="VCLHQEQEEFH"/>
+                <BottomRCurve Value="2.229087833070935165e+00" ID="XEKIDWBMKFR"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="KNDUOIFYXKW"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="ZFQRHOJRQKC"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="FFUGDOQUVJD"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="DANPQUKSZLN"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="LFNYCCXXPOW"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="WPNIDMMXGWL"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="TVKNUSNKTQS"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="YMXYEJVXKDE"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="ESRJKKPRIYT"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="NRWEDGQCIEB"/>
+                <LeftLAngle Value="-4.500000000000000000e+01" ID="OIKEETLKEDG"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="MMMPDDOUDYN"/>
+                <LeftLCurve Value="2.347057560144663491e+00" ID="BFSEJTHJLLG"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="GWRBJXFBMQF"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="SFJTDOHDFSK"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="GQSGSCHAEWT"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="ILDCPOLKDJX"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="YBEKMAOJKXU"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="DBJEAGVEROD"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="PMKOBERYYUJ"/>
+                <LeftLStrength Value="7.500000000000000000e-01" ID="RQLMPNJCZCB"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="QRQMHJCWKLH"/>
+                <LeftRAngle Value="-4.500000000000000000e+01" ID="PBMLKEQMCFG"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="CBXVQHQWXUE"/>
+                <LeftRCurve Value="2.347057563459612695e+00" ID="TAUDXXFIRWA"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="ELJLTUXMAHE"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="UCRCKIBJFAH"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="PWWLARSEEES"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="XVYWJYBRCIE"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="PDRMDJTXTWV"/>
+                <RLSym Value="1.000000000000000000e+00" ID="MCHMDQMFJNC"/>
+                <RefLength Value="5.500000000000000000e+00" ID="ENXBFCXSDDZ"/>
+                <RightLAngle Value="-4.500000000000000000e+01" ID="ITIKUOJFELO"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="UXZQZUYFVMM"/>
+                <RightLCurve Value="2.347057560144663046e+00" ID="YZPYHHHVJAH"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="KWNCXEOJFOH"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="CLHMVSHURMA"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="LVBNGTXCMDU"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="LEQMFXWSBES"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="FBJNHHJQBYL"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="JSVXIGDZVWU"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="GVUVBDIWLSN"/>
+                <RightLStrength Value="7.500000000000000000e-01" ID="ZIOOSCJOXGT"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="WCFDXHXJHLX"/>
+                <RightRAngle Value="-4.500000000000000000e+01" ID="XZPXSOKFDKQ"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="FREJPFEJKXI"/>
+                <RightRCurve Value="2.347057563459611806e+00" ID="QGVWQOGNQDZ"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="SLDMYFFXGZJ"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="EXXNBASSCVA"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="QRKQDTRCEYP"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="TQZPOVOJUHC"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="SVBSLPCEXKU"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="FVPKQMIFIIO"/>
+                <Spin Value="0.000000000000000000e+00" ID="JPYGMOVEIIY"/>
+                <TBSym Value="1.000000000000000000e+00" ID="XRJMJNCYTKE"/>
+                <TopLAngle Value="-4.500000000000000000e+01" ID="GPVAQICJTBE"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="JWSSDJJGFHO"/>
+                <TopLCurve Value="2.229087829970557433e+00" ID="HLBHWAVZKAJ"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="NOQZJDERUEW"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="IBNUADWDADZ"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="KKNTTUKZFHW"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="WBSDBCFEEYT"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="BYQTBHBBTYB"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="WGRCYUFGYGK"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="PPGGOJDQXGX"/>
+                <TopLStrength Value="7.500000000000000000e-01" ID="FZOIFMGOFLS"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="KIFRPGJICFB"/>
+                <TopRAngle Value="-4.500000000000000000e+01" ID="QPJFZCHCHEC"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="AMJRVQYXOXP"/>
+                <TopRCurve Value="2.229087833070936497e+00" ID="KACIDWQOTBI"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="CXIKXCUBHOW"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="TBOILXPHQQF"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="JXSFOOBJYXB"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="WWFQUQKVWCR"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="TYOIMGLVJYH"/>
+                <XLocPercent Value="1.000000000000000000e+00" ID="VYCWGONOWYJ"/>
+                <XRotate Value="0.000000000000000000e+00" ID="UZMEHIPSECK"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="LBZTVOQDEJN"/>
+                <YRotate Value="0.000000000000000000e+00" ID="SAACQWLNMFF"/>
+                <ZLocPercent Value="7.377000000000000224e-02" ID="ZCHXPPZBJLW"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="WBGUIPJZABZ"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>OFLYHVQMUW</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="APHOVMCWVZA"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="UUMMYBXLUDR"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="WGMGSDOPACG"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="IDTUQFBNZRW"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="ATRIVBKLAZU"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="BIPXZSZGFAH"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="VJZPWUKMOIT"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="DFIQWYTICQN"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="UYKZFQQMVAF"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="JGGPREWTXWV"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="ZEFOLUWHOHA"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="GVNCEUJPRTF"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="AKZNUSMFJYB"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="WYFCITLGZXX"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="KBZOSXMWYWO"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="YMLGGGIGNRU"/>
+                    <Number Value="8.000000000000000000e+00" ID="XHENBIYOORF"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="VSPLKUXAXYM"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="IDGEDSMRAOW"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="NGDOIQOLOHT"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="YAIESGYYNBQ"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="ZVCLXQWUIKK"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="RVQMIOUDIBM"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="JFFDZDQNJXC"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="PFQDQTFQGWL"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="FDJDVBGCQQN"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="EJLSCPSBTTH"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="EADSEFXTXQY"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="CPJAFJWAGES"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="IDTZEQJOBLM"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="MDGMFSJRRPA"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="SHTDADHRNFI"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="DHBFXMOHKTV"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="EHTOZEOJSBJ"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="JKFUGGSGJJA"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="RJGNFDKXHFL"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="VILSQFGFEYZ"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="KGETHYZSLKC"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="WIPHOXUFLPS"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="VUDTGDLDHXB"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="QJXHPXNPZYQ"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="PYTCPBTTLLW"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="DVFJYXWTJYM"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="NCZTWNCMMNN"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="PJKORISITRS"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="PTBPRWJTIRG"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="DBQZVBWQJXR"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="GOHLWHEIQFQ"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="OBKMIEZHBQD"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="OGHSVMYPMNK"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="JNVCTDZSJMR"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="QINGJEUEWRL"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="VNPDHLQPKAM"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="ALIQSOZHKCA"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="WMDKOMPSVAO"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="CIMFWBSBFSP"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="QHOTYHPKXMB"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="0.000000000000000000e+00" ID="GBQXOQCQYXH"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="OMLFVZIYELV"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="EWQSLQLLNSE"/>
+                    <HWRatio Value="1.000000000000000000e+00" ID="DIQSDUCCHCX"/>
+                    <Scale Value="1.000000000000000000e+00" ID="ZKUWMDZIZOW"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="SVMTIBMAZSP"/>
+                    <Theta Value="0.000000000000000000e+00" ID="PEPKKVIDFSO"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="SRDOZRUGLCD"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="CHQTVJMMHTP"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="GVFYUISVHMH"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="QHUOSFUOUBF"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="ZDNMIQVBFDP"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="KBREWHTAVYY"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="WOJVSXEYOVR"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="PWCSNSGSXQX"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>0</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+        </XSecSurf>
+      </FuselageGeom>
+    </Geom>
+    <Geom>
+      <ParmContainer>
+        <ID>LOENSIWPJA</ID>
+        <Name>WingGeom</Name>
+        <Attach>
+          <Eta_Attach_Location Value="0.000000000000000000e+00" ID="DNULSHQQXCT"/>
+          <L_01 Value="1.000000000000000000e+00" ID="LIWXZYFUMKI"/>
+          <L_Attach_Location Value="0.000000000000000000e+00" ID="CJCWHJZCTUV"/>
+          <L_Attach_Location0Len Value="0.000000000000000000e+00" ID="NJRTCEIBRFK"/>
+          <M_Attach_Location Value="5.000000000000000000e-01" ID="OKHLUCHWSMY"/>
+          <N_Attach_Location Value="5.000000000000000000e-01" ID="IFCLDJDKEGC"/>
+          <R_01 Value="1.000000000000000000e+00" ID="OOWDWSLMNOY"/>
+          <R_Attach_Location Value="0.000000000000000000e+00" ID="EAVKYAEKCHW"/>
+          <R_Attach_Location0N Value="0.000000000000000000e+00" ID="KWKKCPBDUJO"/>
+          <Rots_Attach_Flag Value="1.000000000000000000e+00" ID="UROEPADASYW"/>
+          <S_Attach_Location Value="5.000000000000000000e-01" ID="TCAUVHBXXTF"/>
+          <T_Attach_Location Value="5.000000000000000000e-01" ID="BZGMLIASCNL"/>
+          <Trans_Attach_Flag Value="1.000000000000000000e+00" ID="PPVMKAMBAOV"/>
+          <U_01 Value="1.000000000000000000e+00" ID="IGEZGHVIQNX"/>
+          <U_Attach_Location Value="0.000000000000000000e+00" ID="PAWBBPIFLMU"/>
+          <U_Attach_Location0N Value="0.000000000000000000e+00" ID="RCWMUPTSLBY"/>
+          <V_Attach_Location Value="0.000000000000000000e+00" ID="KMOIMPJQDHQ"/>
+        </Attach>
+        <BBox>
+          <X_Len Value="1.000000000000000000e+00" ID="TENZFRMMLSA"/>
+          <X_Min Value="1.516393442622950616e+00" ID="ZHQVSFJOLDM"/>
+          <Y_Len Value="4.500000000000000000e+00" ID="IYHNHPOMATV"/>
+          <Y_Min Value="-2.250000000000000000e+00" ID="ADDMMVPNFFN"/>
+          <Z_Len Value="1.000580443696266197e-01" ID="ZJFSJKSIOPA"/>
+          <Z_Min Value="5.237414696184653495e-01" ID="HUHHUGDCSYH"/>
+        </BBox>
+        <EndCap>
+          <CapUMaxLength Value="1.000000000000000000e+00" ID="UPFGEZMGVYR"/>
+          <CapUMaxOffset Value="0.000000000000000000e+00" ID="DYMGTVRNGJM"/>
+          <CapUMaxOption Value="1.000000000000000000e+00" ID="IABVXKRSHGA"/>
+          <CapUMaxStrength Value="5.000000000000000000e-01" ID="QTBWRNAJYOZ"/>
+          <CapUMaxSweepFlag Value="0.000000000000000000e+00" ID="AKDMZEBIMVR"/>
+          <CapUMinLength Value="1.000000000000000000e+00" ID="CDPSFHKZRUO"/>
+          <CapUMinOffset Value="0.000000000000000000e+00" ID="XHNXNWVOOCI"/>
+          <CapUMinOption Value="1.000000000000000000e+00" ID="ZAXTOJLHFUB"/>
+          <CapUMinStrength Value="5.000000000000000000e-01" ID="MNRXSOTMWMQ"/>
+          <CapUMinSweepFlag Value="0.000000000000000000e+00" ID="HUGAWFEICMJ"/>
+          <CapUMinTess Value="3.000000000000000000e+00" ID="HXBFKARTTLL"/>
+        </EndCap>
+        <Index>
+          <ActiveAirfoil Value="1.000000000000000000e+00" ID="UGGLKSCOAOV"/>
+          <ActiveXSec Value="0.000000000000000000e+00" ID="MKTTSTCUSCR"/>
+        </Index>
+        <Mass_Props>
+          <CGx Value="0.000000000000000000e+00" ID="NBUXDLCKIKG"/>
+          <CGy Value="0.000000000000000000e+00" ID="NNUVFZPJPST"/>
+          <CGz Value="0.000000000000000000e+00" ID="SHRSJNTMACI"/>
+          <Density Value="1.000000000000000000e+00" ID="YPKMFTCMICK"/>
+          <Ixx Value="0.000000000000000000e+00" ID="XBNZSSQTXCF"/>
+          <Ixy Value="0.000000000000000000e+00" ID="RFPTJEFWIZM"/>
+          <Ixz Value="0.000000000000000000e+00" ID="TDPNHGWTNHY"/>
+          <Iyy Value="0.000000000000000000e+00" ID="JBGANHJLYMG"/>
+          <Iyz Value="0.000000000000000000e+00" ID="LZBQHNVAXQL"/>
+          <Izz Value="0.000000000000000000e+00" ID="KMTDBCMIJYR"/>
+          <Mass_Area Value="1.000000000000000000e+00" ID="UVSEIBGULTV"/>
+          <Mass_Prior Value="0.000000000000000000e+00" ID="RNFEIFDDFBV"/>
+          <PointMass Value="0.000000000000000000e+00" ID="EINNBAJWWEO"/>
+          <Shell_Flag Value="0.000000000000000000e+00" ID="ANURIXITCSG"/>
+        </Mass_Props>
+        <Negative_Volume_Props>
+          <Negative_Volume_Flag Value="0.000000000000000000e+00" ID="WRHVHQLRXTS"/>
+        </Negative_Volume_Props>
+        <ParasiteDragProps>
+          <ExpandedList Value="0.000000000000000000e+00" ID="DDHRDHXHLGW"/>
+          <FFBodyEqnType Value="3.000000000000000000e+00" ID="PDQNTEYWEAV"/>
+          <FFUser Value="1.000000000000000000e+00" ID="PZDYALPFSWU"/>
+          <FFWingEqnType Value="3.000000000000000000e+00" ID="ILDUYOFKMCO"/>
+          <IncorporatedGen Value="0.000000000000000000e+00" ID="GEGIXFNVZJH"/>
+          <PercLam Value="0.000000000000000000e+00" ID="DUUZVLENPOX"/>
+          <Q Value="1.000000000000000000e+00" ID="SIDVZONECJK"/>
+          <Roughness Value="0.000000000000000000e+00" ID="USERAEAZKRS"/>
+          <TawTwRatio Value="1.000000000000000000e+00" ID="KPARIQKTRXX"/>
+          <TeTwRatio Value="1.000000000000000000e+00" ID="SQIFKEDNRHR"/>
+        </ParasiteDragProps>
+        <Shape>
+          <Tess_U Value="1.600000000000000000e+01" ID="DBNPANVFZGQ"/>
+          <Tess_W Value="3.300000000000000000e+01" ID="TPEUKNOJVKE"/>
+          <Wake Value="0.000000000000000000e+00" ID="ALREKRRCBLJ"/>
+        </Shape>
+        <Sym>
+          <Sym_Ancestor Value="2.000000000000000000e+00" ID="YKMKHQXLVGR"/>
+          <Sym_Ancestor_Origin_Flag Value="0.000000000000000000e+00" ID="DDCZBDSFEUY"/>
+          <Sym_Axial_Flag Value="0.000000000000000000e+00" ID="RRRZSYAKWUM"/>
+          <Sym_Planar_Flag Value="2.000000000000000000e+00" ID="ULYAWLOVNBF"/>
+          <Sym_Rot_N Value="2.000000000000000000e+00" ID="QITVWORYGNC"/>
+        </Sym>
+        <WakeSettings>
+          <WakeAngle Value="0.000000000000000000e+00" ID="FCDKVJRXZNQ"/>
+          <WakeScale Value="2.000000000000000000e+00" ID="BGOWNQGIHHQ"/>
+        </WakeSettings>
+        <WingGeom>
+          <CorrectAirfoilthicknessFlag Value="1.000000000000000000e+00" ID="SUCOIWPVBSI"/>
+          <LECluster Value="2.500000000000000000e-01" ID="BFLHHOYDUDS"/>
+          <MaxGrowth Value="1.437005756083839181e+00" ID="SLDCMVBTBFS"/>
+          <RelativeDihedralFlag Value="0.000000000000000000e+00" ID="BUHONLKDKSC"/>
+          <RelativeTwistFlag Value="0.000000000000000000e+00" ID="KJTQWRODAOV"/>
+          <RotateAirfoilMatchDideralFlag Value="0.000000000000000000e+00" ID="ZERJLTPEKHX"/>
+          <SmallPanelW Value="8.741353597993953284e-03" ID="KOXRADXEEYW"/>
+          <TECluster Value="2.500000000000000000e-01" ID="HATJICAMHPN"/>
+          <TotalAR Value="5.000000000000000000e+00" ID="TKFBYRMOHGO"/>
+          <TotalArea Value="4.049999999999999822e+00" ID="IIFMCFNIWRJ"/>
+          <TotalChord Value="9.000000000000000222e-01" ID="RPBACFXJUMS"/>
+          <TotalProjectedSpan Value="4.500000000000000000e+00" ID="GISCSUYGUDH"/>
+          <TotalSpan Value="4.500000000000000000e+00" ID="TWUIXZIUIJG"/>
+        </WingGeom>
+        <XForm>
+          <Abs_Or_Relitive_flag Value="1.000000000000000000e+00" ID="NXNIWNBDJXQ"/>
+          <Last_Scale Value="2.500000000000000000e-01" ID="MNZTZCUNUYE"/>
+          <Origin Value="0.000000000000000000e+00" ID="MZJKXCOYNCX"/>
+          <Scale Value="2.500000000000000000e-01" ID="YBUFIGFZBQI"/>
+          <X_Location Value="1.516393442622950616e+00" ID="WVZAYZNDXBS"/>
+          <X_Rel_Location Value="1.516393442622950616e+00" ID="OCSISXOTDAJ"/>
+          <X_Rel_Rotation Value="0.000000000000000000e+00" ID="KGGCZACBBKP"/>
+          <X_Rotation Value="0.000000000000000000e+00" ID="QWXXNJFZMAI"/>
+          <Y_Location Value="0.000000000000000000e+00" ID="WYMXYWTSDAG"/>
+          <Y_Rel_Location Value="0.000000000000000000e+00" ID="RRXHOJSKIMN"/>
+          <Y_Rel_Rotation Value="0.000000000000000000e+00" ID="NKHQOQTYEBY"/>
+          <Y_Rotation Value="0.000000000000000000e+00" ID="JEQSUYAUSGK"/>
+          <Z_Location Value="5.737704918032786594e-01" ID="EMKNSMWZARA"/>
+          <Z_Rel_Location Value="5.737704918032786594e-01" ID="SGPFLBYDZPU"/>
+          <Z_Rel_Rotation Value="0.000000000000000000e+00" ID="COERWZMIWOC"/>
+          <Z_Rotation Value="0.000000000000000000e+00" ID="HWIEGVFZTRG"/>
+        </XForm>
+      </ParmContainer>
+      <GeomBase>
+        <TypeName>Wing</TypeName>
+        <TypeID>5</TypeID>
+        <TypeFixed>0</TypeFixed>
+        <ParentID>OHEAIBPMDY</ParentID>
+        <Child_List>
+          <Child>
+            <ID>LIYGGQUBGZ</ID>
+          </Child>
+          <Child>
+            <ID>OFLJSHOFTB</ID>
+          </Child>
+        </Child_List>
+      </GeomBase>
+      <Material>
+        <Name>Default</Name>
+      </Material>
+      <Wire_Color>
+        <ParmContainer>
+          <ID>BLUCOJHKJR</ID>
+          <Name>Default</Name>
+          <Color_Parm>
+            <Alpha Value="2.550000000000000000e+02" ID="PLDUWRTQUMA"/>
+            <Blue Value="2.550000000000000000e+02" ID="KMOQAXFISFS"/>
+            <Green Value="0.000000000000000000e+00" ID="ZTSWSBKNUCY"/>
+            <Red Value="0.000000000000000000e+00" ID="QIZPVDFVRWC"/>
+          </Color_Parm>
+        </ParmContainer>
+      </Wire_Color>
+      <Textures>
+        <Num_of_Tex>0</Num_of_Tex>
+      </Textures>
+      <Geom>
+        <Set_List>1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, </Set_List>
+        <SubSurfaces/>
+        <FeaStructures/>
+      </Geom>
+      <WingGeom>
+        <ParmContainer>
+          <ID>ZQZQSOYLPB</ID>
+          <Name>Default</Name>
+        </ParmContainer>
+        <XSecSurf>
+          <XSec>
+            <ParmContainer>
+              <ID>EWWDBNVWUL</ID>
+              <Name>Default</Name>
+              <XSec>
+                <Area Value="4.500000000000000000e+00" ID="HIAPJIPTCQJ"/>
+                <Aspect Value="1.125000000000000000e+00" ID="NJEPWEHKCCU"/>
+                <Avg_Chord Value="2.000000000000000000e+00" ID="ENAKMRJJDBO"/>
+                <Dihedral Value="0.000000000000000000e+00" ID="TFAUSEADQRT"/>
+                <InCluster Value="1.000000000000000000e+00" ID="IMMRVJIMBIA"/>
+                <InLEDihedral Value="7.202106782626759676e-15" ID="WKIUXNGSFZS"/>
+                <InLEMode Value="0.000000000000000000e+00" ID="TQXAOEZGLLF"/>
+                <InLEStrength Value="1.000000000000000000e+00" ID="QFVFHXRWKOX"/>
+                <InLESweep Value="1.273030020056722833e+00" ID="JVUSHXMJRCZ"/>
+                <InTEDihedral Value="-7.026264704321072235e-15" ID="ZDSLQFCXYOE"/>
+                <InTEMode Value="0.000000000000000000e+00" ID="ZZBGATRBDJW"/>
+                <InTEStrength Value="1.000000000000000000e+00" ID="JQKHBGKKVRW"/>
+                <InTESweep Value="-3.814074834290352101e+00" ID="ICAVIADLHYM"/>
+                <OutCluster Value="1.000000000000000000e+00" ID="RDAAHTCTILH"/>
+                <OutLEDihedral Value="-7.202106782626759676e-15" ID="BOBUDGRZOXJ"/>
+                <OutLEMode Value="0.000000000000000000e+00" ID="HPJCPEPTZMD"/>
+                <OutLEStrength Value="1.000000000000000000e+00" ID="MQSWHWBTNUA"/>
+                <OutLESweep Value="1.273030020056722833e+00" ID="QXIXRMXNQCH"/>
+                <OutTEDihedral Value="7.026264704321072235e-15" ID="CCAYXYCZHNX"/>
+                <OutTEMode Value="0.000000000000000000e+00" ID="CLVEUJCEOLJ"/>
+                <OutTEStrength Value="1.000000000000000000e+00" ID="SBPQKCIJPYL"/>
+                <OutTESweep Value="-3.814074834290352101e+00" ID="LYSDZGSZFZE"/>
+                <ProjectedSpan Value="0.000000000000000000e+00" ID="BJLVZPDICLK"/>
+                <Root_Chord Value="3.000000000000000000e+00" ID="GIRWSCMEOZX"/>
+                <RotateMatchDideralFlag Value="0.000000000000000000e+00" ID="BRECXWRDFQR"/>
+                <Sec_Sweep Value="-4.163353933657020178e+01" ID="OOYQGBOORZN"/>
+                <Sec_Sweep_Location Value="1.000000000000000000e+00" ID="OHNZJWBGKWK"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="FAKDMFQLEYB"/>
+                <Span Value="2.250000000000000000e+00" ID="AICNGSCXPHZ"/>
+                <Sweep Value="0.000000000000000000e+00" ID="EHKYCGHFTHU"/>
+                <Sweep_Location Value="0.000000000000000000e+00" ID="QGDDDCERIYG"/>
+                <Taper Value="3.333333333333333148e-01" ID="ODERFCUZYBJ"/>
+                <Tip_Chord Value="1.000000000000000000e+00" ID="YCNGWVYLUYP"/>
+                <Twist Value="0.000000000000000000e+00" ID="OCPIQPRTUHG"/>
+                <Twist_Location Value="2.500000000000000000e-01" ID="OBUWEXBAVKC"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>2</Type>
+              <GroupName>XSec</GroupName>
+              <DriverGroup>
+                <NumVar>8</NumVar>
+                <NumChoices>3</NumChoices>
+                <ChoiceVec>1, 5, 6, </ChoiceVec>
+              </DriverGroup>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>JWRDGBNLBT</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="KQPHAAVFMSW"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="LUMCMYZMMYM"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="BPHHJHXGOUS"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="WRUHUUDNNZK"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="SWZEJENARHV"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="XVUOOZISHRH"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="SRPZCGOXRPD"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="VJVCSOINKYQ"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="TOBZDXHHAGP"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="RTQAQFEXCTO"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="TSGUQDGXIGT"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="WTTVGKHQIKH"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="BVLTOMJUFUE"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="WCKOZEZYOSP"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="IVZBJIARAUF"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="VUYZERKYZZI"/>
+                    <Number Value="8.000000000000000000e+00" ID="PMYDYEJFKPM"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="MXCUNBTQIXC"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="RMJVRGAIZZX"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="NUZKVSAVJSF"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="SJXJJGMQOSC"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="PLTYEPIDETR"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="VFOHCWPWRRR"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="BGTLSRVSZBV"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="JKCOVRIQBIN"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="XGTMDNONGPI"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="DPYMYAEIIIC"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="ARZBQTFDNFF"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="HGDIRTZPRAQ"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="NUCPLYKXLWQ"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="KEOKDQETUNM"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="XASYBZMILSJ"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="JLKUPSGARPB"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="CJQSLKDNNAX"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="HXZOKJEYOXW"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="DGPAVUGSFPC"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="NPKLVQOMWKZ"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="HPKTLNLXPBE"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="EFTUXBECKTA"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="COSUOBHBFYX"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="FVWFFINXXRE"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="GZIRLJAEGMU"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="MYSGIUZRUQS"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="JMRYGIWLSPH"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="RPSZGRWZUMA"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="QLRCBXZIRMO"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="STCWDLSRTVP"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="TLDBDQEJSTY"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="XMKNIZJOQTX"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="PCLDQDOHYZZ"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="ZNRCZJUSWUV"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="PYLFTMOHSPO"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="YCJGRKHTJUG"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="UKBLFBMCRHD"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="YXRJWOUFKMM"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="MJSPXLERKAQ"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="HAPKGJIUEGO"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="6.788561334348937326e-02" ID="EMFUXWRIPXZ"/>
+                    <Camber Value="0.000000000000000000e+00" ID="YBECRRETNJU"/>
+                    <CamberInputFlag Value="0.000000000000000000e+00" ID="HLBPNHHWQME"/>
+                    <CamberLoc Value="2.000000000000000111e-01" ID="YQIZRXWFFLQ"/>
+                    <Chord Value="1.000000000000000000e+00" ID="BCINREBCCDE"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="WPEEAOYNWBI"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="FIKSVUTNNPX"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="SSXXERSVPMX"/>
+                    <HWRatio Value="1.000000000000000056e-01" ID="XUVSIAQZAXE"/>
+                    <IdealCl Value="0.000000000000000000e+00" ID="EITGFJJQWPN"/>
+                    <Invert Value="0.000000000000000000e+00" ID="OCUMQILRNRE"/>
+                    <Scale Value="1.000000000000000000e+00" ID="VGYFBCEFDSM"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="YTQWLXKJTQV"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="TUKXXQGUQGV"/>
+                    <Theta Value="0.000000000000000000e+00" ID="EGUKJLSBGHQ"/>
+                    <ThickChord Value="1.000000000000000056e-01" ID="SDVYXTOUVNM"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="UIYYUNPNSXM"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="EKUVURQZNDC"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="QNURXNJJOXF"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="SMVJOWSGXHV"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="UCMGRTGPXSW"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="TFRVTDTQOKQ"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="OJQCSOOSROV"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="FOYBIZNKZLG"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>7</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>NDJGCUFNIH</ID>
+              <Name>Default</Name>
+              <XSec>
+                <Area Value="2.024999999999999911e+00" ID="NQHKSLWQBCM"/>
+                <Aspect Value="2.500000000000000000e+00" ID="HHJFJAWIXCJ"/>
+                <Avg_Chord Value="9.000000000000000222e-01" ID="FBLYJRRVRGO"/>
+                <Dihedral Value="0.000000000000000000e+00" ID="SLFSVZEFAHD"/>
+                <InCluster Value="1.000000000000000000e+00" ID="AXASUWVYWFF"/>
+                <InLEDihedral Value="7.202106782626759676e-15" ID="KWFQPEPSIEV"/>
+                <InLEMode Value="0.000000000000000000e+00" ID="CPHTMVUHZIR"/>
+                <InLEStrength Value="1.000000000000000000e+00" ID="ALXGPPVVQVN"/>
+                <InLESweep Value="1.273030020056722833e+00" ID="LTDCSCBDOZT"/>
+                <InTEDihedral Value="-7.026264704321072235e-15" ID="AUXZXIYFURS"/>
+                <InTEMode Value="0.000000000000000000e+00" ID="VHMDATWTBFX"/>
+                <InTEStrength Value="1.000000000000000000e+00" ID="DNGIUBIVFQA"/>
+                <InTESweep Value="-3.814074834290352101e+00" ID="KDWMFXMCZMH"/>
+                <OutCluster Value="1.000000000000000000e+00" ID="KSOGXHYDARO"/>
+                <OutLEDihedral Value="-7.020606388143039735e-15" ID="RQCGQYOEZCX"/>
+                <OutLEMode Value="0.000000000000000000e+00" ID="QFRCPKBDZVL"/>
+                <OutLEStrength Value="1.000000000000000000e+00" ID="SNLNRYBWVKK"/>
+                <OutLESweep Value="1.273030020056722833e+00" ID="TZCRAWPUFPM"/>
+                <OutTEDihedral Value="7.051705571983791478e-15" ID="HCZSSXSQHKG"/>
+                <OutTEMode Value="0.000000000000000000e+00" ID="TZARJXDXABE"/>
+                <OutTEStrength Value="1.000000000000000000e+00" ID="BYQTZANGDNV"/>
+                <OutTESweep Value="-3.814074834290352101e+00" ID="DPCREMSMZKY"/>
+                <ProjectedSpan Value="2.250000000000000000e+00" ID="QONFVPFXXYY"/>
+                <Root_Chord Value="1.000000000000000000e+00" ID="LFMXFDZNTWT"/>
+                <RotateMatchDideralFlag Value="0.000000000000000000e+00" ID="TAZNVFSWBBH"/>
+                <Sec_Sweep Value="-3.814074834290353877e+00" ID="AYRXHXVJSUZ"/>
+                <Sec_Sweep_Location Value="1.000000000000000000e+00" ID="NRNLLIURZBG"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="OVHKKUDYVJE"/>
+                <Span Value="2.250000000000000000e+00" ID="MBYWMRCTUEN"/>
+                <Sweep Value="0.000000000000000000e+00" ID="CXYMVFFJDXP"/>
+                <Sweep_Location Value="2.500000000000000000e-01" ID="YUFRFMPAJAZ"/>
+                <Taper Value="8.000000000000000444e-01" ID="MWNWHAOUWLV"/>
+                <Tip_Chord Value="8.000000000000000444e-01" ID="PKDJRLMTXXH"/>
+                <Twist Value="0.000000000000000000e+00" ID="KWVQQCBNSGX"/>
+                <Twist_Location Value="2.500000000000000000e-01" ID="BZZKQQHPFLA"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>2</Type>
+              <GroupName>XSec</GroupName>
+              <DriverGroup>
+                <NumVar>8</NumVar>
+                <NumChoices>3</NumChoices>
+                <ChoiceVec>1, 5, 6, </ChoiceVec>
+              </DriverGroup>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>KZWHRNXXTS</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="YIHGNRMYKTX"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="CFZTMJEXHFN"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="BZFSRRWDZSU"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="BORFKPBTUMT"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="HHETVIYBAET"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="TMREGXPLXLM"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="EJMZFPSDQRM"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="ASMAZLAATDG"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="JRDQFCQQPCF"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="NCHVFKEZNOQ"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="EYRTUFZNHQJ"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="EIEBCNKVUYT"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="SHOZADDRERZ"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="AMUHMSBIUXR"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="YHZIKDZEJEB"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="PLTZCHYGGJN"/>
+                    <Number Value="8.000000000000000000e+00" ID="XJFBOWSIJTD"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="MMOGSHTKLFC"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="JOXTHMSTGTJ"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="MIVJVEEUHXN"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="CVWNRCVLSQE"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="AMYTLYWIBPB"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="ESXKZFWHSFC"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="IZIINYPBMFX"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="CEFGBUCDASS"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="VKMATKXFKML"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="WTFIKOBLETL"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="IKCTSSYWBED"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="FJJARXIJUBH"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="UWKWESRAXQY"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="SPCNNWHNSNG"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="JQBVSVGUYYT"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="KNCAJATDQPK"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="RYYMIVZCUKO"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="TEVFHDPSYSK"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="BAVMQAVYGBP"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="QUNYOVYTKKY"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="UKNKODQPLWW"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="QGKIIDTNVWQ"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="JPCUUBNXSAW"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="UNTAJKOPXHX"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="SOOGCWHCORX"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="BJAGWQUZUYS"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="VVXSUQONGJD"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="TMYMZAGDEEZ"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="LSLPRNFHQDE"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="WBRJJEQXYOP"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="HFLPYARQSGT"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="KBDLWBVPDSG"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="TWXXVEIUUDQ"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="YTFHZMRWLUY"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="DUWIHLSDZLK"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="ZUAUNDOJQWA"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="GZGJDKFQOIK"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="NBTKVFFYDUT"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="UMOQNCCFSTH"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="SZTFTFGDBEA"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="4.344679253983323164e-02" ID="DHDXHKPDJSY"/>
+                    <Camber Value="0.000000000000000000e+00" ID="JPRFEJITHZV"/>
+                    <CamberInputFlag Value="0.000000000000000000e+00" ID="DWSZYZYGLCH"/>
+                    <CamberLoc Value="2.000000000000000111e-01" ID="DTWRWMDKFOB"/>
+                    <Chord Value="8.000000000000000444e-01" ID="RJKDCNRHPYM"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="MEEITPXFNTV"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="ORCDQVFJHKW"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="PLHVDDWCPGT"/>
+                    <HWRatio Value="1.000000000000000056e-01" ID="FMNMUEVMVGK"/>
+                    <IdealCl Value="0.000000000000000000e+00" ID="INNZWWYRSUI"/>
+                    <Invert Value="0.000000000000000000e+00" ID="NVVSUMJLYCK"/>
+                    <Scale Value="1.000000000000000000e+00" ID="HYHTXFNOYTJ"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="HIPSOKEOSLY"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="LNJUHPLISGA"/>
+                    <Theta Value="0.000000000000000000e+00" ID="BQRWHTBLMBZ"/>
+                    <ThickChord Value="1.000000000000000056e-01" ID="LLTPADLIYJW"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="UWFHRHGGAZL"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="LMYEVJSRALJ"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="JPHNCFPSXRO"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="IXWVUYHRETQ"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="WCYEAPWGBWM"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="JMYRSJKSXDD"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="ZZHMGSOMLYN"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="YKXZRLVCUUT"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>7</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+        </XSecSurf>
+      </WingGeom>
+    </Geom>
+    <Geom>
+      <ParmContainer>
+        <ID>LIYGGQUBGZ</ID>
+        <Name>PropNacells</Name>
+        <Attach>
+          <Eta_Attach_Location Value="0.000000000000000000e+00" ID="NBEVJIXOECR"/>
+          <L_01 Value="1.000000000000000000e+00" ID="IXYFGVIJWDB"/>
+          <L_Attach_Location Value="0.000000000000000000e+00" ID="HMEOAEEDFUN"/>
+          <L_Attach_Location0Len Value="0.000000000000000000e+00" ID="LLMCTHXPQWI"/>
+          <M_Attach_Location Value="5.000000000000000000e-01" ID="PWSQHRSKSDM"/>
+          <N_Attach_Location Value="5.000000000000000000e-01" ID="SQXHWWPYNSI"/>
+          <R_01 Value="1.000000000000000000e+00" ID="RSLDVBSHWUC"/>
+          <R_Attach_Location Value="0.000000000000000000e+00" ID="FBGLJNGIAKO"/>
+          <R_Attach_Location0N Value="0.000000000000000000e+00" ID="CVFZYAPBQXW"/>
+          <Rots_Attach_Flag Value="1.000000000000000000e+00" ID="ASSMWLIXKTM"/>
+          <S_Attach_Location Value="5.000000000000000000e-01" ID="QNFIXUDGCFV"/>
+          <T_Attach_Location Value="5.000000000000000000e-01" ID="HHHFMEXPYML"/>
+          <Trans_Attach_Flag Value="1.000000000000000000e+00" ID="PEWSZIPMIQI"/>
+          <U_01 Value="1.000000000000000000e+00" ID="KKADWLEHNOP"/>
+          <U_Attach_Location Value="0.000000000000000000e+00" ID="ODWBMCHROEW"/>
+          <U_Attach_Location0N Value="0.000000000000000000e+00" ID="PMXZLKFPQLM"/>
+          <V_Attach_Location Value="0.000000000000000000e+00" ID="FMPGZDIDYNX"/>
+        </Attach>
+        <BBox>
+          <X_Len Value="2.100000000000000089e+00" ID="JPMBYIDWUWU"/>
+          <X_Min Value="1.036435636715777875e+00" ID="XOJXBSXELER"/>
+          <Y_Len Value="2.613879307090027915e-01" ID="ZFSQHRKGELE"/>
+          <Y_Min Value="1.472306034645498585e+00" ID="VJVBOTBGOYQ"/>
+          <Z_Len Value="2.604377329073118141e-01" ID="MCOOPXZPHHS"/>
+          <Z_Min Value="3.358982672753682563e-01" ID="PGERQHGVGRX"/>
+        </BBox>
+        <Design>
+          <Length Value="2.100000000000000089e+00" ID="FDXXHQRNRSS"/>
+          <OrderPolicy Value="0.000000000000000000e+00" ID="QQQRIAWCZKI"/>
+        </Design>
+        <EndCap>
+          <CapUMaxLength Value="1.000000000000000000e+00" ID="LRJXICGHFMJ"/>
+          <CapUMaxOffset Value="0.000000000000000000e+00" ID="ELUPXPKUSQK"/>
+          <CapUMaxOption Value="0.000000000000000000e+00" ID="FGFJTHJYPED"/>
+          <CapUMaxStrength Value="5.000000000000000000e-01" ID="URIWYBUOBHI"/>
+          <CapUMaxSweepFlag Value="0.000000000000000000e+00" ID="MHNDTAUFQKS"/>
+          <CapUMinLength Value="1.000000000000000000e+00" ID="KISKIHCZNMB"/>
+          <CapUMinOffset Value="0.000000000000000000e+00" ID="YJVXZHCDKDO"/>
+          <CapUMinOption Value="0.000000000000000000e+00" ID="PSERJUIHYMP"/>
+          <CapUMinStrength Value="5.000000000000000000e-01" ID="ULBVPHFFETT"/>
+          <CapUMinSweepFlag Value="0.000000000000000000e+00" ID="HGFPLFXZKDN"/>
+          <CapUMinTess Value="3.000000000000000000e+00" ID="MBLCJRZJBRJ"/>
+        </EndCap>
+        <EngineModel>
+          <AutoExtensionFlag Value="0.000000000000000000e+00" ID="PHJWUPKAVKU"/>
+          <AutoExtensionSet Value="1.000000000000000000e+00" ID="HXUYFMINGMQ"/>
+          <ExtensionDistance Value="7.000000000000000000e+00" ID="WHVQEVTUPFE"/>
+          <GeomIOType Value="0.000000000000000000e+00" ID="XDHVRWDFCQS"/>
+          <GeomInType Value="0.000000000000000000e+00" ID="RFELVHPKQGU"/>
+          <GeomOutType Value="1.000000000000000000e+00" ID="RYASMLWXRUA"/>
+          <InletFaceIndex Value="0.000000000000000000e+00" ID="WWGYDDSTXVK"/>
+          <InletFaceMode Value="0.000000000000000000e+00" ID="PTNTLPJIIIP"/>
+          <InletFaceU Value="0.000000000000000000e+00" ID="CLAWKCFWMKE"/>
+          <InletLipIndex Value="0.000000000000000000e+00" ID="KOLTZJXOFUE"/>
+          <InletLipMode Value="0.000000000000000000e+00" ID="XLGYMRSQJEC"/>
+          <InletLipU Value="0.000000000000000000e+00" ID="CEGFYMSEJVY"/>
+          <InletModeType Value="2.000000000000000000e+00" ID="EYMLQNDXWSH"/>
+          <OutletFaceIndex Value="0.000000000000000000e+00" ID="WCSCDOZGCXA"/>
+          <OutletFaceMode Value="0.000000000000000000e+00" ID="GJNDFQXKUTJ"/>
+          <OutletFaceU Value="0.000000000000000000e+00" ID="JEHDYLGKRCA"/>
+          <OutletLipIndex Value="0.000000000000000000e+00" ID="OTZVYBBCBSU"/>
+          <OutletLipMode Value="0.000000000000000000e+00" ID="UZCBNMJQUGJ"/>
+          <OutletLipU Value="0.000000000000000000e+00" ID="TLPMZRQXVCX"/>
+          <OutletModeType Value="2.000000000000000000e+00" ID="DMKLDDANLNS"/>
+        </EngineModel>
+        <Index>
+          <ActiveXSec Value="4.000000000000000000e+00" ID="PZODGLFMACW"/>
+        </Index>
+        <Mass_Props>
+          <CGx Value="0.000000000000000000e+00" ID="EYIOVGXOGAM"/>
+          <CGy Value="0.000000000000000000e+00" ID="CGTOAXDAYHO"/>
+          <CGz Value="0.000000000000000000e+00" ID="CYMWTKFAEJG"/>
+          <Density Value="1.000000000000000000e+00" ID="ZOGQNFMGIWI"/>
+          <Ixx Value="0.000000000000000000e+00" ID="UGTJLYCUEDS"/>
+          <Ixy Value="0.000000000000000000e+00" ID="UGYWHCBRQGO"/>
+          <Ixz Value="0.000000000000000000e+00" ID="XVNYJCFNPAT"/>
+          <Iyy Value="0.000000000000000000e+00" ID="ZPHREWCKTPF"/>
+          <Iyz Value="0.000000000000000000e+00" ID="QAOFPWAPZXW"/>
+          <Izz Value="0.000000000000000000e+00" ID="LMTFUEUDUHF"/>
+          <Mass_Area Value="1.000000000000000000e+00" ID="JNXAAZUOCUH"/>
+          <Mass_Prior Value="0.000000000000000000e+00" ID="NFATNVDVEGO"/>
+          <PointMass Value="0.000000000000000000e+00" ID="TILDGNXNNNN"/>
+          <Shell_Flag Value="0.000000000000000000e+00" ID="LIXVUMEBESH"/>
+        </Mass_Props>
+        <Negative_Volume_Props>
+          <Negative_Volume_Flag Value="0.000000000000000000e+00" ID="BODTXEZSSMV"/>
+        </Negative_Volume_Props>
+        <ParasiteDragProps>
+          <ExpandedList Value="0.000000000000000000e+00" ID="TSXPKNZDTWP"/>
+          <FFBodyEqnType Value="3.000000000000000000e+00" ID="LLVHVINQIBL"/>
+          <FFUser Value="1.000000000000000000e+00" ID="QZSDBGRAWIR"/>
+          <FFWingEqnType Value="3.000000000000000000e+00" ID="ACABXBGISNH"/>
+          <IncorporatedGen Value="0.000000000000000000e+00" ID="OZOQKKKXWGM"/>
+          <PercLam Value="0.000000000000000000e+00" ID="DTVLYPJUPUR"/>
+          <Q Value="1.000000000000000000e+00" ID="FLQUEXXGKXK"/>
+          <Roughness Value="0.000000000000000000e+00" ID="EUIDXSXPIZQ"/>
+          <TawTwRatio Value="1.000000000000000000e+00" ID="VJRMLQKUJBV"/>
+          <TeTwRatio Value="1.000000000000000000e+00" ID="NMJJOXYLTJV"/>
+        </ParasiteDragProps>
+        <Shape>
+          <Tess_U Value="1.600000000000000000e+01" ID="QDPXIFYMQTM"/>
+          <Tess_W Value="1.700000000000000000e+01" ID="UJWASVTYCFC"/>
+          <Wake Value="0.000000000000000000e+00" ID="XEDELZSULZC"/>
+        </Shape>
+        <Sym>
+          <Sym_Ancestor Value="3.000000000000000000e+00" ID="TQBZMHZPXQQ"/>
+          <Sym_Ancestor_Origin_Flag Value="0.000000000000000000e+00" ID="BLXYGMWJHTI"/>
+          <Sym_Axial_Flag Value="0.000000000000000000e+00" ID="UJSUXUFBMXA"/>
+          <Sym_Planar_Flag Value="0.000000000000000000e+00" ID="TIUWEETMQWI"/>
+          <Sym_Rot_N Value="2.000000000000000000e+00" ID="DLXYNOWQKYS"/>
+        </Sym>
+        <WakeSettings>
+          <WakeAngle Value="0.000000000000000000e+00" ID="OAQRRRODNAW"/>
+          <WakeScale Value="2.000000000000000000e+00" ID="RXSYRUWERGD"/>
+        </WakeSettings>
+        <XForm>
+          <Abs_Or_Relitive_flag Value="1.000000000000000000e+00" ID="VLQLYBVBYVB"/>
+          <Last_Scale Value="1.000000000000000000e+00" ID="HGPXXBTIRXX"/>
+          <Origin Value="0.000000000000000000e+00" ID="QKXSJTLVRGZ"/>
+          <Scale Value="1.000000000000000000e+00" ID="KAFFGGEKMPE"/>
+          <X_Location Value="1.036435636715777875e+00" ID="LXGFQFDVHZD"/>
+          <X_Rel_Location Value="-4.799578059071727409e-01" ID="XBSNXAHXULD"/>
+          <X_Rel_Rotation Value="0.000000000000000000e+00" ID="WROBKBEHAWO"/>
+          <X_Rotation Value="0.000000000000000000e+00" ID="NJCAZGIWNVJ"/>
+          <Y_Location Value="1.602999999999999980e+00" ID="PSHNZAGJIEE"/>
+          <Y_Rel_Location Value="1.602999999999999980e+00" ID="OJSXYXOSYUX"/>
+          <Y_Rel_Rotation Value="0.000000000000000000e+00" ID="GEWNBTKGLJY"/>
+          <Y_Rotation Value="0.000000000000000000e+00" ID="SBMSUOYSHYL"/>
+          <Z_Location Value="3.737704918032786483e-01" ID="HVQPLHZUNSH"/>
+          <Z_Rel_Location Value="-2.000000000000000111e-01" ID="WLBCCAZZYHJ"/>
+          <Z_Rel_Rotation Value="0.000000000000000000e+00" ID="YVMQPAKDEFY"/>
+          <Z_Rotation Value="0.000000000000000000e+00" ID="NEYKTJUXODZ"/>
+        </XForm>
+      </ParmContainer>
+      <GeomBase>
+        <TypeName>Fuselage</TypeName>
+        <TypeID>4</TypeID>
+        <TypeFixed>0</TypeFixed>
+        <ParentID>LOENSIWPJA</ParentID>
+        <Child_List>
+          <Child>
+            <ID>PDXWMKKXNN</ID>
+          </Child>
+          <Child>
+            <ID>XJBKGMUNCX</ID>
+          </Child>
+        </Child_List>
+      </GeomBase>
+      <Material>
+        <Name>Default</Name>
+      </Material>
+      <Wire_Color>
+        <ParmContainer>
+          <ID>VMLRNFETBG</ID>
+          <Name>Default</Name>
+          <Color_Parm>
+            <Alpha Value="2.550000000000000000e+02" ID="KMEEFCBFHRI"/>
+            <Blue Value="2.550000000000000000e+02" ID="QTNMBTHWSZC"/>
+            <Green Value="0.000000000000000000e+00" ID="SLXKBIMWXMS"/>
+            <Red Value="0.000000000000000000e+00" ID="HPBMTGNHPNJ"/>
+          </Color_Parm>
+        </ParmContainer>
+      </Wire_Color>
+      <Textures>
+        <Num_of_Tex>0</Num_of_Tex>
+      </Textures>
+      <Geom>
+        <Set_List>1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, </Set_List>
+        <SubSurfaces/>
+        <FeaStructures/>
+      </Geom>
+      <FuselageGeom>
+        <ParmContainer>
+          <ID>GAGDGJDZHX</ID>
+          <Name>Default</Name>
+        </ParmContainer>
+        <XSecSurf>
+          <XSec>
+            <ParmContainer>
+              <ID>MLOVTTNFQO</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="IVFQYYYUNJH"/>
+                <AllSym Value="0.000000000000000000e+00" ID="CRMZGQRHTLI"/>
+                <BottomLAngle Value="4.500000000000000000e+01" ID="DTIZEVCFRAR"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="NMXAZRWUGBT"/>
+                <BottomLCurve Value="1.840502975425566401e+00" ID="VHYTSIICLMI"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="KLNHUUCJWYQ"/>
+                <BottomLRAngleEq Value="1.000000000000000000e+00" ID="YSWTFNPEHSM"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="PMVJLYMOMOZ"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="FRQSRUAHRUE"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="PVOIOXOOHFX"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="SUMMHYJOMMH"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="TYGICKXDYTI"/>
+                <BottomLStrength Value="7.500000000000000000e-01" ID="OURGIIZPBQM"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="AIPHSVVUJXW"/>
+                <BottomRAngle Value="4.500000000000000000e+01" ID="CTXVGJUODCH"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="MHEUAAGSGHF"/>
+                <BottomRCurve Value="1.840502972834015205e+00" ID="CLABTYTGEBI"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="KBRCRKAKSSW"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="PVAPXYJLEIL"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="LSJLYNHGXDD"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="WKEUSTMXGNE"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="ZLSPUJDDOMO"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="FOAASTFRMAE"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="APEBROVOYEC"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="IEBHCKJBNTK"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="UIJTPLLPQYN"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="DFNEIRBCQMN"/>
+                <LeftLAngle Value="4.500000000000000000e+01" ID="WSMHFKZCLKF"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="AAFRHVJPUBO"/>
+                <LeftLCurve Value="1.947290939287852796e+00" ID="FQGDUWZZMGY"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="TGUFCJPMDOV"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="GUXSUNEUNRJ"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="QXZKHUWPHKK"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="PGNUGOAEWBZ"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="XROVCTPTQFH"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="URMPXHEWUYQ"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="LPBMQXZDFFX"/>
+                <LeftLStrength Value="7.500000000000000000e-01" ID="QMMKYHYYVVI"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="BIAMJFAWAFZ"/>
+                <LeftRAngle Value="4.500000000000000000e+01" ID="AIGJGOYIRJP"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="RLURJTIGBVA"/>
+                <LeftRCurve Value="1.947290936590385879e+00" ID="JJQKIHFVOZK"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="DATMCAWVQMY"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="TIMCYDHSHUG"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="OWICDHSASYJ"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="OSEAEROAWOP"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="JKPHBGDNSVX"/>
+                <RLSym Value="1.000000000000000000e+00" ID="WBQOIIPCJDD"/>
+                <RefLength Value="2.100000000000000089e+00" ID="FSCDYZLMYDQ"/>
+                <RightLAngle Value="4.500000000000000000e+01" ID="PMLKEQFRIPJ"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="QBUDVMTVTBA"/>
+                <RightLCurve Value="1.947290939287852796e+00" ID="XNMJVYFMHJY"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="UBLSQGKMAWK"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="AYESHKHFQLY"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="XZGFBWNIYMR"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="XLPLEDCEIAC"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="MTOTPZHDTKT"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="LFMWYSWIJFH"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="KPPLGJWMBII"/>
+                <RightLStrength Value="7.500000000000000000e-01" ID="HQWTVVOTXNO"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="AKOOKWMKKQR"/>
+                <RightRAngle Value="4.500000000000000000e+01" ID="TJTSUQXVWYJ"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="WCHCPRYOEBC"/>
+                <RightRCurve Value="1.947290936590385879e+00" ID="LYRLMXJXZIN"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="PESTRBVTRTA"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="SXLWXSXGGPP"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="FISTRRGDNXJ"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="OWYPGYZEGMC"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="CHUQFRXOLOQ"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="XPKVXULZMRG"/>
+                <Spin Value="0.000000000000000000e+00" ID="EUHFMJBPBDU"/>
+                <TBSym Value="1.000000000000000000e+00" ID="MTBNYCTUTMB"/>
+                <TopLAngle Value="4.500000000000000000e+01" ID="XXJRYTPYIPU"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="UHZJPJJRTVK"/>
+                <TopLCurve Value="2.087484339984205128e+00" ID="TFAVYBDEZYK"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="QRPKHSPNKUH"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="NPXEZKAFTGR"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="DVIYKZSNNRS"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="PPWGWKOJSMK"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="RARBDQVGNVK"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="RFDGVVKJBBE"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="LZNLZKQFEAE"/>
+                <TopLStrength Value="7.500000000000000000e-01" ID="OMKAAQLFIGV"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="ZLHMAIZMLMZ"/>
+                <TopRAngle Value="4.500000000000000000e+01" ID="TSLFFUBABAY"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="OVEHYPUNEDV"/>
+                <TopRCurve Value="2.087484337121613631e+00" ID="OWYOHNAHDJK"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="PALWATNXSZN"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="RHXANXSHMQX"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="MYWZGFJRHTO"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="RHNRBCVAXVA"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="WFJKFDCKABL"/>
+                <XLocPercent Value="0.000000000000000000e+00" ID="BPYCNQMGUIA"/>
+                <XRotate Value="0.000000000000000000e+00" ID="WITCFJSFUKB"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="IBGRWYIMYHG"/>
+                <YRotate Value="0.000000000000000000e+00" ID="CSXINSIJWJX"/>
+                <ZLocPercent Value="5.801687763713080093e-02" ID="SFFOTGJMJQV"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="JJRWCEPJCOG"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>OCNTYDIYMO</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="XKLTOZTIWHS"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="ESWRHCWZDSX"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="STYNOVPHAFE"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="LXNIPYZWDUU"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="LPOWTJZSWIF"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="LAYYQSPGFAT"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="JJNQHDLUPQZ"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="ZMIRTYJJIEO"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="HNEYYWYKWES"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="ZVSJVKVBCRQ"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="YHJPJJDRHCQ"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="OSCMXPYIEOP"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="XBKNJMJFJFO"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="AQDZOBRMIDN"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="BHTIPWOKEVH"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="LKUMTZSWGTC"/>
+                    <Number Value="8.000000000000000000e+00" ID="IWKDFQDISTH"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="GGFIBZCLJFH"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="TAARGLIUXAC"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="KBHHZMBWXME"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="ORDLZLJOLED"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="ADGPPQBXEHH"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="TCJPPABGIEX"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="AMPSNQYWUBB"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="QXJPCKOAMRY"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="ZHBBFAMZKOR"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="HEEYNYBIXJQ"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="LCDZIGUKAKQ"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="TWLASWGEDLC"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="MWXOCAZLRSQ"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="VJCYLGOKESD"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="UZPCYEUBBBF"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="IBDALDXZQDE"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="CAXLFIOTPEZ"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="LLCCHGZRNID"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="EWWMCSETDTU"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="MMDNIGKLYIM"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="HHFYIUXHNFD"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="NRYBOCJLOVI"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="NPSEHMUIYRW"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="QFTWITNVMUC"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="QOWQMRRUNTW"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="PWPTNTETTJY"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="YDBQJBYNYGW"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="ZLKWMRXWLCR"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="UPYOGAQLGFJ"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="DFAOUYEGNSO"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="JVAMUCAJARM"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="BCVTMLNOAYM"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="HISNJBAORJH"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="USNLBEYIHLX"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="DLAXQSEGWCN"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="HSHWOYOUQFA"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="OWWKCZTZDUV"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="HGSFPVTZYVT"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="GGCSUYYLYIX"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="LJRMOJBCDCH"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="0.000000000000000000e+00" ID="CAOQHTKDYJA"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="KOJPCHZJBTK"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="UWNTZEKGGXQ"/>
+                    <HWRatio Value="1.000000000000000000e+00" ID="PFGEBYYPRQS"/>
+                    <Scale Value="1.000000000000000000e+00" ID="QAKDEOUDPTR"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="LLKNZLNCXIF"/>
+                    <Theta Value="0.000000000000000000e+00" ID="JZPKIBLWYVL"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="AKJDBTXKWTF"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="OQKLYKSCTGW"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="SAYDVHSJMYO"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="JQXPCKITOES"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="JLZUDZVJZMU"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="GYXGHFBWJRP"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="BJUXYPJEDWV"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="ZYQLAVMOVQM"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>0</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>YPBUHSHOED</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="KLDHNTTMXWA"/>
+                <AllSym Value="0.000000000000000000e+00" ID="TCDJIZHCEKY"/>
+                <BottomLAngle Value="4.736842105263164626e+00" ID="YVMRHMTSDGD"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="QOYSTHQIHEQ"/>
+                <BottomLCurve Value="-1.005137962405838081e+00" ID="HXYZETLRPGL"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="LQCXGZMVESG"/>
+                <BottomLRAngleEq Value="0.000000000000000000e+00" ID="VWRFAHGTDIK"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="EYRQTAXOVST"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="WDUKUXWOFHY"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="MERDYZOEZEE"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="KEIFKTQDEGF"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="OPGBCVMFBTH"/>
+                <BottomLStrength Value="1.000000000000000000e+00" ID="FTRIYEPHYUS"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="ORGUYCCSCGT"/>
+                <BottomRAngle Value="0.000000000000000000e+00" ID="FHJQYZXUQPW"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="FPNZNBZWSLV"/>
+                <BottomRCurve Value="-3.637301593151403556e-01" ID="MOYRBMUDPOL"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="AJANQROAAET"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="MRGMEMEOAAX"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="NJTCUPVKYSH"/>
+                <BottomRStrength Value="1.090909090909090828e+00" ID="PNWBOZMXZHQ"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="VJYEBOFLIOS"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="SEELMSWDSQL"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="KZYBRALKCFW"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="VQGOSWJPDXG"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="OEUHCXUAVSJ"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="EQAQUKDUCES"/>
+                <LeftLAngle Value="0.000000000000000000e+00" ID="MPREYKTVOHS"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="PGALBIVBWVN"/>
+                <LeftLCurve Value="-1.045789331960177426e+00" ID="ELMGLFHAVSJ"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="PDAHCRSSXCH"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="QIUJCGNDIVH"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="SCRGEQYCYCC"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="WZYAEHRVYIS"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="BXYGQAJLNSA"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="EIPTZPCOBYV"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="FHQGBQVYAXS"/>
+                <LeftLStrength Value="1.000000000000000000e+00" ID="AWFMCICLITT"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="ZAJPBMKJOHS"/>
+                <LeftRAngle Value="0.000000000000000000e+00" ID="LHQKISLERDR"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="YWBJTPHQHAZ"/>
+                <LeftRCurve Value="-8.020330779186549477e-03" ID="FPCTKOABTKQ"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="XZDVLXYPFZZ"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="LTVWCJSZSOM"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="PPFCEWKLJDN"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="IOVAKCSGEFZ"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="JJPLHWFJXSK"/>
+                <RLSym Value="1.000000000000000000e+00" ID="VRIDHTYBHOS"/>
+                <RefLength Value="2.100000000000000089e+00" ID="IBXEYJTRKVF"/>
+                <RightLAngle Value="0.000000000000000000e+00" ID="RRNTFIYMAYR"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="DILNIVDIZPM"/>
+                <RightLCurve Value="-1.045789331960177204e+00" ID="CPHMPMBHLVY"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="EXFLECAMVGQ"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="MCVMZSAWYBG"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="DHFRVGJEUAP"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="NOOERSCQAWG"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="WUMFSGDWIXM"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="DEDNXKHFNLS"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="RYGZHCMYOBS"/>
+                <RightLStrength Value="1.000000000000000000e+00" ID="NLLFQUEMNNZ"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="KREZPNOSFNN"/>
+                <RightRAngle Value="0.000000000000000000e+00" ID="TLZPLFMIHXY"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="PKMXKAKZVUN"/>
+                <RightRCurve Value="0.000000000000000000e+00" ID="STUAFMSMJOC"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="YFVXOWVFEDO"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="UWCZPDBFAYK"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="CGHQOVKCELP"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="LKFXHFKDBQM"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="ECBGUBGLGWZ"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="TVMZUWQFLZV"/>
+                <Spin Value="0.000000000000000000e+00" ID="UNOXCSJZEDU"/>
+                <TBSym Value="0.000000000000000000e+00" ID="YAUBSBGWCQE"/>
+                <TopLAngle Value="0.000000000000000000e+00" ID="QWDSSUEWUUZ"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="UVAMQTWUMCT"/>
+                <TopLCurve Value="9.094578927186869333e-01" ID="PRAIVQXZOOR"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="MFNNLKKQPGU"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="QHURKUYZTDF"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="RUSRQUMIVXF"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="UAQMNVCLODN"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="NXJYSXNZZVJ"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="FVHMFGLCINK"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="QOTEIPWWABM"/>
+                <TopLStrength Value="1.000000000000000000e+00" ID="BMYSODLPCZY"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="QIBOVEQLVKX"/>
+                <TopRAngle Value="0.000000000000000000e+00" ID="ZEWVZUNFDNL"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="TCTHEDAJPOB"/>
+                <TopRCurve Value="8.020330779186865197e-03" ID="LHFWLFRGCQM"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="YGVOTGJMTCC"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="ETGDJEBFXZD"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="KLGPZQBYGQR"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="SBLYXBUSBJM"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="KCGZTFDUZBG"/>
+                <XLocPercent Value="2.500000000000000000e-01" ID="OOQLPUQIVCX"/>
+                <XRotate Value="0.000000000000000000e+00" ID="PETSHARJDTB"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="NANTWUFOQIQ"/>
+                <YRotate Value="0.000000000000000000e+00" ID="PTOVQCYTIZQ"/>
+                <ZLocPercent Value="4.148941689147124523e-02" ID="PSNJMLTSEKP"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="NOMLMRGNNCD"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>PXMFMKOGZT</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="FMCMXCSJZJF"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="TQUQXMEGSWA"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="ENXOMZMSNXJ"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="NZEQXGPDPNV"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="CHVVLIMNBYB"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="EPMYEXJFJAF"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="TJZDNYCOEZZ"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="TKSXTRHFKON"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="EZAJOLMKCSM"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="RPFHOTSPRRO"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="YORUECCNIEX"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="QDQVOKNRWZC"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="BWDMOUGLXLV"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="PHAXWTGMOKH"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="TWRFORJEFZU"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="MOMARNPVIHG"/>
+                    <Number Value="8.000000000000000000e+00" ID="IEMRKEUENSA"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="CXEEVZDOUOU"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="DGNVLZHFSCC"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="NDICJHZVIZU"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="BARTRZXHSQX"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="ZDKTYIADFML"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="IGQDBCQBEYM"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="LHQHKKFEUOP"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="FMWHYNBUFAT"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="JHZCJXSHGBE"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="BYABSSGPYQC"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="RTXKAPSTKCS"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="CPXBABHIVCU"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="ZHKIFEHMEMD"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="DOJXDVOOXRR"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="KBKHTVISRFB"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="VWHXNKPOWZE"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="AQXPITLDMWC"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="JXZOMCWQNCO"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="KRGUESYVXMT"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="OCJFWVIDMDC"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="CJSXNPNCMBD"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="ZSFKEUBWWEZ"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="JRYSPWHHZFB"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="OGLDNFYSNCK"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="OMQTMUOXCOV"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="VWXVHDORZNM"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="CQLMEZKXFWW"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="KZXTOOTNGQV"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="AKVZRYYZQGK"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="KOKYAVSNDSI"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="UAMWFMTQWAB"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="MIFHITAIEGF"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="FRHKZCPVWMC"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="RTLBHGIDXWZ"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="RWTGBVKHKST"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="TLASDGQQCKP"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="JHYMRGRQDDP"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="QIZOQZIXRVE"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="QKYBXIKNHPM"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="LHVBZNODADI"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="4.909109284730346634e-02" ID="IOLQLNPKGMY"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="WPVJUBZJOEP"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="UZMUZBNXGXH"/>
+                    <Ellipse_Height Value="2.500000000000000000e-01" ID="ERJVRMZYFDZ"/>
+                    <Ellipse_Width Value="2.500000000000000000e-01" ID="ODNWSPSXJDE"/>
+                    <HWRatio Value="1.000000000000000000e+00" ID="WCQPLCMRUPJ"/>
+                    <Scale Value="1.000000000000000000e+00" ID="RIMVTRMECSM"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="GQMUCPQXRVW"/>
+                    <Theta Value="0.000000000000000000e+00" ID="OUOYOYFRGJI"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="WKDDCKNWLNK"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="NHJPROIWSBQ"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="QRBSJOJTXIK"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="YZGRLMIZDMH"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="WIYDFTSETYJ"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="WDQDAEHAWBG"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="PELBDCYZAOI"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="JRSGZCRHCAL"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>2</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>IFANPVNVFP</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="ZZLUQAPDYOT"/>
+                <AllSym Value="0.000000000000000000e+00" ID="EJLSFDOVMMD"/>
+                <BottomLAngle Value="0.000000000000000000e+00" ID="CKOTNZOPYKJ"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="ZKEMTBIJFSK"/>
+                <BottomLCurve Value="1.820003461835718039e-01" ID="DIYWIRFHCBT"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="FIPWPXCUOCX"/>
+                <BottomLRAngleEq Value="0.000000000000000000e+00" ID="VQMVJTJWGSQ"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="JGDURAIGTWB"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="BSVQVCTZMRO"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="VXWHNOZKHSN"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="HFSPYMGONWI"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="BUTKKAIRZNZ"/>
+                <BottomLStrength Value="1.000000000000000000e+00" ID="LRSKCTPRYUD"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="SIFFCSOYKRR"/>
+                <BottomRAngle Value="-4.352773826458047779e+00" ID="CVNPJAZCZIP"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="RGHBYZRVQCZ"/>
+                <BottomRCurve Value="-7.860471630506493668e-02" ID="LRZCUKDTPZP"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="TLIXAINVMLA"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="OLXOSWOYVTX"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="TAWXXLYJWFU"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="QNSMDBMPPGG"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="MHFWHIWKJHK"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="VCIWJYPMCVY"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="YDJAHOCGTTI"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="AMDJMJHTXWG"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="VLVPICVIXBV"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="DKOGAOKOEOY"/>
+                <LeftLAngle Value="0.000000000000000000e+00" ID="RASNFGOCNCO"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="NWAQENYVWZA"/>
+                <LeftLCurve Value="8.020330779186549477e-03" ID="ZAKSJUNDOON"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="OMLCVOBXRAX"/>
+                <LeftLRAngleEq Value="0.000000000000000000e+00" ID="EVVLRECYPSS"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="CZCDVFOQHES"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="ZFFKDHNLWPO"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="DLVTJGAOCLI"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="NWPLLHLUNUR"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="MAAVHAGOAWO"/>
+                <LeftLStrength Value="1.000000000000000000e+00" ID="KFIPDFQCLZI"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="DKHPXZBMIMT"/>
+                <LeftRAngle Value="0.000000000000000000e+00" ID="QZBJZQVXWIO"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="JUPDLKYSMBF"/>
+                <LeftRCurve Value="-4.363563847631892201e-01" ID="UTRNUKNZPPI"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="TPQKHZPJKOL"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="QUFKLHENWOD"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="NDESAZCNAHV"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="WXAYQHLQGOG"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="WDAGQGDWHOI"/>
+                <RLSym Value="1.000000000000000000e+00" ID="XAPSRGFIYFB"/>
+                <RefLength Value="2.100000000000000089e+00" ID="NSEEQSBWIDF"/>
+                <RightLAngle Value="0.000000000000000000e+00" ID="VDFQYRNNYSU"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="IBDKQITATMB"/>
+                <RightLCurve Value="0.000000000000000000e+00" ID="UFAEQYVXOFG"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="ISDJGRGEQVZ"/>
+                <RightLRAngleEq Value="0.000000000000000000e+00" ID="HUHYMVFOFHH"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="SOUIGXJPISS"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="YUHSIZZNWJJ"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="RLXUUBPPLDY"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="ZPOYIWSVHSK"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="LVCOECXOHOH"/>
+                <RightLStrength Value="1.000000000000000000e+00" ID="UUVRFGZTZZZ"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="SJRAPTEEYNB"/>
+                <RightRAngle Value="0.000000000000000000e+00" ID="LRYVMFJIKCF"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="QXVJJDOITEO"/>
+                <RightRCurve Value="0.000000000000000000e+00" ID="SHMRZQCNWLU"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="XFGNBVPKWBP"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="JFHIBEPSHRC"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="JCLZVKIDOVE"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="BAHEBVQNUUQ"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="HSZYKWTDVZS"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="AAQDHQFVNMA"/>
+                <Spin Value="0.000000000000000000e+00" ID="AIFWMEEBVKR"/>
+                <TBSym Value="0.000000000000000000e+00" ID="WMPFYTDVGVA"/>
+                <TopLAngle Value="0.000000000000000000e+00" ID="JQWMJACRGIB"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="PFRYFNBYSMC"/>
+                <TopLCurve Value="-8.020330779186865197e-03" ID="JDIMPCUUSCD"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="KPBFTHQSFOB"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="LSTWDTQPWON"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="VOGSJXQLBQV"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="CCJRSFDMOJT"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="HOJYOGSJNSN"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="ODVDAHEMAHV"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="NKZFYRHQVOG"/>
+                <TopLStrength Value="1.000000000000000000e+00" ID="GCUQARVGJET"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="RWTVAJVNUVW"/>
+                <TopRAngle Value="0.000000000000000000e+00" ID="QOHXDNQUBWO"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="ZSTGNPXQDTI"/>
+                <TopRCurve Value="1.288953942457491016e-02" ID="OFFDRRDWACJ"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="KGUPZANVCKK"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="TXLYONJEHSL"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="BZXSVNAEQAF"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="NCVHUJQQDJN"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="BIHPSLMLROM"/>
+                <XLocPercent Value="5.000000000000000000e-01" ID="UJUEJOHUVUW"/>
+                <XRotate Value="0.000000000000000000e+00" ID="OYWOSMCKJSM"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="QLUTMJELVDR"/>
+                <YRotate Value="0.000000000000000000e+00" ID="INUWEXZXFHX"/>
+                <ZLocPercent Value="4.182359756519333366e-02" ID="DJABMELHIHW"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="MLUBPMKZQNL"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>HSHNOOZBVZ</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="AALGOADAKQW"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="FEJRPGVCFST"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="OFUJQXSIBLQ"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="JOOIERRMTBC"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="CZCYWREGDCW"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="YDCHSAIXPKQ"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="IOPCWZFIEKW"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="URDIYKEILGY"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="QBLBLPWJKRK"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="IOEAMOXEOZE"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="CHFDOAECRLB"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="RZAUATVNHBO"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="WGVXJMRIHKV"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="MDNGYEMGWXH"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="BZSOFIHEAWU"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="DPMBIXTPKRD"/>
+                    <Number Value="8.000000000000000000e+00" ID="SFFQMKHZSRI"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="XIVTVNJUNFI"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="DKEOHHABGIS"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="QCSXSJLVSWO"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="XCFQCNSFYST"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="XQPJYLDBZMX"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="XJSZUOPDJBF"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="ZIGPFBOPWKO"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="VPZLSNIOZSU"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="ZKPWTPLPUZB"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="UXBGEAEPHTU"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="QBRYEQYAZKJ"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="WGWTTUDAEOR"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="DHVCROOUPBR"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="LIVFOGKUHGF"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="RKIJPBBAYDT"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="HFPTJQPBISY"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="DLFYVYUBART"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="WXQAGLIPLBQ"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="GKSCSLYFQBF"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="CREREAJMIJN"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="CVPTBAQKHRF"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="NYLDEPFEISV"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="XTKQISPGZYU"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="ARXUUITLWRA"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="QRASJYQQLFU"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="FJSLNWSGHVF"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="IWXUAVYMRRS"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="PLWCSRCKIVY"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="CNUCDTRQZDU"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="XBPECXOOELE"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="GLZEFTBYXVR"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="ZCOWTOQQIKF"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="TUSPIUEPCME"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="JIWSDAGOJHX"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="FUBEDIPIAZY"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="PJFSKEKBZZD"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="REJGDOAHOFK"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="OVIQGLVBUUA"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="FYJFQYFUJKQ"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="AAMFHIPAMGN"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="4.909109284730346634e-02" ID="YVRFWABDYIE"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="VZCLKASQAUU"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="VPZJYLTZQXP"/>
+                    <Ellipse_Height Value="2.500000000000000000e-01" ID="JCRRGTIRYII"/>
+                    <Ellipse_Width Value="2.500000000000000000e-01" ID="GDRUIKQGXSB"/>
+                    <HWRatio Value="1.000000000000000000e+00" ID="GVAVOWVVYKS"/>
+                    <Scale Value="1.000000000000000000e+00" ID="DSYDJHDWRBB"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="FUESNNENQWF"/>
+                    <Theta Value="0.000000000000000000e+00" ID="KUBVIFIVBFR"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="CIGBMPQSRCT"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="ZPUXHTHUHMQ"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="JQHABDTAERW"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="OYSWLLKKQHN"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="JOLVGJAWEFP"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="DEOJKEFRLAP"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="WJTRGGXWLYG"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="VVYFFSQBFKJ"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>2</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>XYJSOHNOLN</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="BNFJATIPEZZ"/>
+                <AllSym Value="0.000000000000000000e+00" ID="OFBCHQPWGUO"/>
+                <BottomLAngle Value="-1.531578947368420529e+01" ID="GLZJGPYVCMU"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="CHNFRLZOHXK"/>
+                <BottomLCurve Value="-3.697795569023462070e-01" ID="TQQJUEBHFCJ"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="CVQZECULHTP"/>
+                <BottomLRAngleEq Value="1.000000000000000000e+00" ID="HIOEXKSJIYW"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="ZUXXLPMYERM"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="PUGEWEMATDS"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="AEOVYCAETFQ"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="WHIDELSBPON"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="MXZPWCVQUZK"/>
+                <BottomLStrength Value="1.000000000000000000e+00" ID="WLQRRRHNXJE"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="ULATRURIUDN"/>
+                <BottomRAngle Value="-1.531578947368420529e+01" ID="STWYXWTMTYZ"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="PJMQMEJGGOD"/>
+                <BottomRCurve Value="-1.032577478163970053e+00" ID="EXNIPZNLWEW"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="FTNKQTAMQWC"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="IYQIKDJDGFY"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="NUITXXLNNYF"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="ANMCJMYSNBQ"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="XKXVGKHDPAI"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="OIUCJBXIIAO"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="TGGOAAKYNUU"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="KMLODLAVVCU"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="NXROSOEVXTP"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="POKDMEVBTQW"/>
+                <LeftLAngle Value="0.000000000000000000e+00" ID="PJZMDZXIOHG"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="KZUVBTSSAQJ"/>
+                <LeftLCurve Value="4.344747996324718753e-01" ID="CCPYMMQDPWK"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="HMSAFHRIOFF"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="FACBXZTTDXF"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="EQJZRLNOEQS"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="OZKFSHVMXHY"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="YJKJUAZYILF"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="UFBYMAYNTBC"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="IEPLOGIPDZF"/>
+                <LeftLStrength Value="1.000000000000000000e+00" ID="LRYCZYWWMCN"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="MMWOXULJAEC"/>
+                <LeftRAngle Value="0.000000000000000000e+00" ID="RELLQQTMEQG"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="SXCNBRZQFNK"/>
+                <LeftRCurve Value="-1.336552192311816212e+00" ID="KAHWFKPFYIZ"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="HRDFEQPIUPY"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="AUERPDMRRRH"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="OCHNOKJHRNY"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="LKJXTNOLTMY"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="LNWQUJAIKNI"/>
+                <RLSym Value="1.000000000000000000e+00" ID="IYFJUGECHHY"/>
+                <RefLength Value="2.100000000000000089e+00" ID="CSIIMPJGREY"/>
+                <RightLAngle Value="0.000000000000000000e+00" ID="TXSAVFZUFLP"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="HDCXQROCPKQ"/>
+                <RightLCurve Value="0.000000000000000000e+00" ID="KGQUTTMYYNW"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="KDAPDTWBHVN"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="WFMNEUTODLO"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="DNXUMWUPUTR"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="TLUIMXMILID"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="SBDZHRKUOXZ"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="USMUTHQRWTB"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="ZSZKBKDZRQS"/>
+                <RightLStrength Value="1.000000000000000000e+00" ID="FPYHDKVXGKZ"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="QVGUOBKIYWW"/>
+                <RightRAngle Value="0.000000000000000000e+00" ID="SJUQIVYRTUC"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="YTOMOBCEEIE"/>
+                <RightRCurve Value="-1.336552192311816212e+00" ID="MGCKXBCXULR"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="YDVIBSILHIE"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="KCBHMOMLAPY"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="QOSAJBCEGSZ"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="IGAFEZJVWMU"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="EYOHAXKEZIH"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="PMVKOAWEXOM"/>
+                <Spin Value="0.000000000000000000e+00" ID="YDDJVGBQKGZ"/>
+                <TBSym Value="0.000000000000000000e+00" ID="SMIFUPQEFBX"/>
+                <TopLAngle Value="0.000000000000000000e+00" ID="ACSFFOMGDPQ"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="XTEDYAACVUE"/>
+                <TopLCurve Value="-2.198160871972833913e-02" ID="OOVDKGTMRBC"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="CNIUDVPBFOT"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="XTOWZIEMLMK"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="KWLXDNPLIRQ"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="LHESLETIMIM"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="TRNTLNJCFZK"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="BEMSUZXOZJX"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="KXXXCVQKDCD"/>
+                <TopLStrength Value="1.000000000000000000e+00" ID="OPSIAQDTPHS"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="OEIWBFRACOO"/>
+                <TopRAngle Value="0.000000000000000000e+00" ID="JBRLPOGCYWE"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="QBBPEWWJSJQ"/>
+                <TopRCurve Value="-4.178042928166764702e-01" ID="QCZJFYXHUCO"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="TAVDDNICUCF"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="YPCXFWDKPVP"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="CJGGJXUGWPR"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="UOTPDJWRGKB"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="CTDFDMPUNMG"/>
+                <XLocPercent Value="7.500000000000000000e-01" ID="SHRDLIDVZYC"/>
+                <XRotate Value="0.000000000000000000e+00" ID="DNAUOUTCEFY"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="VADRLPEYSXN"/>
+                <YRotate Value="0.000000000000000000e+00" ID="STZAWTSRYEF"/>
+                <ZLocPercent Value="5.999999999999999778e-02" ID="VMQRECPUUVT"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="TWCORZSDTNS"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>WKVPRAYWSY</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="WEKNIQISGPI"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="UWVMQCWQOVG"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="FMSUFELUOOU"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="JUMBYGSGEOQ"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="FXTPQKQPQVG"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="GINPUOVDWYE"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="YXBNFUXRZVI"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="OLGMCBRANZN"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="KXLVFNNIKCY"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="VIAVTNQFVID"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="DBSUVEFXHAZ"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="ETNBJNQBQQI"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="KOQIRNXALSJ"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="VRRFVRBXOMV"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="HPKPZEFQEDI"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="IREYOZLAWUR"/>
+                    <Number Value="8.000000000000000000e+00" ID="NMZBAGBPRFX"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="EAHYPRNVWAM"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="UGRMSMSPBHT"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="FMIGWVMJRMH"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="PUADFVBUIVQ"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="XSXOXVFGHYI"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="LGBCGDJWPGD"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="OKQIJWHIPAW"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="YWQVEVLJNIQ"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="ELJTXZFWDLA"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="XSAXFXVXOOG"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="COWOIEXINTB"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="ELOJWJQIJKM"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="CXMSWVHTPNS"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="ABOYJCUNWIO"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="BCGJOCHGXFQ"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="WFSZQZLEMHA"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="DZLPGJRFZRN"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="HPJCESXLMOG"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="QOUZSHIRVTO"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="TISFXPIPFZO"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="CHLBDWGAEOP"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="PGSIZBDFZFO"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="RAYRAVMHLIT"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="HWNVEPDREIX"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="JIAEKOTVVMF"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="DWMQYVTXXED"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="NPHXAPKQXYI"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="SPTQVPJQBVM"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="ZOBNGDSEYZO"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="ENVGEVCGDKI"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="NYIIKCSJTOI"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="SGFZTRFLMXS"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="IAVSLJKLAKS"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="ZZDJEBWYRYC"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="NWHWVAERJGO"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="JQTXVVNKNMM"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="BBQZZEOAIPM"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="MKKFIVUDTRD"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="HQAZWHKQFMY"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="KDVFAQWLMXJ"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="3.436376499311242366e-02" ID="VEHIXSXCZZM"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="LSWKMVCGCJA"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="BGJYCNUDDXT"/>
+                    <Ellipse_Height Value="1.749999999999999889e-01" ID="CRASRMHKSSS"/>
+                    <Ellipse_Width Value="2.500000000000000000e-01" ID="KUZDLSJRIMW"/>
+                    <HWRatio Value="6.999999999999999556e-01" ID="GPMEIEDENJA"/>
+                    <Scale Value="1.000000000000000000e+00" ID="CYNRXSIWFGJ"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="JKUUONLFJEI"/>
+                    <Theta Value="0.000000000000000000e+00" ID="YCRATKXOPHR"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="BNXPVEGLBUO"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="VFGDARAOBHK"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="XINLOFPBRVE"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="EVPVCCYOTMF"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="SUJJAKRULUI"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="WXZQRLIOFDT"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="VXOUYKNDDPS"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="TEFMLKJOBNX"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>2</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>YWIIEUZEYF</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="RBJUNLDZFFL"/>
+                <AllSym Value="0.000000000000000000e+00" ID="FHVTECZHEDJ"/>
+                <BottomLAngle Value="-4.500000000000000000e+01" ID="ZCNELJOGZVY"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="LSHPLDQSBLG"/>
+                <BottomLCurve Value="1.930250083497661251e+00" ID="CKFNGASIDUK"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="GZWEZZBDXAP"/>
+                <BottomLRAngleEq Value="1.000000000000000000e+00" ID="DKIXJOEQLXK"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="IRHIKPAJTNX"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="VGKQJOQHGJM"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="RSDHDHHVJHZ"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="LIEPOGLZUKM"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="BSOZBINYURO"/>
+                <BottomLStrength Value="7.500000000000000000e-01" ID="SXEQTFTETEF"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="ODKVVNKARWG"/>
+                <BottomRAngle Value="-4.500000000000000000e+01" ID="SVBHAVZSUTK"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="NKCWHQLLLND"/>
+                <BottomRCurve Value="1.930250086405383758e+00" ID="YTPRXTUJLDJ"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="ESZILXCZPHV"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="CTIPQQLVZWA"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="JLHTWPXGBUX"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="MZUEJHNVJPD"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="PRRNCEHBBLU"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="IKPKTEWYDFT"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="XWJTIJSGLCJ"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="DQRUORAGBEK"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="DJSBZHQRRFH"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="ZPEWNIWSGJV"/>
+                <LeftLAngle Value="-4.500000000000000000e+01" ID="RILWRJAEKBR"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="FKNLECAXIBO"/>
+                <LeftLCurve Value="2.087126206574033471e+00" ID="JIXQUYQPCJJ"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="QLECNPZJZJN"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="IXXURRIBCTC"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="HISNXMPTTYO"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="VKFCFZZLEUA"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="HCBHVOEMHBN"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="WXGGBVIAEJI"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="ECYIJDBNENL"/>
+                <LeftLStrength Value="7.500000000000000000e-01" ID="JBGOUVMFDKE"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="RFRSMXSVBJK"/>
+                <LeftRAngle Value="-4.500000000000000000e+01" ID="NXKJVDDPRBC"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="WBNBLMBROMQ"/>
+                <LeftRCurve Value="2.087126209652672149e+00" ID="HFECLYIDPDV"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="QPSMLDZLUIY"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="BYYMRSYYOMU"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="JVRJKDKJWLN"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="QOAIBSHCMIH"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="HYMFOBDZTZY"/>
+                <RLSym Value="1.000000000000000000e+00" ID="ADQXPBEQGDT"/>
+                <RefLength Value="2.100000000000000089e+00" ID="IZGFPGBUVTJ"/>
+                <RightLAngle Value="-4.500000000000000000e+01" ID="TQHAJXRRJIS"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="XVHPEHTPHXH"/>
+                <RightLCurve Value="2.087126206574033471e+00" ID="RSYSVZTRSNL"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="WLPWHXHNBKU"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="HRTJSJGEYIL"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="DJVBDGILNLX"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="CRARFVOBTNJ"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="WPKKRFWXMIV"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="WRETTBQVOAX"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="EMMPHBQONEB"/>
+                <RightLStrength Value="7.500000000000000000e-01" ID="TLTBCARJECD"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="BNVWBBNWKEM"/>
+                <RightRAngle Value="-4.500000000000000000e+01" ID="YIVYOVDAGPP"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="VUQIJUIYQLI"/>
+                <RightRCurve Value="2.087126209652672149e+00" ID="CENZPAXFSID"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="TNYBAWNHJFY"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="BSGHRXGTTFF"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="JVCYEHJNVQM"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="LAKWAXCJWRP"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="BOMCEBGOUXV"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="POSWUVQYFZL"/>
+                <Spin Value="0.000000000000000000e+00" ID="LBZSBNCJCXZ"/>
+                <TBSym Value="0.000000000000000000e+00" ID="QIESGFPEOAQ"/>
+                <TopLAngle Value="0.000000000000000000e+00" ID="MSRMFBUFAZU"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="UDKADJMMMRX"/>
+                <TopLCurve Value="8.350857580352554210e-01" ID="PUORDKTYAWL"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="LWTQTFCCHKV"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="TMMDTWLPACJ"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="JWYBRHCPCHH"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="GHMXIHAWFXS"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="SAPJYGQFEHT"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="LUHYHTMCOKR"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="AOTUGJONCKQ"/>
+                <TopLStrength Value="7.500000000000000000e-01" ID="TQYPBYWENOE"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="IGRAWDFCNBF"/>
+                <TopRAngle Value="0.000000000000000000e+00" ID="ITPKABPBUOI"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="WRWEOPBTIKN"/>
+                <TopRCurve Value="8.350857592736108392e-01" ID="EVMXTSDPDZA"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="UNQXFQIDERR"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="JFGDHASEDBR"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="MPNTKRFFFDH"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="JIENJNNKGAP"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="IKCRZEKGPXK"/>
+                <XLocPercent Value="1.000000000000000000e+00" ID="EOFUGYGREDQ"/>
+                <XRotate Value="0.000000000000000000e+00" ID="MVRTEYQKLJU"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="TTYYKHVTDFA"/>
+                <YRotate Value="0.000000000000000000e+00" ID="MBMKLIYPFFT"/>
+                <ZLocPercent Value="1.002356989693573980e-01" ID="GVILFWWRDGA"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="WFTGHFTSRPL"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>KLLSXXRHNA</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="KGJDZZJDHFA"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="XPLZYYOPRFS"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="KOJXKEDMBFK"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="PJHSITROBTW"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="LZSDSHUIWWU"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="CNTRYVDELNC"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="OWIABQCYPQK"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="GNMMFYIFOIQ"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="VNBIMWYNFDD"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="QXSIOECWNMR"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="BJZKRUSYLEK"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="WHAMYJUAMHX"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="GTOGDJDYOEX"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="NDIKISVAZVS"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="CFPPQLVCULY"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="HRBOGYMKEJW"/>
+                    <Number Value="8.000000000000000000e+00" ID="NPFVRIGMCVV"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="YSYJSVOFLDV"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="XSKXBDPRQBR"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="NGMNGVZSWTI"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="INJSNNXOHFB"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="QCAWNKUKGIN"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="IXAFDCOLLFW"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="EZWCYYVLNGX"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="PHRMTWSWZQJ"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="KTQHFYWTXAU"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="ZJTGKYXQFQD"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="HGCBNDRAYEO"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="BLAZIPPHQZG"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="EJPCXUZCKTG"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="TIHSCFDBJEM"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="HREGHJLSNCX"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="XMSJLKYBZRD"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="MWOHQZHEXKZ"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="CSAGYLKXEPW"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="LQQXLYOZXIR"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="PIWCSWYCPQD"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="ZLWVSOXXKYD"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="WODWMDAXCKX"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="HSOSUMBOPDH"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="KIBXMISXUIM"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="CNRKZUJOZJN"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="CEQXTVGBSEY"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="XRFGWPATOJJ"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="NDPQENWNOEE"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="FVRICMTEQID"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="YSQNOCNODSW"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="EBQDJBLIJVE"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="WAGSRDYLEAG"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="GMDTMKFDXAF"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="RFQITDABYBJ"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="XPBQGSVLNEI"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="XNKLMMJPDTA"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="WSCHTSHSAGC"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="PTQTVVTJTUX"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="DEIRJGOJMAT"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="KGFYQGDLXTQ"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="0.000000000000000000e+00" ID="KZAGUDHJKEW"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="PRQPBLHNLGI"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="BJBUSNEFELE"/>
+                    <HWRatio Value="1.000000000000000000e+00" ID="VLYSCDGOQGQ"/>
+                    <Scale Value="1.000000000000000000e+00" ID="CKHDIOJBUPV"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="QSDKBCVWMEE"/>
+                    <Theta Value="0.000000000000000000e+00" ID="CTWISADICLD"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="GCXKCCTZLJR"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="BHYSIUKJBUC"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="URUFCJHWUQS"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="YOOGRGGKZXT"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="WXEYXVHWMVC"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="JXVMFRUXTID"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="MGYBOUDQUCK"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="IDHOMKDIYVF"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>0</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+        </XSecSurf>
+      </FuselageGeom>
+    </Geom>
+    <Geom>
+      <ParmContainer>
+        <ID>PDXWMKKXNN</ID>
+        <Name>LiftRotor</Name>
+        <Attach>
+          <Eta_Attach_Location Value="0.000000000000000000e+00" ID="GIEBZYFZCMW"/>
+          <L_01 Value="1.000000000000000000e+00" ID="NVVNLSYLBSQ"/>
+          <L_Attach_Location Value="6.210862014399813891e-01" ID="SCWHIYNPUZG"/>
+          <L_Attach_Location0Len Value="1.310977427880025248e+00" ID="AFIQOKFBOYQ"/>
+          <M_Attach_Location Value="0.000000000000000000e+00" ID="RRPKOYZTNOR"/>
+          <N_Attach_Location Value="5.000000000000000000e-01" ID="HRBYTFEPXJC"/>
+          <R_01 Value="1.000000000000000000e+00" ID="TRFUJMSQXCM"/>
+          <R_Attach_Location Value="6.232057416267942074e-01" ID="MABLKIHUQGN"/>
+          <R_Attach_Location0N Value="2.492822966507176830e+00" ID="YYZUIPEQWCL"/>
+          <Rots_Attach_Flag Value="1.000000000000000000e+00" ID="NBOEMMVXHBQ"/>
+          <S_Attach_Location Value="0.000000000000000000e+00" ID="HPGSLTFVLAL"/>
+          <T_Attach_Location Value="5.000000000000000000e-01" ID="JFQPLYXWUGL"/>
+          <Trans_Attach_Flag Value="1.000000000000000000e+00" ID="ZKNLMDFGJWB"/>
+          <U_01 Value="1.000000000000000000e+00" ID="JKFOMPAWYKK"/>
+          <U_Attach_Location Value="6.232057416267942074e-01" ID="GQQOYAOOKTH"/>
+          <U_Attach_Location0N Value="2.492822966507176830e+00" ID="WQROWOCSSXB"/>
+          <V_Attach_Location Value="0.000000000000000000e+00" ID="DHULYVPSJDF"/>
+        </Attach>
+        <BBox>
+          <X_Len Value="1.402522517016349113e+00" ID="AQFKWJTBYXV"/>
+          <X_Min Value="2.344688907926179233e+00" ID="NYMFVPMRMAM"/>
+          <Y_Len Value="1.402522517016348891e+00" ID="IEGTWUOFAIL"/>
+          <Y_Min Value="9.017387414918254240e-01" ID="EGOWFDFSJSD"/>
+          <Z_Len Value="5.605583212626674694e-02" ID="NVEPKHCUCCD"/>
+          <Z_Min Value="6.551419151470110336e-01" ID="BKULAFBLUUO"/>
+        </BBox>
+        <Design>
+          <AF Value="1.489186065046675083e+02" ID="TTFXESQQFDB"/>
+          <AFLimit Value="4.000000000000000222e-01" ID="PMWHVOUINHI"/>
+          <AxFoldAx Value="0.000000000000000000e+00" ID="UWSCDVHQMXC"/>
+          <AzFoldDir Value="0.000000000000000000e+00" ID="WFEVCUOBVYI"/>
+          <BalanceX1 Value="0.000000000000000000e+00" ID="HEQCLWTCRHH"/>
+          <BalanceX2 Value="0.000000000000000000e+00" ID="MNYJNGUVZFV"/>
+          <Beta34 Value="2.000000000000000000e+01" ID="UJGPUOZLSFK"/>
+          <BladeAz_2 Value="9.000000000000000000e+01" ID="NPAPMTICCXZ"/>
+          <BladeAz_3 Value="1.800000000000000000e+02" ID="SQGIKOYLTVD"/>
+          <BladeAz_4 Value="2.700000000000000000e+02" ID="LNLSZSWUJGY"/>
+          <BladeAzimuthDeltaFlag Value="0.000000000000000000e+00" ID="YMMWOJEUSJH"/>
+          <BladeAzimuthMode Value="0.000000000000000000e+00" ID="QNDNNRNBAPD"/>
+          <CLi Value="5.240457003555305526e-01" ID="RGNDZFCTNGP"/>
+          <Chord Value="1.776562499999999878e-01" ID="CDYRBKXBXIX"/>
+          <ConstructXoC Value="5.000000000000000000e-01" ID="QFHYUHGFHLK"/>
+          <CylindricalSectionsFlag Value="0.000000000000000000e+00" ID="XUMFUMJAVKY"/>
+          <DeltaAz_2 Value="0.000000000000000000e+00" ID="XMOFSIBLRHV"/>
+          <DeltaAz_3 Value="0.000000000000000000e+00" ID="JWIYKKMNBNB"/>
+          <DeltaAz_4 Value="0.000000000000000000e+00" ID="IRUBYKDQOSU"/>
+          <Diameter Value="1.399999999999999911e+00" ID="JSSGZFDJONZ"/>
+          <ElFoldDir Value="0.000000000000000000e+00" ID="OLAVTVLBPNG"/>
+          <Feather Value="3.225249339548309280e+00" ID="UHPQXGQTYIE"/>
+          <FeatherAxisXoC Value="5.000000000000000000e-01" ID="JARTHXCQFJT"/>
+          <FeatherOffsetXoC Value="0.000000000000000000e+00" ID="JXWDBLYMSXL"/>
+          <FoldAngle Value="0.000000000000000000e+00" ID="PRPNSBYLFAL"/>
+          <FoldAngle_1 Value="0.000000000000000000e+00" ID="YPVLBIOUKOP"/>
+          <FoldAngle_2 Value="0.000000000000000000e+00" ID="GYGRLRCEJBQ"/>
+          <FoldAngle_3 Value="0.000000000000000000e+00" ID="CTYXLKAWBLG"/>
+          <InCluster Value="1.000000000000000000e+00" ID="VSWGBOSIJGU"/>
+          <IndividualBladeFoldFlag Value="0.000000000000000000e+00" ID="UIZXDYIJAAW"/>
+          <LECluster Value="2.500000000000000000e-01" ID="QMMFBVNTFZT"/>
+          <NumBlade Value="4.000000000000000000e+00" ID="IIWIPDORTCT"/>
+          <OffFoldAx Value="0.000000000000000000e+00" ID="XWOMXMXGPKY"/>
+          <OutCluster Value="1.000000000000000000e+00" ID="QNAPJQXFQTR"/>
+          <PChord Value="1.942800443498498009e-01" ID="BUUIUZUPOOO"/>
+          <PSolidity Value="2.473650352191299751e-01" ID="QXJSSIFBXVJ"/>
+          <Precone Value="0.000000000000000000e+00" ID="DXNALVVIWUT"/>
+          <PropMode Value="0.000000000000000000e+00" ID="PHYMVTGLUGG"/>
+          <RFoldAx Value="2.000000000000000111e-01" ID="FAHLWORPAGO"/>
+          <ReverseFlag Value="0.000000000000000000e+00" ID="PXSQMRYSKNB"/>
+          <Rotate Value="0.000000000000000000e+00" ID="NCUGWTGZULA"/>
+          <Solidity Value="2.261989628693562293e-01" ID="EBOKNTYINAI"/>
+          <TChord Value="1.923498613911290012e-01" ID="NNBLWUOTOWT"/>
+          <TECluster Value="2.500000000000000000e-01" ID="IEMKOBEYLYZ"/>
+          <TSolidity Value="2.449074499475127342e-01" ID="DFKVZUCKZYB"/>
+          <UseBeta34Flag Value="1.000000000000000000e+00" ID="MWFYSUPLUYP"/>
+        </Design>
+        <EndCap>
+          <CapUMaxLength Value="1.000000000000000000e+00" ID="VHSZVXWBEOP"/>
+          <CapUMaxOffset Value="0.000000000000000000e+00" ID="OISGVNBQPMT"/>
+          <CapUMaxOption Value="2.000000000000000000e+00" ID="DVETVXZFNFD"/>
+          <CapUMaxStrength Value="1.000000000000000000e+00" ID="TURUCJAHUPD"/>
+          <CapUMaxSweepFlag Value="0.000000000000000000e+00" ID="FRZKXMJYKFL"/>
+          <CapUMinLength Value="1.000000000000000000e+00" ID="RSSIEJOAFOK"/>
+          <CapUMinOffset Value="0.000000000000000000e+00" ID="RLYUKOOJVFJ"/>
+          <CapUMinOption Value="1.000000000000000000e+00" ID="KTRRHMGDOZW"/>
+          <CapUMinStrength Value="5.000000000000000000e-01" ID="XBOLIAORYEF"/>
+          <CapUMinSweepFlag Value="0.000000000000000000e+00" ID="DFJPWXUMKWZ"/>
+          <CapUMinTess Value="3.000000000000000000e+00" ID="PJSUAOHWOYD"/>
+        </EndCap>
+        <Index>
+          <ActiveBlade Value="1.000000000000000000e+00" ID="VGKOWZHVPUF"/>
+          <ActiveXSec Value="2.000000000000000000e+00" ID="OETPOJDTZIP"/>
+        </Index>
+        <Mass_Props>
+          <CGx Value="0.000000000000000000e+00" ID="SQLTIPRWLKB"/>
+          <CGy Value="0.000000000000000000e+00" ID="UFJPODJZPFN"/>
+          <CGz Value="0.000000000000000000e+00" ID="VKNHQFGXNCO"/>
+          <Density Value="1.000000000000000000e+00" ID="ZRVKBWWJQPO"/>
+          <Ixx Value="0.000000000000000000e+00" ID="BDIGZSHPEVJ"/>
+          <Ixy Value="0.000000000000000000e+00" ID="DRFSSJCWABV"/>
+          <Ixz Value="0.000000000000000000e+00" ID="OACEKFSHWEQ"/>
+          <Iyy Value="0.000000000000000000e+00" ID="NKOAEIHRSZC"/>
+          <Iyz Value="0.000000000000000000e+00" ID="QUHMOKWVJPY"/>
+          <Izz Value="0.000000000000000000e+00" ID="MUUZJOOETCA"/>
+          <Mass_Area Value="1.000000000000000000e+00" ID="IIEYZQXCUTG"/>
+          <Mass_Prior Value="0.000000000000000000e+00" ID="BLPHOECUFOD"/>
+          <PointMass Value="0.000000000000000000e+00" ID="LSWUHGBJGJE"/>
+          <Shell_Flag Value="0.000000000000000000e+00" ID="SZECCDKEDNH"/>
+        </Mass_Props>
+        <Negative_Volume_Props>
+          <Negative_Volume_Flag Value="0.000000000000000000e+00" ID="NMKPNAVEMZU"/>
+        </Negative_Volume_Props>
+        <ParasiteDragProps>
+          <ExpandedList Value="0.000000000000000000e+00" ID="JLMLWMBYUMK"/>
+          <FFBodyEqnType Value="3.000000000000000000e+00" ID="NHYISPWZMVX"/>
+          <FFUser Value="1.000000000000000000e+00" ID="UVIVIRGOOTY"/>
+          <FFWingEqnType Value="3.000000000000000000e+00" ID="TGWKUBNALEO"/>
+          <IncorporatedGen Value="0.000000000000000000e+00" ID="YKKTGQVMNDH"/>
+          <PercLam Value="0.000000000000000000e+00" ID="RHQYYDVCMEL"/>
+          <Q Value="1.000000000000000000e+00" ID="NXLEYBGPLTJ"/>
+          <Roughness Value="0.000000000000000000e+00" ID="JUAOBTJFBWB"/>
+          <TawTwRatio Value="1.000000000000000000e+00" ID="JHMDLLOBDID"/>
+          <TeTwRatio Value="1.000000000000000000e+00" ID="OECRNNLJYRL"/>
+        </ParasiteDragProps>
+        <PropGeom>
+          <MaxGrowth Value="1.963769402454648594e+00" ID="EETOTOXPFNK"/>
+          <SmallPanelW Value="3.132476266568270744e-04" ID="EYNNLHQNAOU"/>
+        </PropGeom>
+        <Shape>
+          <Tess_U Value="1.200000000000000000e+01" ID="AJHVXYRECAR"/>
+          <Tess_W Value="1.700000000000000000e+01" ID="LPAPNPIPSPL"/>
+          <Wake Value="0.000000000000000000e+00" ID="BFRZQOWLKKL"/>
+        </Shape>
+        <Sym>
+          <Sym_Ancestor Value="4.000000000000000000e+00" ID="BRYHVZKCJWQ"/>
+          <Sym_Ancestor_Origin_Flag Value="0.000000000000000000e+00" ID="VVHRIMBQIBD"/>
+          <Sym_Axial_Flag Value="0.000000000000000000e+00" ID="VPZEMFVLKVN"/>
+          <Sym_Planar_Flag Value="0.000000000000000000e+00" ID="VXZYRZSKXXN"/>
+          <Sym_Rot_N Value="2.000000000000000000e+00" ID="EKKBAGKUMXK"/>
+        </Sym>
+        <WakeSettings>
+          <WakeAngle Value="0.000000000000000000e+00" ID="DRPNLIDYWRW"/>
+          <WakeScale Value="2.000000000000000000e+00" ID="IDQCAOEITNU"/>
+        </WakeSettings>
+        <XForm>
+          <Abs_Or_Relitive_flag Value="1.000000000000000000e+00" ID="JVEMMHHGGIC"/>
+          <Last_Scale Value="1.000000000000000000e+00" ID="IGCWMWUTCUS"/>
+          <Origin Value="0.000000000000000000e+00" ID="LCXFSHGJKZU"/>
+          <Scale Value="1.000000000000000000e+00" ID="KUZYTBUTGIC"/>
+          <X_Location Value="3.045950166434353790e+00" ID="QUTISNUIIQQ"/>
+          <X_Rel_Location Value="2.009514529718575915e+00" ID="VAWQSPCMEMZ"/>
+          <X_Rel_Rotation Value="0.000000000000000000e+00" ID="WCBWIGTDOBI"/>
+          <X_Rotation Value="0.000000000000000000e+00" ID="HDQBDXOLRNO"/>
+          <Y_Location Value="1.602999999999999980e+00" ID="MNEDOSZXJDX"/>
+          <Y_Rel_Location Value="0.000000000000000000e+00" ID="ECEMQBBEPNS"/>
+          <Y_Rel_Rotation Value="9.000000000000000000e+01" ID="HQZVDZIGNSP"/>
+          <Y_Rotation Value="9.000000000000000000e+01" ID="PSIVVMFXMHP"/>
+          <Z_Location Value="6.821329609956905404e-01" ID="RJYCVSQKQGO"/>
+          <Z_Rel_Location Value="3.083624691924118366e-01" ID="HGLYNPWTVPV"/>
+          <Z_Rel_Rotation Value="0.000000000000000000e+00" ID="WRHRJIUVMUT"/>
+          <Z_Rotation Value="0.000000000000000000e+00" ID="XNAWDINTSSV"/>
+        </XForm>
+      </ParmContainer>
+      <GeomBase>
+        <TypeName>Propeller</TypeName>
+        <TypeID>11</TypeID>
+        <TypeFixed>0</TypeFixed>
+        <ParentID>LIYGGQUBGZ</ParentID>
+        <Child_List/>
+      </GeomBase>
+      <Material>
+        <Name>Default</Name>
+      </Material>
+      <Wire_Color>
+        <ParmContainer>
+          <ID>GJHJSJAWQE</ID>
+          <Name>Default</Name>
+          <Color_Parm>
+            <Alpha Value="2.550000000000000000e+02" ID="RNDLIWWXJUM"/>
+            <Blue Value="2.550000000000000000e+02" ID="VVJLXGBZCXC"/>
+            <Green Value="0.000000000000000000e+00" ID="HBKFJPSIMEQ"/>
+            <Red Value="0.000000000000000000e+00" ID="YCIVKWIMEQV"/>
+          </Color_Parm>
+        </ParmContainer>
+      </Wire_Color>
+      <Textures>
+        <Num_of_Tex>0</Num_of_Tex>
+      </Textures>
+      <Geom>
+        <Set_List>1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, </Set_List>
+        <SubSurfaces/>
+        <FeaStructures/>
+      </Geom>
+      <PropellerGeom>
+        <ParmContainer>
+          <ID>AKPUSOZQWO</ID>
+          <Name>Default</Name>
+        </ParmContainer>
+        <XSecSurf>
+          <XSec>
+            <ParmContainer>
+              <ID>JIKDXQNYLC</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="2.000000000000000111e-01" ID="JEEPRXKVICE"/>
+                <RefLength Value="6.999999999999999556e-01" ID="UZVTHDLUOVC"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="DBQLXDJLAJA"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>EKFNXXSMRQ</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="MYBHJPTNWNM"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="NTOCONHHITK"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="NKZSPMTFIYV"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="VLHPMKDISRW"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="FMCOLSNIIMC"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="XUVXFZXMUOE"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="ZNUFMZFCZMR"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="TXQYCMQZBYI"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="FPERAKPLKAB"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="HNGWWPHYLDI"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="TVMZZPKOARO"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="XDAQFNEJYTM"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="UDPXESXUWCY"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="EDDVFGESFJO"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="CWOAKSGDKLF"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="NAERJWUAAAL"/>
+                    <Number Value="8.000000000000000000e+00" ID="UOAEZHTCRQP"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="PSSCKJHBDZP"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="XZARRPWVSZD"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="EXHEJWRZCVP"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="LTXXFTQNQFG"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="CBOAPLCBHXF"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="LVEHMDLIKQG"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="RTPOIUODGOX"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="UKKRCDKSYAH"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="DTPGGIVHBFK"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="JIBZRZFRKXB"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="EGGSIHOXDNH"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="ZRMOPJYALAC"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="JBGXCCXZDCJ"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="GOCIMSKOMTU"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="XNTOEHMPRQH"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="LEXEMADLSVX"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="HCPTKUPYRJA"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="VXJDTOUZLOG"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="YPYMOEUDQRZ"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="UAURMAVYUES"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="VWYXKSCSDPU"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="ZFGQSKMIEKT"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="BADGLVVQLDA"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="XHNUUVRFZYL"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="BJPBWKITMDG"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="CMIQBWPTTUV"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="RBVQFELCTIA"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="KRAUNURUJIE"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="VBGLDFKKWXR"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="QZYPXXEVAGL"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="NMVFABCPSGV"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="WFYHIRCOTMX"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="AKTYVHYDOJW"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="RFGNCBKQLRK"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="YFNVPAMXRTE"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="SJHWFSCMQAO"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="GJIFVGNITYB"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="AEZWTBMFAWB"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="IDKYHRLPCUC"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="RGIORAXUEGD"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="1.231597337353149179e-03" ID="ALJZRDQAXNZ"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="NQWXBUMHWAI"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="IVRKKPJZBDT"/>
+                    <Ellipse_Height Value="2.799999999999999711e-02" ID="YIXLWSHSNSL"/>
+                    <Ellipse_Width Value="5.599999999999999423e-02" ID="GXMRHBXMGEV"/>
+                    <HWRatio Value="5.000000000000000000e-01" ID="JDRGTDWWTEQ"/>
+                    <Scale Value="1.000000000000000000e+00" ID="FRISIGRTAZZ"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="QUYGOTOHWOL"/>
+                    <Theta Value="0.000000000000000000e+00" ID="SSLUCROBKXN"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="ZXIUYLFSQMO"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="QWRWMGZUFGT"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="OFDTNJYIYOU"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="HXJSUGUVLNB"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="QJMYSQMHGNF"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="NUMXCNZEMQZ"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="XCCQMWZOXCS"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="PZRJZGFKTLI"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>2</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>JLSXLXFRIS</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="4.000009999999999954e-01" ID="XVWFCFYMZDN"/>
+                <RefLength Value="6.999999999999999556e-01" ID="AJSNPMIZYTA"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="QXOQZUDQQXF"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>YSANNWTVNG</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="ZEIZGYIRGKO"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="FBRXYGECKLK"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="CUSLDGFQRVW"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="HZEYYCVHMTW"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="KVSSSWMDGZF"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="BUVTARWTGFV"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="AQYUMVJAJQU"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="VRKITGUYWNX"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="TXCPIHPTZQD"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="NALVIXEQMTK"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="FQUJFSYUIGY"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="YDEGAXTXOKC"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="YCGKOSYCIPG"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="ZBDBJNLECAO"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="AAYLYMAZYWU"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="ITCKLBKTVNN"/>
+                    <Number Value="8.000000000000000000e+00" ID="ISPXFWNWCGW"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="WILTFPOFVUE"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="REASZIMLNMJ"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="YLBABZGRMDC"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="ASOHSQUMNLP"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="NQDGRDFYSCG"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="KTNJWRIHFKH"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="RKVURIKGAHR"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="FSKGDONAWPW"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="SVHXWUIQZSV"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="ODVYZWLJDIQ"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="HJZAUZGWJUB"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="VEYOGJBZVNO"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="XAESITHPRXM"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="DBTYEGPOPUY"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="BRXIDQFFFHM"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="WLRGCAHLOWW"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="MPUORCFJMKU"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="BQERBNZEBYJ"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="CUAUZOQRUOD"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="ODCHBBYWVOW"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="AEEAVXKDXJC"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="OGMEHHDXZEW"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="GFLAUEQEADB"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="IGMIMMJFDLU"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="RHBJDWEVFNZ"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="NMTFSGZEZWY"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="FMNLZCAGXLT"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="QCESRLQIAIL"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="GUWOCNQUOJJ"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="URSTJGOWGYV"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="FRHZZRDMKLR"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="BCYGVFMIICJ"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="WZJOQZNVDJK"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="XDBVTEOIHRV"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="WPQSCMPYYSK"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="SFVXDINLWUG"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="PKUWPMPPHWY"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="EZXXIWAQEIX"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="FYRBIHFZBZC"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="WWCWUMRGMYQ"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="1.982433088306019206e-03" ID="TAFAQZVUAMQ"/>
+                    <Chord Value="1.163752231245406277e-01" ID="MMHHUQUGJDQ"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="QFYWZWCECNF"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="FGQAQMCPAAB"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="WJRSDEWTNKW"/>
+                    <HWRatio Value="2.000371431728833194e-01" ID="MEQSRTFEMSJ"/>
+                    <IdealCl Value="6.999999999152259900e-01" ID="TKMPBTYEUNZ"/>
+                    <Invert Value="0.000000000000000000e+00" ID="OJXXYOEEIFI"/>
+                    <Scale Value="1.000000000000000000e+00" ID="IWIKEXFOXMK"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="VWXGGWUTLRB"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="MYWRXBVPGQE"/>
+                    <Theta Value="0.000000000000000000e+00" ID="ASKADTIYZGR"/>
+                    <ThickChord Value="2.000371431728833194e-01" ID="NEZNCARUTAJ"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="XAEYDMLAAPM"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="GQWHFRZYYQQ"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="RNDNQVEIIZB"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="GBLEYZPDOTK"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="BAXOLZDQWAB"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="OQBCXRMNHRT"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="QZAUQECIHBJ"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="UMDMULLIWWP"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>18</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>EDJBBZGMSV</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="1.000000000000000000e+00" ID="RVFFDMLAHVG"/>
+                <RefLength Value="6.999999999999999556e-01" ID="BZMTHXPDPNQ"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="XJTTSWJHJAB"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>AMQZCXOGAB</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="XEBSPTEHHUU"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="LBHTKVSPGEL"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="KOFCXWVATSV"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="IJESODVCBCT"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="WJXLDGLLXWB"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="JXWNCMVLRZJ"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="ZRXWFHAGBJL"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="WFWVSTJIYUW"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="QNXTTWUZDLJ"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="YSXZGCTNJRV"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="MTFCEZNLXHP"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="KHKHCQHCEOL"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="ENIAXDDMXDY"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="XPTTZQQDWCO"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="TEASAGJKGRY"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="SBKRPQSVCAS"/>
+                    <Number Value="8.000000000000000000e+00" ID="YACYEWRHBGH"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="LDSWWJEFGFN"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="WIULOCAOSCC"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="KHNAQBDATTM"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="PHXSMKICQFG"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="INKEOFFQLZX"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="KTAQQMSDOIQ"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="VKHOIMMZHWV"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="ZGVDGCTWMSS"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="VQRJFCEISKZ"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="RNSKHXSRMTS"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="RFHCJWLZYXT"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="UZBYVGHDVMJ"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="NMNRXKVHAHT"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="RNKECHZHJZG"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="RRUIOYFXXHB"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="QDFQXGZANOT"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="IFCAIVYFNJA"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="TZIZAXDGGFB"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="ATJGRFXSHQR"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="UUBVMYQCPZJ"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="ETYMMJRPIUT"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="HBSWPCWXGLG"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="CNICRAJPAMY"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="GVBEJUJMVNC"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="GTQDCNLPVIF"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="MPUTAVXGTVI"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="TSFQADSREOC"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="HFXEUZHBNQC"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="VBCFPCLDIZB"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="JUQKQELLEXN"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="IVJMDDXZRIV"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="WUMNGFBUNCD"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="IXNJEWDQNXD"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="SMDDTIPQIFZ"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="NDKFFAUARBE"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="YQWPDVIZEJH"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="BCQXFBZGOID"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="UEPDRZRAJPZ"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="GUGTFBUQQNU"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="FROOTNTTXLP"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="1.813775732647776432e-04" ID="RNPRNUKPCEV"/>
+                    <Chord Value="9.099999999999999756e-02" ID="TIKFPHMUMGL"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="VXFAIPBXLIB"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="UJJVIDILAUP"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="ATVCZRZBBYU"/>
+                    <HWRatio Value="2.999999999999999889e-02" ID="PNUAEPXZTEB"/>
+                    <IdealCl Value="2.000000000000000111e-01" ID="UWSRKHHEIKO"/>
+                    <Invert Value="0.000000000000000000e+00" ID="TPJRKYZMFLU"/>
+                    <Scale Value="1.000000000000000000e+00" ID="LPVJRCFRFQG"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="YUKRHKTTAJI"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="EHYNEYWIECQ"/>
+                    <Theta Value="0.000000000000000000e+00" ID="TXPUVSXCRCW"/>
+                    <ThickChord Value="2.999999999999999889e-02" ID="YLERXZNDPSE"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="EQOPHUWRSWP"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="ZFWDDPWUDUO"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="UQLJNLYVWJU"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="GHMCXFFZMNQ"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="WRFDYVXXZCZ"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="WVFQOBVXOTC"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="GMOXECZHPYM"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="QZQJMYNRNLB"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>18</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+        </XSecSurf>
+        <Chord>
+          <PCurve>
+            <NumPts>10</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>PSJKVXPKES</ID>
+            <Name>PCurve</Name>
+            <Chord>
+              <ConvType Value="2.000000000000000000e+00" ID="ECXQJNTKMRD"/>
+              <CrvType Value="2.000000000000000000e+00" ID="ACPBHSZDXTC"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="SYOFTWGPLHO"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="MMBJKJZEYUK"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="FCFLQPJXRVU"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="LRGWUQJSIIY"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="ZCXJFGSIOFV"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="KYOSIWAKWAS"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="WPHRDMHPLCB"/>
+              <G1_7 Value="0.000000000000000000e+00" ID="DEPLOYEKGOW"/>
+              <G1_8 Value="0.000000000000000000e+00" ID="ROZBTPNGFJY"/>
+              <G1_9 Value="0.000000000000000000e+00" ID="AGNHTZWSCNI"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="BFWPSUSOELS"/>
+              <crd_0 Value="8.000000000000000167e-02" ID="USMBNTPKTFX"/>
+              <crd_1 Value="1.499999999999999944e-01" ID="USTXHMESYQP"/>
+              <crd_2 Value="2.000000000000000111e-01" ID="FMHTEWUPLEJ"/>
+              <crd_3 Value="2.000000000000000111e-01" ID="LAZKMFEFHTR"/>
+              <crd_4 Value="2.000000000000000111e-01" ID="CSNKQRPJVKI"/>
+              <crd_5 Value="2.000000000000000111e-01" ID="QZLSPLCRJLU"/>
+              <crd_6 Value="2.000000000000000111e-01" ID="MEPNKGNDWLC"/>
+              <crd_7 Value="2.000000000000000111e-01" ID="KFHEEEYPUPV"/>
+              <crd_8 Value="2.000000000000000111e-01" ID="JUIKJTEBLZU"/>
+              <crd_9 Value="1.300000000000000044e-01" ID="CEMRBRUSNFD"/>
+              <r_0 Value="2.000000000000000111e-01" ID="EPIPNBZKPLE"/>
+              <r_1 Value="3.333333333333333703e-01" ID="BVNSZKQSFZS"/>
+              <r_2 Value="4.666666666666666741e-01" ID="XRSWAKHJQXO"/>
+              <r_3 Value="5.999999999999999778e-01" ID="VNJGLKSZTEA"/>
+              <r_4 Value="7.166666666666666741e-01" ID="QBIGQRJITEL"/>
+              <r_5 Value="8.333333333333332593e-01" ID="GBJHWPZQGGS"/>
+              <r_6 Value="9.499999999999999556e-01" ID="LHZXSLAIJRX"/>
+              <r_7 Value="9.666666666666666741e-01" ID="ZDRLWZRQELN"/>
+              <r_8 Value="9.833333333333332815e-01" ID="TZNXGIZDBJI"/>
+              <r_9 Value="1.000000000000000000e+00" ID="QJACBBDWUYM"/>
+            </Chord>
+          </ParmContainer>
+        </Chord>
+        <Twist>
+          <PCurve>
+            <NumPts>7</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>EGNETPUSAG</ID>
+            <Name>PCurve</Name>
+            <Twist>
+              <ConvType Value="2.000000000000000000e+00" ID="TISWCGCHPQG"/>
+              <CrvType Value="2.000000000000000000e+00" ID="TYMRFHHOFYT"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="JSYWLVDRKKY"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="TQICBUQAFLP"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="FJHZHIZRCKX"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="VINDGODBQFS"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="TIJZJWIVDFO"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="AJNXOBCNYDI"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="EBKGYAECWYJ"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="OOBUDLSHOAZ"/>
+              <r_0 Value="2.000000000000000111e-01" ID="HIYMOOPMUVB"/>
+              <r_1 Value="3.344706911636046165e-01" ID="UHKMGBJVBVF"/>
+              <r_2 Value="4.689413823272091664e-01" ID="HGNHFSGBVNU"/>
+              <r_3 Value="6.034120734908137162e-01" ID="CLMEJSBTIMC"/>
+              <r_4 Value="7.356080489938757738e-01" ID="BOAIUCJYEGD"/>
+              <r_5 Value="8.678040244969379424e-01" ID="ABNVGAVXUVR"/>
+              <r_6 Value="1.000000000000000000e+00" ID="YVDQOTERKVB"/>
+              <tw_0 Value="3.116666666666666785e+01" ID="ADYWISYELHQ"/>
+              <tw_1 Value="2.342592592592592382e+01" ID="LNYFEDVUWCA"/>
+              <tw_2 Value="2.077777777777777857e+01" ID="NBRLZKAJVZN"/>
+              <tw_3 Value="1.874074074074074048e+01" ID="FLGKEYFIGMV"/>
+              <tw_4 Value="1.670370370370370594e+01" ID="MLBGADIJIBX"/>
+              <tw_5 Value="1.548148148148148096e+01" ID="WIDGPPFVVFW"/>
+              <tw_6 Value="1.425925925925925952e+01" ID="OKMIYRMUYQR"/>
+            </Twist>
+          </ParmContainer>
+        </Twist>
+        <Rake>
+          <PCurve>
+            <NumPts>2</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>PFTFNHHUBD</ID>
+            <Name>PCurve</Name>
+            <Rake>
+              <ConvType Value="2.000000000000000000e+00" ID="XPMSVQONLCH"/>
+              <CrvType Value="0.000000000000000000e+00" ID="QEKWQFBFWDY"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="XZHFORBMUMX"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="MFNNYANQFMS"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="YCTSFEYJJKD"/>
+              <r_0 Value="2.000000000000000111e-01" ID="WOJGHXFPOVB"/>
+              <r_1 Value="1.000000000000000000e+00" ID="JEEDYQIBATT"/>
+              <rak_0 Value="0.000000000000000000e+00" ID="SDLPXHXOZKD"/>
+              <rak_1 Value="0.000000000000000000e+00" ID="JLBYTIBWNYP"/>
+            </Rake>
+          </ParmContainer>
+        </Rake>
+        <Skew>
+          <PCurve>
+            <NumPts>2</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>RCAOLFKGMT</ID>
+            <Name>PCurve</Name>
+            <Skew>
+              <ConvType Value="2.000000000000000000e+00" ID="UBIRQREYFYC"/>
+              <CrvType Value="0.000000000000000000e+00" ID="NNQISQILQIW"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="AISYAPFSVAD"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="FTTVKZGTGLM"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="NPOMSIWOZMH"/>
+              <r_0 Value="2.000000000000000111e-01" ID="WCHPJMXFQRF"/>
+              <r_1 Value="1.000000000000000000e+00" ID="ZYFXNRNHLOK"/>
+              <skw_0 Value="0.000000000000000000e+00" ID="NIYIGQYIBDX"/>
+              <skw_1 Value="0.000000000000000000e+00" ID="WXKHVJPYHQY"/>
+            </Skew>
+          </ParmContainer>
+        </Skew>
+        <Sweep>
+          <PCurve>
+            <NumPts>2</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>FXXEUMIIDM</ID>
+            <Name>PCurve</Name>
+            <Sweep>
+              <ConvType Value="2.000000000000000000e+00" ID="IBVUVCWOBEZ"/>
+              <CrvType Value="0.000000000000000000e+00" ID="ZKSVHUNMSKY"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="PRBBDQLKOOL"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="LABHZTLIANC"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="HTIGMFFZTCY"/>
+              <r_0 Value="2.000000000000000111e-01" ID="PLGFFVJRYAL"/>
+              <r_1 Value="1.000000000000000000e+00" ID="SHOCHZUDQZE"/>
+              <sw_0 Value="0.000000000000000000e+00" ID="HMPMDFIOBWU"/>
+              <sw_1 Value="0.000000000000000000e+00" ID="FNKQESBKBUQ"/>
+            </Sweep>
+          </ParmContainer>
+        </Sweep>
+        <Thick>
+          <PCurve>
+            <NumPts>10</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>BXICEPSGFX</ID>
+            <Name>PCurve</Name>
+            <Thick>
+              <ConvType Value="2.000000000000000000e+00" ID="ROZLIXWLAXW"/>
+              <CrvType Value="2.000000000000000000e+00" ID="GNQJCZEQTSR"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="ZZQCNYIVMDY"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="WAGMPNAUMOW"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="AFOXOOWTJAB"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="ZXYIZVKFFRX"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="QOIDGVPETFI"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="GDKKYAGIVVF"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="TKVTTSIUVQZ"/>
+              <G1_7 Value="0.000000000000000000e+00" ID="TVFXFDBOAHS"/>
+              <G1_8 Value="0.000000000000000000e+00" ID="ZFIAPWVZUJS"/>
+              <G1_9 Value="0.000000000000000000e+00" ID="VUUHCMTTRRR"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="GLMRFSJLHNU"/>
+              <r_0 Value="2.000000000000000111e-01" ID="NDGTJGSAVLS"/>
+              <r_1 Value="2.666999999999999926e-01" ID="DVLARJUNBQY"/>
+              <r_2 Value="3.334000000000000297e-01" ID="JSXCUQYYQRH"/>
+              <r_3 Value="4.001000000000000112e-01" ID="FNBWXNPFQYP"/>
+              <r_4 Value="4.667333333333333334e-01" ID="BNFKFKMXMYS"/>
+              <r_5 Value="5.333666666666666556e-01" ID="EEGVHMHZRNR"/>
+              <r_6 Value="5.999999999999999778e-01" ID="QWGXCUIAIBP"/>
+              <r_7 Value="7.333333333333332815e-01" ID="BXIZOUXTLRG"/>
+              <r_8 Value="8.666666666666666963e-01" ID="EEENISCGVLM"/>
+              <r_9 Value="1.000000000000000000e+00" ID="BMRZTHFTAZN"/>
+              <toc_0 Value="5.000000000000000000e-01" ID="XBEDEVHMBJB"/>
+              <toc_1 Value="2.999999999999999889e-01" ID="CDXTVWEPOAR"/>
+              <toc_2 Value="2.250000000000000056e-01" ID="FVBFQXPQECF"/>
+              <toc_3 Value="2.000000000000000111e-01" ID="ZMPQGFZKPEW"/>
+              <toc_4 Value="1.250000000000000000e-01" ID="CIPAMSJMLWC"/>
+              <toc_5 Value="1.150000000000000050e-01" ID="MDHNOSDDETD"/>
+              <toc_6 Value="1.000000000000000056e-01" ID="QGKOFLSDSMR"/>
+              <toc_7 Value="7.499999999999999722e-02" ID="NCNYOAKYXKC"/>
+              <toc_8 Value="5.500000000000000028e-02" ID="JQJWJBURUKO"/>
+              <toc_9 Value="2.999999999999999889e-02" ID="RPJXQNGHNTY"/>
+            </Thick>
+          </ParmContainer>
+        </Thick>
+        <CLI>
+          <PCurve>
+            <NumPts>10</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>ZGNBURJIWX</ID>
+            <Name>PCurve</Name>
+            <CLI>
+              <ConvType Value="2.000000000000000000e+00" ID="WLEUXDKHHYI"/>
+              <CrvType Value="2.000000000000000000e+00" ID="JZNJNXOIRNP"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="HDIPYFCSCBM"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="LLQRMYWQTCG"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="FNRRYOCFHVN"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="UWPAHIAXJQI"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="SQCPYRHZLZM"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="CKJMHSSIGAP"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="KIJBROFGNDO"/>
+              <G1_7 Value="0.000000000000000000e+00" ID="TSZKJXFQCFN"/>
+              <G1_8 Value="0.000000000000000000e+00" ID="JGAEPUWIZFX"/>
+              <G1_9 Value="0.000000000000000000e+00" ID="PXCPLJKECIH"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="MEOBRLVAMNQ"/>
+              <cli_0 Value="0.000000000000000000e+00" ID="CPGEIYXQTJL"/>
+              <cli_1 Value="6.999999999999999556e-01" ID="DMIUQVQAXVK"/>
+              <cli_2 Value="6.999999999999999556e-01" ID="RHTCUOWKEYM"/>
+              <cli_3 Value="6.999999999999999556e-01" ID="COOGVIKRKCH"/>
+              <cli_4 Value="6.999999999999999556e-01" ID="NAWFKJMWYPM"/>
+              <cli_5 Value="6.999999999999999556e-01" ID="RRJEDLOXCSU"/>
+              <cli_6 Value="6.999999999999999556e-01" ID="POLWWCBQNKN"/>
+              <cli_7 Value="6.999999999999999556e-01" ID="GYXODMPVLHG"/>
+              <cli_8 Value="6.999999999999999556e-01" ID="UXTJVNETXFT"/>
+              <cli_9 Value="2.000000000000000111e-01" ID="TTIYCBNQZRD"/>
+              <r_0 Value="2.000000000000000111e-01" ID="HQOYQVAVXLW"/>
+              <r_1 Value="2.666999999999999926e-01" ID="GCMUTSLFCCT"/>
+              <r_2 Value="3.334000000000000297e-01" ID="TCGLPXCCPRE"/>
+              <r_3 Value="4.001000000000000112e-01" ID="JACGLROBLJJ"/>
+              <r_4 Value="4.667333333333333334e-01" ID="XNKQGXXYVUE"/>
+              <r_5 Value="5.333666666666666556e-01" ID="IUIGALQMSHW"/>
+              <r_6 Value="5.999999999999999778e-01" ID="YFLXPZAQTXM"/>
+              <r_7 Value="7.333333333333332815e-01" ID="GYBSTVTCVCC"/>
+              <r_8 Value="8.666666666666666963e-01" ID="VSKMGQINYWC"/>
+              <r_9 Value="1.000000000000000000e+00" ID="APZIKWMCUFT"/>
+            </CLI>
+          </ParmContainer>
+        </CLI>
+        <Axial>
+          <PCurve>
+            <NumPts>2</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>XXUQQUCCCJ</ID>
+            <Name>PCurve</Name>
+            <Axial>
+              <ConvType Value="2.000000000000000000e+00" ID="PGVZNZDCUXN"/>
+              <CrvType Value="0.000000000000000000e+00" ID="RSNMQVMQSAK"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="DUGTSFABPZW"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="KLDMCEKDGNX"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="OQYAQZSYWRQ"/>
+              <ax_0 Value="0.000000000000000000e+00" ID="KCVVVOTVPJL"/>
+              <ax_1 Value="0.000000000000000000e+00" ID="WSNFSHXGMYD"/>
+              <r_0 Value="2.000000000000000111e-01" ID="JNVEBZHXCQK"/>
+              <r_1 Value="1.000000000000000000e+00" ID="SAUATYCJPOJ"/>
+            </Axial>
+          </ParmContainer>
+        </Axial>
+        <Tangential>
+          <PCurve>
+            <NumPts>2</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>QXRJONKYLS</ID>
+            <Name>PCurve</Name>
+            <Tangential>
+              <ConvType Value="2.000000000000000000e+00" ID="RKJYUNATTCV"/>
+              <CrvType Value="0.000000000000000000e+00" ID="ZKMIQFRNJBS"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="IBHDJHCNYCX"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="FPWIZGWVWPJ"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="OSWGUHARPJC"/>
+              <r_0 Value="2.000000000000000111e-01" ID="FBFGZCKCGWS"/>
+              <r_1 Value="1.000000000000000000e+00" ID="EDFFJEUFJWN"/>
+              <tan_0 Value="0.000000000000000000e+00" ID="BGWIQOEQMKF"/>
+              <tan_1 Value="0.000000000000000000e+00" ID="LNILEVPQRQK"/>
+            </Tangential>
+          </ParmContainer>
+        </Tangential>
+      </PropellerGeom>
+    </Geom>
+    <Geom>
+      <ParmContainer>
+        <ID>XJBKGMUNCX</ID>
+        <Name>HingeGeom</Name>
+        <Attach>
+          <Eta_Attach_Location Value="0.000000000000000000e+00" ID="NKZCCROGPOK"/>
+          <L_01 Value="1.000000000000000000e+00" ID="ZXYZFERQEIU"/>
+          <L_Attach_Location Value="0.000000000000000000e+00" ID="ZAJQEUQNUDT"/>
+          <L_Attach_Location0Len Value="0.000000000000000000e+00" ID="TBHEDZNPCNR"/>
+          <M_Attach_Location Value="5.000000000000000000e-01" ID="QZCSPTRZSPP"/>
+          <N_Attach_Location Value="5.000000000000000000e-01" ID="EVXPGXRZYWU"/>
+          <R_01 Value="1.000000000000000000e+00" ID="KKJGAAJIPBL"/>
+          <R_Attach_Location Value="0.000000000000000000e+00" ID="CWULKEARONL"/>
+          <R_Attach_Location0N Value="0.000000000000000000e+00" ID="GPGOAQDJBTI"/>
+          <Rots_Attach_Flag Value="1.000000000000000000e+00" ID="SAXJPYXMFQJ"/>
+          <S_Attach_Location Value="5.000000000000000000e-01" ID="YNDFOCRTLVI"/>
+          <T_Attach_Location Value="5.000000000000000000e-01" ID="SZDALICXDVY"/>
+          <Trans_Attach_Flag Value="1.000000000000000000e+00" ID="GSNSWRAFMHX"/>
+          <U_01 Value="1.000000000000000000e+00" ID="JMDZKZEFYGM"/>
+          <U_Attach_Location Value="0.000000000000000000e+00" ID="FBLRMWQOPFG"/>
+          <U_Attach_Location0N Value="0.000000000000000000e+00" ID="TJPHLAORXXZ"/>
+          <V_Attach_Location Value="0.000000000000000000e+00" ID="NENMOXYUXUD"/>
+        </Attach>
+        <BBox>
+          <X_Len Value="0.000000000000000000e+00" ID="KESHJXWZUDB"/>
+          <X_Min Value="0.000000000000000000e+00" ID="XUCJRRXEDNH"/>
+          <Y_Len Value="0.000000000000000000e+00" ID="HDOODTSDJBO"/>
+          <Y_Min Value="0.000000000000000000e+00" ID="ASRFSHASVCB"/>
+          <Z_Len Value="0.000000000000000000e+00" ID="VIPCGVJSNDL"/>
+          <Z_Min Value="0.000000000000000000e+00" ID="UHRAZBARPLM"/>
+        </BBox>
+        <EndCap>
+          <CapUMaxLength Value="1.000000000000000000e+00" ID="YSNZWTUPNOQ"/>
+          <CapUMaxOffset Value="0.000000000000000000e+00" ID="YQYECEUGBQU"/>
+          <CapUMaxOption Value="0.000000000000000000e+00" ID="SYLTUVVJQPN"/>
+          <CapUMaxStrength Value="5.000000000000000000e-01" ID="UHKQRNFSVYT"/>
+          <CapUMaxSweepFlag Value="0.000000000000000000e+00" ID="CLVKAPBIRXC"/>
+          <CapUMinLength Value="1.000000000000000000e+00" ID="UNPSWZVJUTF"/>
+          <CapUMinOffset Value="0.000000000000000000e+00" ID="RKJVOMUPPHF"/>
+          <CapUMinOption Value="0.000000000000000000e+00" ID="GITPNKPXUWO"/>
+          <CapUMinStrength Value="5.000000000000000000e-01" ID="DWEVJQJMKLY"/>
+          <CapUMinSweepFlag Value="0.000000000000000000e+00" ID="VEORMSFZMVU"/>
+          <CapUMinTess Value="3.000000000000000000e+00" ID="IONNNMKIHHA"/>
+        </EndCap>
+        <Hinge>
+          <JointRotMax Value="3.600000000000000000e+02" ID="JOIENVUQNTQ"/>
+          <JointRotMaxFlag Value="0.000000000000000000e+00" ID="ANSFTDBWPWS"/>
+          <JointRotMin Value="-3.600000000000000000e+02" ID="YTMAILSJPDL"/>
+          <JointRotMinFlag Value="0.000000000000000000e+00" ID="WNHWZJFSRZQ"/>
+          <JointRotate Value="0.000000000000000000e+00" ID="JYYRBQOQSMM"/>
+          <JointRotateFlag Value="1.000000000000000000e+00" ID="URVBJAKIDKP"/>
+          <JointTransMax Value="1.000000000000000000e+03" ID="VTLIHVNVQHC"/>
+          <JointTransMaxFlag Value="0.000000000000000000e+00" ID="SYUQOKYYFGV"/>
+          <JointTransMin Value="-1.000000000000000000e+03" ID="CSBRFUZCSYF"/>
+          <JointTransMinFlag Value="0.000000000000000000e+00" ID="SBMQQHQHVUA"/>
+          <JointTranslate Value="0.000000000000000000e+00" ID="BHCTYVUGJUM"/>
+          <JointTranslateFlag Value="0.000000000000000000e+00" ID="CFMGJZANKTO"/>
+          <OrientRotFlag Value="0.000000000000000000e+00" ID="VPLHTTZLZJJ"/>
+          <PrimOffAbsRelFlag Value="1.000000000000000000e+00" ID="TGCKELUYYMU"/>
+          <PrimType Value="0.000000000000000000e+00" ID="LHQVWGYLRPW"/>
+          <PrimULoc Value="0.000000000000000000e+00" ID="DBKFMWFXYEC"/>
+          <PrimVecAbsRelFlag Value="1.000000000000000000e+00" ID="OGDZOMSCFYO"/>
+          <PrimWLoc Value="0.000000000000000000e+00" ID="WVALDXXIXTK"/>
+          <PrimXOff Value="0.000000000000000000e+00" ID="LHYUITZMVHZ"/>
+          <PrimXOffRel Value="0.000000000000000000e+00" ID="GUIRBBMTYMY"/>
+          <PrimXVec Value="0.000000000000000000e+00" ID="NLBDHIQMUDK"/>
+          <PrimXVecRel Value="0.000000000000000000e+00" ID="UHZFBHMPRLK"/>
+          <PrimYOff Value="0.000000000000000000e+00" ID="UHNOYKKBGMQ"/>
+          <PrimYOffRel Value="0.000000000000000000e+00" ID="LDLYZHCXRID"/>
+          <PrimYVec Value="1.000000000000000000e+00" ID="NOHZYYYFZID"/>
+          <PrimYVecRel Value="1.000000000000000000e+00" ID="GLPUDGONFKO"/>
+          <PrimZOff Value="0.000000000000000000e+00" ID="OORNRVSANWQ"/>
+          <PrimZOffRel Value="0.000000000000000000e+00" ID="LCWPKCBUSZN"/>
+          <PrimZVec Value="0.000000000000000000e+00" ID="MQUPJHOXFZV"/>
+          <PrimZVecRel Value="0.000000000000000000e+00" ID="YKFBMPYGIGZ"/>
+          <PrimaryDir Value="1.000000000000000000e+00" ID="NWXIOFLXVFW"/>
+          <SecVecAbsRelFlag Value="1.000000000000000000e+00" ID="ULFBYKOWCYA"/>
+          <SecondaryDir Value="0.000000000000000000e+00" ID="QTQLYWEAHHG"/>
+          <SecondaryVecDir Value="1.000000000000000000e+00" ID="GCXAWWJOEIF"/>
+        </Hinge>
+        <Mass_Props>
+          <CGx Value="0.000000000000000000e+00" ID="VPIAJLBEQEN"/>
+          <CGy Value="0.000000000000000000e+00" ID="KNJYTHNLZQV"/>
+          <CGz Value="0.000000000000000000e+00" ID="NUVCTGQUACK"/>
+          <Density Value="1.000000000000000000e+00" ID="IYCCOCHDGYO"/>
+          <Ixx Value="0.000000000000000000e+00" ID="EKDFHPODMPU"/>
+          <Ixy Value="0.000000000000000000e+00" ID="ILCJYEZJOGF"/>
+          <Ixz Value="0.000000000000000000e+00" ID="GCAZYNBMLCP"/>
+          <Iyy Value="0.000000000000000000e+00" ID="VYJXCJPLIQH"/>
+          <Iyz Value="0.000000000000000000e+00" ID="ORNXWDNQXVU"/>
+          <Izz Value="0.000000000000000000e+00" ID="SYKEXEYAXFF"/>
+          <Mass_Area Value="1.000000000000000000e+00" ID="DREHBQDJBMB"/>
+          <Mass_Prior Value="0.000000000000000000e+00" ID="WTQKMTYNOEZ"/>
+          <PointMass Value="0.000000000000000000e+00" ID="ALYILMDKXEB"/>
+          <Shell_Flag Value="0.000000000000000000e+00" ID="ZQHABUPDISC"/>
+        </Mass_Props>
+        <Negative_Volume_Props>
+          <Negative_Volume_Flag Value="0.000000000000000000e+00" ID="YYBCFJDHIXX"/>
+        </Negative_Volume_Props>
+        <ParasiteDragProps>
+          <ExpandedList Value="0.000000000000000000e+00" ID="DCSTOOPCJSO"/>
+          <FFBodyEqnType Value="3.000000000000000000e+00" ID="OMWIPANRWIT"/>
+          <FFUser Value="1.000000000000000000e+00" ID="IJQORDSFERP"/>
+          <FFWingEqnType Value="3.000000000000000000e+00" ID="LLLWFVPJWXC"/>
+          <IncorporatedGen Value="0.000000000000000000e+00" ID="LTCHLTMFWSS"/>
+          <PercLam Value="0.000000000000000000e+00" ID="MFVERXYJIJD"/>
+          <Q Value="1.000000000000000000e+00" ID="WKMPCHHTPXB"/>
+          <Roughness Value="0.000000000000000000e+00" ID="LMPHYACOHJT"/>
+          <TawTwRatio Value="1.000000000000000000e+00" ID="JMETWJNYYKQ"/>
+          <TeTwRatio Value="1.000000000000000000e+00" ID="FLCEQOPHENJ"/>
+        </ParasiteDragProps>
+        <Shape>
+          <Tess_U Value="8.000000000000000000e+00" ID="QIPHREGCVXB"/>
+          <Tess_W Value="9.000000000000000000e+00" ID="GNWIOCBZKAT"/>
+          <Wake Value="0.000000000000000000e+00" ID="FZQCKJVHJAO"/>
+        </Shape>
+        <Sym>
+          <Sym_Ancestor Value="2.000000000000000000e+00" ID="ZXEJXSDQYNS"/>
+          <Sym_Ancestor_Origin_Flag Value="0.000000000000000000e+00" ID="WSTMEXUVIJB"/>
+          <Sym_Axial_Flag Value="0.000000000000000000e+00" ID="KQSQYJGOZKA"/>
+          <Sym_Planar_Flag Value="0.000000000000000000e+00" ID="MWNLBBZXUEZ"/>
+          <Sym_Rot_N Value="2.000000000000000000e+00" ID="BEMGXHFKLGC"/>
+        </Sym>
+        <WakeSettings>
+          <WakeAngle Value="0.000000000000000000e+00" ID="MHZAUEGAJDF"/>
+          <WakeScale Value="2.000000000000000000e+00" ID="BASPLJZTISP"/>
+        </WakeSettings>
+        <XForm>
+          <Abs_Or_Relitive_flag Value="1.000000000000000000e+00" ID="LKEGNBOPBRH"/>
+          <Last_Scale Value="1.000000000000000000e+00" ID="RJHZBHZRMEV"/>
+          <Origin Value="0.000000000000000000e+00" ID="NBGTMWHHPPB"/>
+          <Scale Value="1.000000000000000000e+00" ID="PVJNSQPVCLZ"/>
+          <X_Location Value="9.664356367157778127e-01" ID="BDSSYMOIXYE"/>
+          <X_Rel_Location Value="-7.000000000000000666e-02" ID="TSNWVWGJYBJ"/>
+          <X_Rel_Rotation Value="0.000000000000000000e+00" ID="UXRUSJRVRWE"/>
+          <X_Rotation Value="0.000000000000000000e+00" ID="KSFPJJWYLBG"/>
+          <Y_Location Value="1.602999999999999980e+00" ID="CKRBFMDWNXL"/>
+          <Y_Rel_Location Value="0.000000000000000000e+00" ID="UOWFTZFOOTS"/>
+          <Y_Rel_Rotation Value="0.000000000000000000e+00" ID="SEEUGRXNHEX"/>
+          <Y_Rotation Value="0.000000000000000000e+00" ID="QOBXRXSQIDF"/>
+          <Z_Location Value="4.737704918032786816e-01" ID="IWVPUGPSSLE"/>
+          <Z_Rel_Location Value="1.000000000000000056e-01" ID="PUAJIZPJQWR"/>
+          <Z_Rel_Rotation Value="0.000000000000000000e+00" ID="WKKJKCGGURP"/>
+          <Z_Rotation Value="0.000000000000000000e+00" ID="BNTLLQMOPKL"/>
+        </XForm>
+      </ParmContainer>
+      <GeomBase>
+        <TypeName>Hinge</TypeName>
+        <TypeID>12</TypeID>
+        <TypeFixed>0</TypeFixed>
+        <ParentID>LIYGGQUBGZ</ParentID>
+        <Child_List>
+          <Child>
+            <ID>KXJEXEPMQX</ID>
+          </Child>
+        </Child_List>
+      </GeomBase>
+      <Material>
+        <Name>Default</Name>
+      </Material>
+      <Wire_Color>
+        <ParmContainer>
+          <ID>XZHURNBJZA</ID>
+          <Name>Default</Name>
+          <Color_Parm>
+            <Alpha Value="2.550000000000000000e+02" ID="NDBBYHJPUAM"/>
+            <Blue Value="2.550000000000000000e+02" ID="QWSEFCJMJCJ"/>
+            <Green Value="0.000000000000000000e+00" ID="TGFQMQHURLT"/>
+            <Red Value="0.000000000000000000e+00" ID="THNQKHGUYDW"/>
+          </Color_Parm>
+        </ParmContainer>
+      </Wire_Color>
+      <Textures>
+        <Num_of_Tex>0</Num_of_Tex>
+      </Textures>
+      <Geom>
+        <Set_List>1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, </Set_List>
+        <SubSurfaces/>
+        <FeaStructures/>
+      </Geom>
+    </Geom>
+    <Geom>
+      <ParmContainer>
+        <ID>KXJEXEPMQX</ID>
+        <Name>CruiseProp</Name>
+        <Attach>
+          <Eta_Attach_Location Value="0.000000000000000000e+00" ID="PKQFOQEWYRQ"/>
+          <L_01 Value="1.000000000000000000e+00" ID="HMVJEJDSMUL"/>
+          <L_Attach_Location Value="0.000000000000000000e+00" ID="UAOVWGDFSEJ"/>
+          <L_Attach_Location0Len Value="0.000000000000000000e+00" ID="DCEBDUNXIKH"/>
+          <M_Attach_Location Value="-nan(ind)" ID="WDEFCIJMXBR"/>
+          <N_Attach_Location Value="5.000000000000000000e-01" ID="ZDCOIYWDJFE"/>
+          <R_01 Value="1.000000000000000000e+00" ID="DIHLXIUGEGP"/>
+          <R_Attach_Location Value="0.000000000000000000e+00" ID="MWYKVOOPCSX"/>
+          <R_Attach_Location0N Value="0.000000000000000000e+00" ID="BLXUUAHPNOL"/>
+          <Rots_Attach_Flag Value="1.000000000000000000e+00" ID="OTTFWTEFGXP"/>
+          <S_Attach_Location Value="3.125000000000000000e-02" ID="IEIZZTUAXIT"/>
+          <T_Attach_Location Value="5.000000000000000000e-01" ID="LGUIQVJWOXW"/>
+          <Trans_Attach_Flag Value="1.000000000000000000e+00" ID="GEGIWDYLTJD"/>
+          <U_01 Value="1.000000000000000000e+00" ID="LQWYJOGGHJS"/>
+          <U_Attach_Location Value="0.000000000000000000e+00" ID="HHMWMVXDPVA"/>
+          <U_Attach_Location0N Value="0.000000000000000000e+00" ID="EGZRTWBAHXN"/>
+          <V_Attach_Location Value="9.843750000000000000e-01" ID="USWPSCXALTD"/>
+        </Attach>
+        <BBox>
+          <X_Len Value="5.161994505472933259e-02" ID="RWVFARXQLFK"/>
+          <X_Min Value="7.370925252153396334e-01" ID="AFIWXFGYRSL"/>
+          <Y_Len Value="1.293576370307742973e+00" ID="LGAZWFUBPTB"/>
+          <Y_Min Value="1.010583572202006675e+00" ID="YSVDWLKUKQS"/>
+          <Z_Len Value="1.351902167440927727e+00" ID="QCUYBCRDIRF"/>
+          <Z_Min Value="-1.990404555078302273e-01" ID="KDLSQDCPCDG"/>
+        </BBox>
+        <Design>
+          <AF Value="1.038843911064995638e+02" ID="SEVNTPRZZVO"/>
+          <AFLimit Value="2.000000000000000111e-01" ID="GFUQJBGAYGF"/>
+          <AxFoldAx Value="0.000000000000000000e+00" ID="HVTVLIEAXUU"/>
+          <AzFoldDir Value="0.000000000000000000e+00" ID="ATBGSIUQDKA"/>
+          <BalanceX1 Value="0.000000000000000000e+00" ID="GCQVEAZYTFW"/>
+          <BalanceX2 Value="0.000000000000000000e+00" ID="LPCQMXLCXFM"/>
+          <Beta34 Value="2.000000000000000000e+01" ID="KEZRHLQWMRA"/>
+          <BladeAz_2 Value="7.200000000000000000e+01" ID="NVQUEXVRURL"/>
+          <BladeAz_3 Value="1.440000000000000000e+02" ID="FRWNOWJVOAW"/>
+          <BladeAz_4 Value="2.160000000000000000e+02" ID="ITMRJOIPTAW"/>
+          <BladeAz_5 Value="2.880000000000000000e+02" ID="EVRZORGWRSK"/>
+          <BladeAzimuthDeltaFlag Value="0.000000000000000000e+00" ID="ZYYRHFJGJDV"/>
+          <BladeAzimuthMode Value="0.000000000000000000e+00" ID="OLTCJZOGCFO"/>
+          <CLi Value="5.387977274373372261e-01" ID="JZJYLOKIMDV"/>
+          <Chord Value="1.324074074074073903e-01" ID="MPOUCGQFMIR"/>
+          <ConstructXoC Value="5.000000000000000000e-01" ID="KAAJMDPZRDT"/>
+          <CylindricalSectionsFlag Value="0.000000000000000000e+00" ID="HKDLRDLMBPA"/>
+          <DeltaAz_2 Value="0.000000000000000000e+00" ID="FQKODRVPCQT"/>
+          <DeltaAz_3 Value="0.000000000000000000e+00" ID="TFFYJQSUZEP"/>
+          <DeltaAz_4 Value="0.000000000000000000e+00" ID="LPXAQNPHANR"/>
+          <DeltaAz_5 Value="0.000000000000000000e+00" ID="LJNLIHJYAME"/>
+          <Diameter Value="1.399999999999999911e+00" ID="BLZVSEGGJUX"/>
+          <ElFoldDir Value="0.000000000000000000e+00" ID="BIXPSAXUBGD"/>
+          <Feather Value="7.968749999999996447e+00" ID="YVAHTHTDCJK"/>
+          <FeatherAxisXoC Value="5.000000000000000000e-01" ID="JEDOTIFGCTD"/>
+          <FeatherOffsetXoC Value="0.000000000000000000e+00" ID="JNQYSAOVSTV"/>
+          <FoldAngle Value="0.000000000000000000e+00" ID="QKPYPULMCXE"/>
+          <FoldAngle_1 Value="0.000000000000000000e+00" ID="MEEKQGYQMXW"/>
+          <FoldAngle_2 Value="0.000000000000000000e+00" ID="EHVVVTPAJHK"/>
+          <FoldAngle_3 Value="0.000000000000000000e+00" ID="RCIQQSHHJNC"/>
+          <FoldAngle_4 Value="0.000000000000000000e+00" ID="KHETMWXVCGW"/>
+          <InCluster Value="1.000000000000000000e+00" ID="AVGAJUOGNVB"/>
+          <IndividualBladeFoldFlag Value="0.000000000000000000e+00" ID="LASTPTDWTGD"/>
+          <LECluster Value="2.500000000000000000e-01" ID="VQGFQFTSWAZ"/>
+          <NumBlade Value="5.000000000000000000e+00" ID="RIDRGNMLPEG"/>
+          <OffFoldAx Value="0.000000000000000000e+00" ID="UAJNCPGTANP"/>
+          <OutCluster Value="1.000000000000000000e+00" ID="UCAPNKZCGVA"/>
+          <PChord Value="1.331851168032045785e-01" ID="BHYDQHWQBDY"/>
+          <PSolidity Value="2.119706968550145731e-01" ID="VLGXLIMXFIZ"/>
+          <Precone Value="0.000000000000000000e+00" ID="BVNUYORGEXO"/>
+          <PropMode Value="0.000000000000000000e+00" ID="MHNOGFIHBWM"/>
+          <RFoldAx Value="2.000000000000000111e-01" ID="VGSVSCHNJFY"/>
+          <ReverseFlag Value="0.000000000000000000e+00" ID="MXVVDNQKMII"/>
+          <Rotate Value="0.000000000000000000e+00" ID="AOFNUZKINZL"/>
+          <Solidity Value="2.107329339087132547e-01" ID="ZKEPSKFNJZS"/>
+          <TChord Value="1.347756869772998856e-01" ID="WNIIAMVWXNY"/>
+          <TECluster Value="2.500000000000000000e-01" ID="BUAWLMAYHSR"/>
+          <TSolidity Value="2.145021679104326395e-01" ID="AVTKNQGMYWW"/>
+          <UseBeta34Flag Value="1.000000000000000000e+00" ID="PZQRDDMJWFO"/>
+        </Design>
+        <EndCap>
+          <CapUMaxLength Value="1.000000000000000000e+00" ID="TNEOAYZDSCB"/>
+          <CapUMaxOffset Value="0.000000000000000000e+00" ID="KNQNYJVPJZW"/>
+          <CapUMaxOption Value="2.000000000000000000e+00" ID="DYVEQBYTSEX"/>
+          <CapUMaxStrength Value="1.000000000000000000e+00" ID="CZXNSFTXBUV"/>
+          <CapUMaxSweepFlag Value="0.000000000000000000e+00" ID="HJFQKSIDMSR"/>
+          <CapUMinLength Value="1.000000000000000000e+00" ID="COTXXZNRZMC"/>
+          <CapUMinOffset Value="0.000000000000000000e+00" ID="XJQXRPAUELD"/>
+          <CapUMinOption Value="1.000000000000000000e+00" ID="DWJPYPICVFJ"/>
+          <CapUMinStrength Value="5.000000000000000000e-01" ID="GPYGAYGWHHJ"/>
+          <CapUMinSweepFlag Value="0.000000000000000000e+00" ID="UOLSRSGNYBG"/>
+          <CapUMinTess Value="3.000000000000000000e+00" ID="PSGJTIBSRXO"/>
+        </EndCap>
+        <Index>
+          <ActiveBlade Value="1.000000000000000000e+00" ID="DLDPQIATVCS"/>
+          <ActiveXSec Value="0.000000000000000000e+00" ID="XMIKQKJGIOP"/>
+        </Index>
+        <Mass_Props>
+          <CGx Value="0.000000000000000000e+00" ID="QHHRVSPZHIK"/>
+          <CGy Value="0.000000000000000000e+00" ID="AABAUKKKBFK"/>
+          <CGz Value="0.000000000000000000e+00" ID="LGLYDKZPMQD"/>
+          <Density Value="1.000000000000000000e+00" ID="QCBEBGRMFKA"/>
+          <Ixx Value="0.000000000000000000e+00" ID="YHOKILCVORH"/>
+          <Ixy Value="0.000000000000000000e+00" ID="DUGEFYURTXV"/>
+          <Ixz Value="0.000000000000000000e+00" ID="ZHONPFFPGFO"/>
+          <Iyy Value="0.000000000000000000e+00" ID="YFGGFHKLTLJ"/>
+          <Iyz Value="0.000000000000000000e+00" ID="POUODQKKAAT"/>
+          <Izz Value="0.000000000000000000e+00" ID="QPNQDWQBZSS"/>
+          <Mass_Area Value="1.000000000000000000e+00" ID="GDAZRXLKNUI"/>
+          <Mass_Prior Value="0.000000000000000000e+00" ID="QPUJAQDOVOC"/>
+          <PointMass Value="0.000000000000000000e+00" ID="FOWOKGOMJNG"/>
+          <Shell_Flag Value="0.000000000000000000e+00" ID="IJCTHEEZSJO"/>
+        </Mass_Props>
+        <Negative_Volume_Props>
+          <Negative_Volume_Flag Value="1.000000000000000000e+00" ID="PEPRYLMVLRU"/>
+        </Negative_Volume_Props>
+        <ParasiteDragProps>
+          <ExpandedList Value="0.000000000000000000e+00" ID="RACTRLQTDWY"/>
+          <FFBodyEqnType Value="3.000000000000000000e+00" ID="WMSZLKUKSLC"/>
+          <FFUser Value="1.000000000000000000e+00" ID="DLTCASIIIXX"/>
+          <FFWingEqnType Value="3.000000000000000000e+00" ID="QGRGBIKVHWI"/>
+          <IncorporatedGen Value="0.000000000000000000e+00" ID="NDYLJPWRKTP"/>
+          <PercLam Value="0.000000000000000000e+00" ID="XETXRFVQMVH"/>
+          <Q Value="1.000000000000000000e+00" ID="XNKTJCFMNZD"/>
+          <Roughness Value="0.000000000000000000e+00" ID="WCJXYCNLLYZ"/>
+          <TawTwRatio Value="1.000000000000000000e+00" ID="ZQWRWIWGQEC"/>
+          <TeTwRatio Value="1.000000000000000000e+00" ID="BEOTAEZLWYL"/>
+        </ParasiteDragProps>
+        <PropGeom>
+          <MaxGrowth Value="1.963769402454648594e+00" ID="DLOULNBRXIR"/>
+          <SmallPanelW Value="1.695692545796784016e-03" ID="XQOZGOICGZX"/>
+        </PropGeom>
+        <Shape>
+          <Tess_U Value="1.200000000000000000e+01" ID="HHWMHLYVXHD"/>
+          <Tess_W Value="1.700000000000000000e+01" ID="PCDFTSIJKIL"/>
+          <Wake Value="0.000000000000000000e+00" ID="DAFGQYEVZLJ"/>
+        </Shape>
+        <Sym>
+          <Sym_Ancestor Value="4.000000000000000000e+00" ID="BLELMHNNELW"/>
+          <Sym_Ancestor_Origin_Flag Value="0.000000000000000000e+00" ID="PDHLOXKDHAA"/>
+          <Sym_Axial_Flag Value="0.000000000000000000e+00" ID="HNGUZMNKMHG"/>
+          <Sym_Planar_Flag Value="0.000000000000000000e+00" ID="ZZKMBIMXDAD"/>
+          <Sym_Rot_N Value="2.000000000000000000e+00" ID="AEGMWTOJPNN"/>
+        </Sym>
+        <WakeSettings>
+          <WakeAngle Value="0.000000000000000000e+00" ID="VLUAAOTKDRA"/>
+          <WakeScale Value="2.000000000000000000e+00" ID="OKSRDVXLQRD"/>
+        </WakeSettings>
+        <XForm>
+          <Abs_Or_Relitive_flag Value="1.000000000000000000e+00" ID="ZJAOUBWAJCU"/>
+          <Last_Scale Value="1.000000000000000000e+00" ID="ZHWTZDISLOD"/>
+          <Origin Value="0.000000000000000000e+00" ID="SMAEISIEGEH"/>
+          <Scale Value="1.000000000000000000e+00" ID="BNSBCYKBAVJ"/>
+          <X_Location Value="7.664356367157778571e-01" ID="FUIURZRIQUN"/>
+          <X_Rel_Location Value="-2.000000000000000111e-01" ID="BPAOXQPVOJE"/>
+          <X_Rel_Rotation Value="0.000000000000000000e+00" ID="NZTNTKRUDJR"/>
+          <X_Rotation Value="0.000000000000000000e+00" ID="PZHZFIUFULC"/>
+          <Y_Location Value="1.602999999999999980e+00" ID="FBHKQUOPVWW"/>
+          <Y_Rel_Location Value="0.000000000000000000e+00" ID="JBKUUJEZKTS"/>
+          <Y_Rel_Rotation Value="0.000000000000000000e+00" ID="JNHHDMCCKKW"/>
+          <Y_Rotation Value="0.000000000000000000e+00" ID="VGWZTRZYCQU"/>
+          <Z_Location Value="4.737704918032786816e-01" ID="YNLJARYTGYE"/>
+          <Z_Rel_Location Value="0.000000000000000000e+00" ID="KGTTKVENENM"/>
+          <Z_Rel_Rotation Value="0.000000000000000000e+00" ID="GMAHXVMFFJT"/>
+          <Z_Rotation Value="0.000000000000000000e+00" ID="HMZPHIBAIRX"/>
+        </XForm>
+      </ParmContainer>
+      <GeomBase>
+        <TypeName>Propeller</TypeName>
+        <TypeID>11</TypeID>
+        <TypeFixed>0</TypeFixed>
+        <ParentID>XJBKGMUNCX</ParentID>
+        <Child_List/>
+      </GeomBase>
+      <Material>
+        <Name>Default</Name>
+      </Material>
+      <Wire_Color>
+        <ParmContainer>
+          <ID>ZMKSGNUCID</ID>
+          <Name>Default</Name>
+          <Color_Parm>
+            <Alpha Value="2.550000000000000000e+02" ID="QRCRXATYEPE"/>
+            <Blue Value="2.550000000000000000e+02" ID="BEQYHNRWEXZ"/>
+            <Green Value="0.000000000000000000e+00" ID="VUMMDKLTPGT"/>
+            <Red Value="0.000000000000000000e+00" ID="FFHTDPXCADF"/>
+          </Color_Parm>
+        </ParmContainer>
+      </Wire_Color>
+      <Textures>
+        <Num_of_Tex>0</Num_of_Tex>
+      </Textures>
+      <Geom>
+        <Set_List>1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, </Set_List>
+        <SubSurfaces/>
+        <FeaStructures/>
+      </Geom>
+      <PropellerGeom>
+        <ParmContainer>
+          <ID>AXQLWVLLEY</ID>
+          <Name>Default</Name>
+        </ParmContainer>
+        <XSecSurf>
+          <XSec>
+            <ParmContainer>
+              <ID>CVBFBIZAJL</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="2.000000000000000111e-01" ID="SXZBYEJQJEO"/>
+                <RefLength Value="6.999999999999999556e-01" ID="OWUDKVOLCVJ"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="DYYLGUGJQHA"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>CHDLTZSPMH</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="HAFNBZHOCPT"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="ZWDHZFREUFX"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="LMZQTZBYEVN"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="POIHWFKQDCE"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="WNNLCTBDONB"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="JXAWLASDMSO"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="ULVDZPFQRFI"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="VAYBTORXTCR"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="ASWRAFLNZFJ"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="AGUHTRJLSSW"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="WFBULATMIDW"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="BLHMZTAPBCE"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="DRFFMDLYNRZ"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="RFBVFPHLAYK"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="ODODUWPJYWS"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="KQZNQJTUVVA"/>
+                    <Number Value="8.000000000000000000e+00" ID="BCUGBHYNHHI"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="GOATZRIMPIY"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="BOCDWRIEASF"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="KRRAUAMVGEX"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="AORMFRMNICY"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="KGVNNYSAVCN"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="HEUXGYRFKRE"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="DATBTGXFQUB"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="JVKZTVPCMFL"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="GLHEKYTIFNY"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="RLQYQQJQMSZ"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="WRMCOJDPVHW"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="BZVTAWJTVOG"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="EGKUJOIFLLU"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="WAOSDSLKGLC"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="OWDZJQLMKHI"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="OTBEMYYWMVR"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="TFCGRKEXLRU"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="YNZJWVVSOKZ"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="IZQUKFTJPCY"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="CYBSOFBQYOE"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="FJNBFFQIZJL"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="CEBORGWCLHT"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="LURSRHIELLG"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="XFFNGRKVDYG"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="GQHGHNIYHMD"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="CGVOMVVSXKP"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="IQOKLSLFKND"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="IHATAZVYXPO"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="DPKWJLEMPQK"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="SYMGVVLJOMX"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="SHAPPPYSEZJ"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="NXGBYSSZFYN"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="CAIBXXYZVFQ"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="GYZMTIMDWLF"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="VSKGNMTVYHB"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="ZPNTQQPLWZK"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="GSGQZOETLXP"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="INKPWCPTBBX"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="TZXTATCQVEC"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="BALUJVQUDVK"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="2.980449878548511642e-04" ID="VMWEBHJOIZZ"/>
+                    <CamberLoc Value="1.499999999999999944e-01" ID="IDVWOQLPRFD"/>
+                    <Chord Value="5.599999999999999423e-02" ID="SNMMRMPYDPF"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="MVICNPQYUGU"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="BUIJXFTRVLO"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="CYIRGVYAMEN"/>
+                    <HWRatio Value="1.400000000000000133e-01" ID="IYKGJESBZQE"/>
+                    <IdealCl Value="0.000000000000000000e+00" ID="NDVTJCOQAZE"/>
+                    <Invert Value="0.000000000000000000e+00" ID="DACLEORZYDV"/>
+                    <Scale Value="1.000000000000000000e+00" ID="UOIKBMDILMX"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="DPBHBPGASDC"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="NZYDDVAHAXD"/>
+                    <Theta Value="0.000000000000000000e+00" ID="QNOAHFGJYIC"/>
+                    <ThickChord Value="1.400000000000000133e-01" ID="EGGVNVQSPJN"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="DSMCOPEBNUQ"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="WNJIXHJZIOC"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="KBOLBLQIPXM"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="TKBBMWOBTSV"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="OWKUEZBCRZA"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="TULHGPJJZZH"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="CEUWKOJFNJR"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="YFRIMOZEIAT"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>16</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>GMXUWUIEPX</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="4.000000000000000222e-01" ID="MXNUXKCKQKN"/>
+                <RefLength Value="6.999999999999999556e-01" ID="QGUZOZPCMEX"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="KTTFIJQAXPB"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>RKHAMMPDXT</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="IBNBGNDGWNT"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="RURMSJUFVXL"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="EOZDBFAINPU"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="TABUFLJATUI"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="PTZMHYKWPHF"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="FPLETFSOJAZ"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="QOKWQHFGIVK"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="AEYXCPPIFDE"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="TVJTOEAYUPQ"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="UPRNRZQKCNV"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="OVHZDCUBHQY"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="YGCXFXUYTDH"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="JVTKWPSQHAD"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="OXMBINZWVKS"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="OTQFWOJBAZW"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="YPKEVZQNAEZ"/>
+                    <Number Value="8.000000000000000000e+00" ID="XQXZFRMRBKP"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="VEGPKJLYSNC"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="KIOSSFONECX"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="REIVLPNPYHC"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="NELWMISHOWA"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="THRRJLAJSGN"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="JPYFJKEBINW"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="EAOXAJWPETF"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="SYXORYYFPBI"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="FVZNXCEEXBK"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="DXSKXOCDBNO"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="QKKVPBHKWCY"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="IZVCKMYXBDY"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="DWKXTMXJJJP"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="ZPDJFVMHNZK"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="JOOSOTWRWTE"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="SEOZERQLJFD"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="JTLSLQYHGSQ"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="LZNCWEFMCWV"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="ETLVPGCQUNI"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="PXZKLZMAWDN"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="OMRAVAMUTPE"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="EPERUZRIHBQ"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="RTDRKORVEOT"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="XHZLDYSETDA"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="SOZIOAPGJYW"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="TDDMYVOJVVS"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="PQWCOEMWSXM"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="ZGVKAZIONLG"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="WONCYCTPASY"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="LGRJILGKQRB"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="URFTANACHMB"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="DLGNXZPAAEA"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="JPXIIXTHHCD"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="TBNUTANPVJL"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="KMJUQXVHQCC"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="IOOFGDSHPEH"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="XPDQNLHPEQC"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="QDVBLGFFTYT"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="UGPQPRIWNYC"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="WVDLQHGJLEM"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="7.297473759736762284e-04" ID="MGGBUYILTYL"/>
+                    <CamberLoc Value="1.499999999999999944e-01" ID="XTATAXISUBJ"/>
+                    <Chord Value="9.540740740740738524e-02" ID="VDEGMLKUHXX"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="JFYVIHPPLNP"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="ZDFLYRITSAZ"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="ZVUJAYJZAZY"/>
+                    <HWRatio Value="1.173104956268221366e-01" ID="DKZJFFNXOQS"/>
+                    <IdealCl Value="6.999999999999999556e-01" ID="CYBJXLLGSGX"/>
+                    <Invert Value="0.000000000000000000e+00" ID="XGKGGJZSLRV"/>
+                    <Scale Value="1.000000000000000000e+00" ID="GDCHKYXIOBU"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="YFFMXHGIKDL"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="RZRBBNSQCDG"/>
+                    <Theta Value="0.000000000000000000e+00" ID="COPSKNKJNRA"/>
+                    <ThickChord Value="1.173104956268221366e-01" ID="AOQXPWOCJUJ"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="CQDZBGBIUUC"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="TISTAKUCTKP"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="PEYRJBAMTJX"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="QJKTXKZAZSC"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="LUFCKWAMLPO"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="CCAIVAESNDH"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="ADZUEGVIHKG"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="UUMRYJOUIKL"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>16</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>VEUSEYEITO</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="1.000000000000000000e+00" ID="XKCYIUCNKUP"/>
+                <RefLength Value="6.999999999999999556e-01" ID="YLYOAJRPYYU"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="RFKNMXFYXYV"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>AJKDVPALBT</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="IREMULXIJMW"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="AACTXBHKLTA"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="THLDBKSXWMR"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="JIMAQCKILLU"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="ALIBPKNBQRV"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="ZLZDHJLJIQV"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="JWULASKOUER"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="CMRSANJNSOP"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="ZQNKTFTLUQK"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="MPIFGJXBALO"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="DEYRWWYMLHP"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="JYDMQAQITAI"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="LFONAGMDGTH"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="CXFMJHERSSS"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="TKUZMCYYZLV"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="ZSZUOFYMXUS"/>
+                    <Number Value="8.000000000000000000e+00" ID="IAPNTDKWWAQ"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="DWIKEBAHEEF"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="KKBEHWAAAFY"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="ZMMIWQPEKGN"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="GCIUGBLBGWL"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="GBCEZZFCPTX"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="RDNTZZIZUTZ"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="AFVXYWOPEWH"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="YEUNHWORSWA"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="UMXIQYEZTKY"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="BGVUUHIKVIY"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="HOTKNILUYWM"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="DDIBUDCZPLF"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="GOUBSBSUWYY"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="IZMRZNQFWSZ"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="TJBLYSNOVLL"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="KYOVSXIIQXG"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="YFZRJMXYLEI"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="OACSPBYRONE"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="VYWFVRYKOCK"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="KOAMDTVHORQ"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="JLWGFZDITUZ"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="DZZXHDXYFAB"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="TQFPVYKYVUF"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="LZZLKKOJPUA"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="QYFUVJQFSHG"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="CDALIPLFOUN"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="QIDPMIXCCTW"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="EQQOLJYVTGX"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="ZLMMAPUBZRR"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="SCDRBNKVIJN"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="DKSWDVUFCVQ"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="TMMKHPYLRQH"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="RJWTKAOADIP"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="EZBXHWYPBSG"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="CCTECURAZBT"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="KYNNRCOTXLV"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="VOQDCHABSPK"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="IGIQHAGGNFI"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="TDWYWNOXIPU"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="ISOFHNMERFB"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="9.984846773124649879e-05" ID="QPBZCBEALOH"/>
+                    <CamberLoc Value="1.499999999999999944e-01" ID="YUSDFBLAUIL"/>
+                    <Chord Value="6.999999999999999278e-02" ID="CDTICJVVWYS"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="QNSYSEYEFBC"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="UMITVFKZUPH"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="WIHBISFXSVP"/>
+                    <HWRatio Value="2.999999999999999889e-02" ID="JMWLAWVLROI"/>
+                    <IdealCl Value="2.000000000000000111e-01" ID="MCFCRBYPJYR"/>
+                    <Invert Value="0.000000000000000000e+00" ID="FDHQWKINCAH"/>
+                    <Scale Value="1.000000000000000000e+00" ID="WNXKUMPKCAA"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="PZWLWFORSKH"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="HZHBOIQPOAB"/>
+                    <Theta Value="0.000000000000000000e+00" ID="GKWZXAHELJI"/>
+                    <ThickChord Value="2.999999999999999889e-02" ID="MVRCTMKDQJZ"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="SZWDDTZGLCE"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="MQFHEIYLQJX"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="PWQLDREXZTG"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="PQRIRGIFDHM"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="OZDLPPCKTNX"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="XCXORZCCWNM"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="YPBIANLBRHK"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="QCVENTBWEZI"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>16</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+        </XSecSurf>
+        <Chord>
+          <PCurve>
+            <NumPts>10</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>PAXIUOVYYO</ID>
+            <Name>PCurve</Name>
+            <Chord>
+              <ConvType Value="2.000000000000000000e+00" ID="CCVYVPISPUE"/>
+              <CrvType Value="2.000000000000000000e+00" ID="ERXEMIJVXGV"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="TXPUHIOPGOG"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="LBIHDUOLFUU"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="ZEESKNHWOVG"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="BJQLSPBSTXR"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="ZXFMUOOPMCI"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="KSFZJVPPKXU"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="VWGNWOUSELM"/>
+              <G1_7 Value="0.000000000000000000e+00" ID="ITZIXREQUBD"/>
+              <G1_8 Value="0.000000000000000000e+00" ID="AZMGUOBKGJQ"/>
+              <G1_9 Value="0.000000000000000000e+00" ID="EMYGMUOCKCQ"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="FZFGKPFIVZV"/>
+              <crd_0 Value="8.000000000000000167e-02" ID="NSRBGFFVZHV"/>
+              <crd_1 Value="9.333333333333333759e-02" ID="LAKOWIMTDWI"/>
+              <crd_2 Value="1.199999999999999817e-01" ID="MBPDWHBAYPY"/>
+              <crd_3 Value="1.362962962962962765e-01" ID="OHWHKMHEJJP"/>
+              <crd_4 Value="1.525925925925925575e-01" ID="KJMJIRWWSBO"/>
+              <crd_5 Value="1.499999999999999944e-01" ID="UFILXFFSJRI"/>
+              <crd_6 Value="1.499999999999999944e-01" ID="YEVEFLVRHVD"/>
+              <crd_7 Value="1.499999999999999944e-01" ID="ORAYGFTZTLM"/>
+              <crd_8 Value="1.499999999999999944e-01" ID="DKAKJICOHOC"/>
+              <crd_9 Value="1.000000000000000056e-01" ID="KFPLMSNCKKS"/>
+              <r_0 Value="2.000000000000000111e-01" ID="IYNAOUQPCHP"/>
+              <r_1 Value="2.666666666666666630e-01" ID="JGDDDZGUHZC"/>
+              <r_2 Value="3.333333333333333703e-01" ID="KKKGDCKERCT"/>
+              <r_3 Value="4.000000000000000222e-01" ID="CXYMRVKPAZV"/>
+              <r_4 Value="4.666666666666666741e-01" ID="XQWJCSXYQAL"/>
+              <r_5 Value="5.333333333333333259e-01" ID="TRDPUPAOKSK"/>
+              <r_6 Value="5.999999999999999778e-01" ID="JOOVHASSMTJ"/>
+              <r_7 Value="7.333333333333332815e-01" ID="TLHLCZETJXV"/>
+              <r_8 Value="8.666666666666666963e-01" ID="EZBREMJLGOR"/>
+              <r_9 Value="1.000000000000000000e+00" ID="WQXFHXWXNNG"/>
+            </Chord>
+          </ParmContainer>
+        </Chord>
+        <Twist>
+          <PCurve>
+            <NumPts>7</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>BZERUWCJIU</ID>
+            <Name>PCurve</Name>
+            <Twist>
+              <ConvType Value="2.000000000000000000e+00" ID="OFSUTVLFKRG"/>
+              <CrvType Value="2.000000000000000000e+00" ID="VWFRNNSHWTG"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="OIYURQIBNLZ"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="QVLEXMXXZJN"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="AMYCOWVSHWJ"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="HGSILTAGEXC"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="TYUUVZLOALE"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="FMWQWIPYQIW"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="OWYXYZSMDCY"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="XNHAFRHBFAI"/>
+              <r_0 Value="2.000000000000000111e-01" ID="NKXPDNWODCM"/>
+              <r_1 Value="3.333333333333333703e-01" ID="SEPQEIDXNCX"/>
+              <r_2 Value="4.666666666666666741e-01" ID="TTCNQJGWRDU"/>
+              <r_3 Value="5.999999999999999778e-01" ID="ANHPVAYQBOG"/>
+              <r_4 Value="7.333333333333332815e-01" ID="UIGZOXZCRGV"/>
+              <r_5 Value="8.666666666666666963e-01" ID="FFQXVKFJIHV"/>
+              <r_6 Value="1.000000000000000000e+00" ID="DHBXXGJBSLQ"/>
+              <tw_0 Value="3.000000000000000000e+01" ID="FOGCTJZEAYV"/>
+              <tw_1 Value="2.337500000000000000e+01" ID="GRRQMVLOPPE"/>
+              <tw_2 Value="1.955555555555555358e+01" ID="ELYTSVEJYRW"/>
+              <tw_3 Value="1.500000000000000000e+01" ID="CWJHJNIDOVD"/>
+              <tw_4 Value="1.161111111111111072e+01" ID="RRMTOSCEZEK"/>
+              <tw_5 Value="1.038888888888888751e+01" ID="EORYCUAWNRJ"/>
+              <tw_6 Value="1.000000000000000000e+01" ID="FORFKSGEJMZ"/>
+            </Twist>
+          </ParmContainer>
+        </Twist>
+        <Rake>
+          <PCurve>
+            <NumPts>4</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>QRRMOFTPAJ</ID>
+            <Name>PCurve</Name>
+            <Rake>
+              <ConvType Value="2.000000000000000000e+00" ID="GZPFYSAYYVO"/>
+              <CrvType Value="2.000000000000000000e+00" ID="UATJMJUEWOU"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="LYEGHJFDNBN"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="XEVROMEZULF"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="TEPFAZCFLVA"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="CIGKKZROXFH"/>
+              <SplitPt Value="6.784776902887139638e-01" ID="GOWORZNBOLY"/>
+              <r_0 Value="2.000000000000000111e-01" ID="NDDBMDVOVJA"/>
+              <r_1 Value="4.666666666666666741e-01" ID="UAMZSYJEKQS"/>
+              <r_2 Value="7.333333333333333925e-01" ID="DNFSFCILUAB"/>
+              <r_3 Value="1.000000000000000000e+00" ID="AVMFMTXWDTN"/>
+              <rak_0 Value="0.000000000000000000e+00" ID="AWFYIGNXERY"/>
+              <rak_1 Value="0.000000000000000000e+00" ID="MLLTQELFZPH"/>
+              <rak_2 Value="0.000000000000000000e+00" ID="FETUUTGXYYZ"/>
+              <rak_3 Value="0.000000000000000000e+00" ID="PMFJYRJDJZA"/>
+            </Rake>
+          </ParmContainer>
+        </Rake>
+        <Skew>
+          <PCurve>
+            <NumPts>4</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>UXJWAYPKFJ</ID>
+            <Name>PCurve</Name>
+            <Skew>
+              <ConvType Value="2.000000000000000000e+00" ID="YUQZMFISCPH"/>
+              <CrvType Value="2.000000000000000000e+00" ID="NKAKPGRSVOL"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="VVFTYHCERDQ"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="RETNMRHVXOS"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="GEEGMPNCMQX"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="OVKKFUSTEJW"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="JSRNMIWFIZH"/>
+              <r_0 Value="2.000000000000000111e-01" ID="CUMRBJGOEEC"/>
+              <r_1 Value="4.666666666666666741e-01" ID="GSNUAXQUWXR"/>
+              <r_2 Value="7.333333333333333925e-01" ID="ZJPZWUPJXUR"/>
+              <r_3 Value="1.000000000000000000e+00" ID="OGWGUHBVGKZ"/>
+              <skw_0 Value="0.000000000000000000e+00" ID="UWGAANMNAVC"/>
+              <skw_1 Value="0.000000000000000000e+00" ID="IKGTXKWJDMK"/>
+              <skw_2 Value="0.000000000000000000e+00" ID="LYTZEOTJBYC"/>
+              <skw_3 Value="0.000000000000000000e+00" ID="YUEAZNNUMJL"/>
+            </Skew>
+          </ParmContainer>
+        </Skew>
+        <Sweep>
+          <PCurve>
+            <NumPts>7</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>ZOOKOGRXSR</ID>
+            <Name>PCurve</Name>
+            <Sweep>
+              <ConvType Value="1.000000000000000000e+00" ID="APVWFHUZXLH"/>
+              <CrvType Value="2.000000000000000000e+00" ID="AGMJAAJODLD"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="KDZMWMLMLPK"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="AGJHTWZSULN"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="KSLBDKPHFFT"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="EZTFEDNDVEN"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="AAZPPWFUIPD"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="GNGQBCUBHMS"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="FXJBDWOSTHG"/>
+              <SplitPt Value="3.839895013123360012e-01" ID="CHMNQNFWAHZ"/>
+              <r_0 Value="2.000000000000000111e-01" ID="ZYNWDHUJXFP"/>
+              <r_1 Value="3.267716535433071723e-01" ID="QTPAFCNQVRM"/>
+              <r_2 Value="4.535433070866142780e-01" ID="KWWVSDGKTQF"/>
+              <r_3 Value="5.803149606299213836e-01" ID="DISMTDSLOFJ"/>
+              <r_4 Value="7.202099737532808854e-01" ID="UJZSCEBVAPF"/>
+              <r_5 Value="8.601049868766404982e-01" ID="QKZQGJBAGWZ"/>
+              <r_6 Value="1.000000000000000000e+00" ID="LDHAFKOZDXG"/>
+              <sw_0 Value="0.000000000000000000e+00" ID="LIBCBRTFSVJ"/>
+              <sw_1 Value="-1.626086956521739291e+00" ID="XMQVIUREFUE"/>
+              <sw_2 Value="-3.000000000000000000e+00" ID="CKWLNONKZUJ"/>
+              <sw_3 Value="-3.000000000000000000e+00" ID="DDGTOHTSNFY"/>
+              <sw_4 Value="-3.000000000000000000e+00" ID="BCYQNSFLPQT"/>
+              <sw_5 Value="-1.639130434782608781e+00" ID="JDXFXEMXTJY"/>
+              <sw_6 Value="1.000000000000000000e+00" ID="VRNUNFXGLBO"/>
+            </Sweep>
+          </ParmContainer>
+        </Sweep>
+        <Thick>
+          <PCurve>
+            <NumPts>4</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>GJZBFPVOOE</ID>
+            <Name>PCurve</Name>
+            <Thick>
+              <ConvType Value="2.000000000000000000e+00" ID="YOBVQLBHHAH"/>
+              <CrvType Value="2.000000000000000000e+00" ID="YDLSCXMVRGZ"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="SHMFYZWXNXB"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="KKIAINXCHHK"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="NDYXLRGTDWM"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="QHYVWRPMRVZ"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="PUQODLRDCRJ"/>
+              <r_0 Value="2.000000000000000111e-01" ID="ACBKVNCMOCQ"/>
+              <r_1 Value="4.666666666666666741e-01" ID="FHCXMSRZUTC"/>
+              <r_2 Value="7.333333333333333925e-01" ID="UQEYXURURZY"/>
+              <r_3 Value="1.000000000000000000e+00" ID="FBNHIXBEKHS"/>
+              <toc_0 Value="1.400000000000000133e-01" ID="MDEJLXTTDFO"/>
+              <toc_1 Value="1.118853255587949902e-01" ID="DFOZHVRYDHX"/>
+              <toc_2 Value="7.521865889212828171e-02" ID="VXBWZFWLZVW"/>
+              <toc_3 Value="3.000000000000000236e-02" ID="XMZYOJEBEGY"/>
+            </Thick>
+          </ParmContainer>
+        </Thick>
+        <CLI>
+          <PCurve>
+            <NumPts>10</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>UIHACVELJL</ID>
+            <Name>PCurve</Name>
+            <CLI>
+              <ConvType Value="2.000000000000000000e+00" ID="ZUQLSROQIZC"/>
+              <CrvType Value="2.000000000000000000e+00" ID="CHYQDBAHBIN"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="TVJXUGGOKBU"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="GTHRRRNHDPB"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="CQXZCHQNYWP"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="QVRYCFETFGV"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="QNQYQHWGFEM"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="UYMVLRWJZAX"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="ITWLJPOVZUU"/>
+              <G1_7 Value="0.000000000000000000e+00" ID="BQATQEFIHBN"/>
+              <G1_8 Value="0.000000000000000000e+00" ID="SSLAEGGGZPG"/>
+              <G1_9 Value="0.000000000000000000e+00" ID="YWIJREZJJGX"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="YHFVGOIRFUV"/>
+              <cli_0 Value="0.000000000000000000e+00" ID="WMKZLMPOYYU"/>
+              <cli_1 Value="6.999999999999999556e-01" ID="VYKKESMDWYB"/>
+              <cli_2 Value="6.999999999999999556e-01" ID="ISYQQUQVTAK"/>
+              <cli_3 Value="6.999999999999999556e-01" ID="YLCNDZJFNOA"/>
+              <cli_4 Value="6.999999999999999556e-01" ID="EGVYUMQXQNZ"/>
+              <cli_5 Value="6.999999999999999556e-01" ID="OMXHPNSSEKC"/>
+              <cli_6 Value="6.999999999999999556e-01" ID="AAYBFPYIUXU"/>
+              <cli_7 Value="6.999999999999999556e-01" ID="CTOEPYSECSA"/>
+              <cli_8 Value="6.999999999999999556e-01" ID="SDJDQYESTUH"/>
+              <cli_9 Value="2.000000000000000111e-01" ID="QSRCGFSAPYY"/>
+              <r_0 Value="2.000000000000000111e-01" ID="IFGTZMZPROV"/>
+              <r_1 Value="2.666666666666666630e-01" ID="SEEWCXPEVQB"/>
+              <r_2 Value="3.333333333333333703e-01" ID="RMYNQNOIPBF"/>
+              <r_3 Value="4.000000000000000222e-01" ID="YWMDEANQYLD"/>
+              <r_4 Value="4.666666666666666741e-01" ID="XFOMWNEQMQK"/>
+              <r_5 Value="5.333333333333333259e-01" ID="QNZRFLFTCFB"/>
+              <r_6 Value="5.999999999999999778e-01" ID="CBPNNRCGZCC"/>
+              <r_7 Value="7.333333333333332815e-01" ID="UOVGDTJIHHJ"/>
+              <r_8 Value="8.666666666666666963e-01" ID="COOPNAZMAOQ"/>
+              <r_9 Value="1.000000000000000000e+00" ID="XMHHKFDUBJJ"/>
+            </CLI>
+          </ParmContainer>
+        </CLI>
+        <Axial>
+          <PCurve>
+            <NumPts>4</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>CSRVLOHCJX</ID>
+            <Name>PCurve</Name>
+            <Axial>
+              <ConvType Value="2.000000000000000000e+00" ID="DWEUAGRCPWT"/>
+              <CrvType Value="2.000000000000000000e+00" ID="ZJGLDTWAWLC"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="AWQGGOXDRKT"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="OLBSXUJBOUG"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="AMKIDSBJFRO"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="YSIMEEUNGXJ"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="XVAXTFXBWCS"/>
+              <ax_0 Value="0.000000000000000000e+00" ID="OXJILYOXQAR"/>
+              <ax_1 Value="0.000000000000000000e+00" ID="PFBBVHBFYEL"/>
+              <ax_2 Value="0.000000000000000000e+00" ID="JMXFFNIEUBK"/>
+              <ax_3 Value="0.000000000000000000e+00" ID="SGPPMAOHUQL"/>
+              <r_0 Value="2.000000000000000111e-01" ID="UZNYTNNDHEG"/>
+              <r_1 Value="4.666666666666666741e-01" ID="QEKDMPNCZMY"/>
+              <r_2 Value="7.333333333333333925e-01" ID="AUKQYOXHPQW"/>
+              <r_3 Value="1.000000000000000000e+00" ID="HNKSBEEYFPE"/>
+            </Axial>
+          </ParmContainer>
+        </Axial>
+        <Tangential>
+          <PCurve>
+            <NumPts>4</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>VGCNOIVHVQ</ID>
+            <Name>PCurve</Name>
+            <Tangential>
+              <ConvType Value="2.000000000000000000e+00" ID="LQWADJPXNGX"/>
+              <CrvType Value="2.000000000000000000e+00" ID="NRJPZVEQEOC"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="AMQRCUHICMQ"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="VLJZLFVOZND"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="MRWZYYBZPAH"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="EQSQNPBDEUA"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="SJDYUJXCHHH"/>
+              <r_0 Value="2.000000000000000111e-01" ID="ZUPDPQKNNKC"/>
+              <r_1 Value="4.666666666666666741e-01" ID="AVASUFLFOYM"/>
+              <r_2 Value="7.333333333333333925e-01" ID="XFINGXRFUBS"/>
+              <r_3 Value="1.000000000000000000e+00" ID="JJYHVGYRNPX"/>
+              <tan_0 Value="0.000000000000000000e+00" ID="UKHHHFUNNCB"/>
+              <tan_1 Value="0.000000000000000000e+00" ID="MYMYAICPTIC"/>
+              <tan_2 Value="0.000000000000000000e+00" ID="DWTTEQBFRUY"/>
+              <tan_3 Value="0.000000000000000000e+00" ID="DVONXRSKBXM"/>
+            </Tangential>
+          </ParmContainer>
+        </Tangential>
+      </PropellerGeom>
+    </Geom>
+    <Geom>
+      <ParmContainer>
+        <ID>OFLJSHOFTB</ID>
+        <Name>PropNacells_2</Name>
+        <Attach>
+          <Eta_Attach_Location Value="0.000000000000000000e+00" ID="EIFABYLJHPR"/>
+          <L_01 Value="1.000000000000000000e+00" ID="IHCRUACEKBU"/>
+          <L_Attach_Location Value="0.000000000000000000e+00" ID="NGQFCTBITAK"/>
+          <L_Attach_Location0Len Value="0.000000000000000000e+00" ID="MTAQTGMJSTN"/>
+          <M_Attach_Location Value="5.000000000000000000e-01" ID="JYGGXWWSNQR"/>
+          <N_Attach_Location Value="5.000000000000000000e-01" ID="GEPTEYEAUIO"/>
+          <R_01 Value="1.000000000000000000e+00" ID="LDGHCEVWUQA"/>
+          <R_Attach_Location Value="0.000000000000000000e+00" ID="WPARAMFTQOZ"/>
+          <R_Attach_Location0N Value="0.000000000000000000e+00" ID="KNXXEDRRNEN"/>
+          <Rots_Attach_Flag Value="1.000000000000000000e+00" ID="INOPYAZKOQG"/>
+          <S_Attach_Location Value="5.000000000000000000e-01" ID="OJIJBQDHTJH"/>
+          <T_Attach_Location Value="5.000000000000000000e-01" ID="DMIIIHUQJOQ"/>
+          <Trans_Attach_Flag Value="1.000000000000000000e+00" ID="ASOPECJAMOK"/>
+          <U_01 Value="1.000000000000000000e+00" ID="FKGYBGKPLKF"/>
+          <U_Attach_Location Value="0.000000000000000000e+00" ID="VBVSNGZECMO"/>
+          <U_Attach_Location0N Value="0.000000000000000000e+00" ID="AAQDGTNXSIM"/>
+          <V_Attach_Location Value="0.000000000000000000e+00" ID="GMQTPNYANYU"/>
+        </Attach>
+        <BBox>
+          <X_Len Value="2.100000000000000089e+00" ID="ULTWRIFJRNH"/>
+          <X_Min Value="1.036435636715777875e+00" ID="XPUVXMTZFME"/>
+          <Y_Len Value="2.613879307090027915e-01" ID="QGUTTHVCKBE"/>
+          <Y_Min Value="-1.733693965354501376e+00" ID="DUTDHROOTAQ"/>
+          <Z_Len Value="2.604377329073118141e-01" ID="ISBMEONRYYY"/>
+          <Z_Min Value="3.358982672753682563e-01" ID="PZJCNFBGRDV"/>
+        </BBox>
+        <Design>
+          <Length Value="2.100000000000000089e+00" ID="YAJUQEHUKFC"/>
+          <OrderPolicy Value="0.000000000000000000e+00" ID="OVJCUZRARUL"/>
+        </Design>
+        <EndCap>
+          <CapUMaxLength Value="1.000000000000000000e+00" ID="WDLOCPDUFQL"/>
+          <CapUMaxOffset Value="0.000000000000000000e+00" ID="RIOUQYNSMGQ"/>
+          <CapUMaxOption Value="0.000000000000000000e+00" ID="TMGZTBCAPRW"/>
+          <CapUMaxStrength Value="5.000000000000000000e-01" ID="DQXODZUXNWN"/>
+          <CapUMaxSweepFlag Value="0.000000000000000000e+00" ID="RJYPOJMIYFC"/>
+          <CapUMinLength Value="1.000000000000000000e+00" ID="REOTXRAJENB"/>
+          <CapUMinOffset Value="0.000000000000000000e+00" ID="DGIWFMDJSMJ"/>
+          <CapUMinOption Value="0.000000000000000000e+00" ID="NPTZOWWXVVA"/>
+          <CapUMinStrength Value="5.000000000000000000e-01" ID="KIYJZJZWFZR"/>
+          <CapUMinSweepFlag Value="0.000000000000000000e+00" ID="GCENRTZVYWD"/>
+          <CapUMinTess Value="3.000000000000000000e+00" ID="AYNMKXEHWDO"/>
+        </EndCap>
+        <EngineModel>
+          <AutoExtensionFlag Value="0.000000000000000000e+00" ID="KEVRETKQWGK"/>
+          <AutoExtensionSet Value="1.000000000000000000e+00" ID="OBGUPFMOWYE"/>
+          <ExtensionDistance Value="7.000000000000000000e+00" ID="ZAEGEXCQFJQ"/>
+          <GeomIOType Value="0.000000000000000000e+00" ID="SUKKOKJXGWE"/>
+          <GeomInType Value="0.000000000000000000e+00" ID="SELHARNSADO"/>
+          <GeomOutType Value="1.000000000000000000e+00" ID="VZNAFUNFHQF"/>
+          <InletFaceIndex Value="0.000000000000000000e+00" ID="UWZNNYQPJUP"/>
+          <InletFaceMode Value="0.000000000000000000e+00" ID="VCXWFNTGTJX"/>
+          <InletFaceU Value="0.000000000000000000e+00" ID="UGRACJXRGQU"/>
+          <InletLipIndex Value="0.000000000000000000e+00" ID="ONOKPJENCDZ"/>
+          <InletLipMode Value="0.000000000000000000e+00" ID="LKOKCAZZBJC"/>
+          <InletLipU Value="0.000000000000000000e+00" ID="FWOTFCQNTON"/>
+          <InletModeType Value="2.000000000000000000e+00" ID="TPRGQCVMHCA"/>
+          <OutletFaceIndex Value="0.000000000000000000e+00" ID="BHLRTOPFRSD"/>
+          <OutletFaceMode Value="0.000000000000000000e+00" ID="QCXVTODFHCC"/>
+          <OutletFaceU Value="0.000000000000000000e+00" ID="PRBUCZDNLVK"/>
+          <OutletLipIndex Value="0.000000000000000000e+00" ID="PJXIAXJITND"/>
+          <OutletLipMode Value="0.000000000000000000e+00" ID="PZONHUMPCRX"/>
+          <OutletLipU Value="0.000000000000000000e+00" ID="BVNDYTYLYBN"/>
+          <OutletModeType Value="2.000000000000000000e+00" ID="MNILYRHDAIA"/>
+        </EngineModel>
+        <Index>
+          <ActiveXSec Value="4.000000000000000000e+00" ID="HMZYNBKRUID"/>
+        </Index>
+        <Mass_Props>
+          <CGx Value="0.000000000000000000e+00" ID="GXAFINYIWYK"/>
+          <CGy Value="0.000000000000000000e+00" ID="XHFGIFGDKKT"/>
+          <CGz Value="0.000000000000000000e+00" ID="ZFSUTKDPYGA"/>
+          <Density Value="1.000000000000000000e+00" ID="GFOXALLCBPC"/>
+          <Ixx Value="0.000000000000000000e+00" ID="AAKKWUDAHGP"/>
+          <Ixy Value="0.000000000000000000e+00" ID="ZFUUVPLLFUA"/>
+          <Ixz Value="0.000000000000000000e+00" ID="MMENCSJNPAG"/>
+          <Iyy Value="0.000000000000000000e+00" ID="SXOGPWNPYHB"/>
+          <Iyz Value="0.000000000000000000e+00" ID="SQDRAHHHNCY"/>
+          <Izz Value="0.000000000000000000e+00" ID="VSXUTBPPDXF"/>
+          <Mass_Area Value="1.000000000000000000e+00" ID="SGUKZINMCEF"/>
+          <Mass_Prior Value="0.000000000000000000e+00" ID="UHEACGHLLHH"/>
+          <PointMass Value="0.000000000000000000e+00" ID="SHJAAWXENHS"/>
+          <Shell_Flag Value="0.000000000000000000e+00" ID="PEKTYGRYAFB"/>
+        </Mass_Props>
+        <Negative_Volume_Props>
+          <Negative_Volume_Flag Value="0.000000000000000000e+00" ID="JQLNBWLCEGF"/>
+        </Negative_Volume_Props>
+        <ParasiteDragProps>
+          <ExpandedList Value="0.000000000000000000e+00" ID="BSGUFCOMJPY"/>
+          <FFBodyEqnType Value="3.000000000000000000e+00" ID="XBBNNGNNPRH"/>
+          <FFUser Value="1.000000000000000000e+00" ID="JNXDAPHTCXU"/>
+          <FFWingEqnType Value="3.000000000000000000e+00" ID="ZZYAJXDJSOU"/>
+          <IncorporatedGen Value="0.000000000000000000e+00" ID="MADUPPXAOXZ"/>
+          <PercLam Value="0.000000000000000000e+00" ID="TTPCUNGKZXZ"/>
+          <Q Value="1.000000000000000000e+00" ID="UMCACOHXISY"/>
+          <Roughness Value="0.000000000000000000e+00" ID="VYUQMLZCIXC"/>
+          <TawTwRatio Value="1.000000000000000000e+00" ID="HIRPRGXQQEW"/>
+          <TeTwRatio Value="1.000000000000000000e+00" ID="OFIXLQSYZKR"/>
+        </ParasiteDragProps>
+        <Shape>
+          <Tess_U Value="1.600000000000000000e+01" ID="IOGBOTLCCNX"/>
+          <Tess_W Value="1.700000000000000000e+01" ID="ONWPVTAIQKK"/>
+          <Wake Value="0.000000000000000000e+00" ID="WUFVEZREPYB"/>
+        </Shape>
+        <Sym>
+          <Sym_Ancestor Value="3.000000000000000000e+00" ID="KKXFYCPYJMG"/>
+          <Sym_Ancestor_Origin_Flag Value="0.000000000000000000e+00" ID="XAIBBJIDCYO"/>
+          <Sym_Axial_Flag Value="0.000000000000000000e+00" ID="YIDTRYGWYPV"/>
+          <Sym_Planar_Flag Value="0.000000000000000000e+00" ID="NJYMAERKKNG"/>
+          <Sym_Rot_N Value="2.000000000000000000e+00" ID="LRBKOLFLVYF"/>
+        </Sym>
+        <WakeSettings>
+          <WakeAngle Value="0.000000000000000000e+00" ID="NXFJAGLUUXF"/>
+          <WakeScale Value="2.000000000000000000e+00" ID="FJSEWWZQGHG"/>
+        </WakeSettings>
+        <XForm>
+          <Abs_Or_Relitive_flag Value="1.000000000000000000e+00" ID="DAAEVHTFWLO"/>
+          <Last_Scale Value="1.000000000000000000e+00" ID="FRBYCJUYUPT"/>
+          <Origin Value="0.000000000000000000e+00" ID="YMJBXQSCJAR"/>
+          <Scale Value="1.000000000000000000e+00" ID="KVUNDEXXJTA"/>
+          <X_Location Value="1.036435636715777875e+00" ID="MBPUGEZPFAA"/>
+          <X_Rel_Location Value="-4.799578059071727409e-01" ID="MXNEBSUVFWB"/>
+          <X_Rel_Rotation Value="0.000000000000000000e+00" ID="NSQAFSDNQJU"/>
+          <X_Rotation Value="0.000000000000000000e+00" ID="OJTBNNAARFP"/>
+          <Y_Location Value="-1.602999999999999980e+00" ID="MYXGWWRJBWL"/>
+          <Y_Rel_Location Value="-1.602999999999999980e+00" ID="AGMGSVAOFNA"/>
+          <Y_Rel_Rotation Value="0.000000000000000000e+00" ID="IQRJQGXORIP"/>
+          <Y_Rotation Value="0.000000000000000000e+00" ID="QRLHGFCSZDI"/>
+          <Z_Location Value="3.737704918032786483e-01" ID="CCUPYZLVHCI"/>
+          <Z_Rel_Location Value="-2.000000000000000111e-01" ID="JIPCXEGUSCK"/>
+          <Z_Rel_Rotation Value="0.000000000000000000e+00" ID="QNPXQNCGKGO"/>
+          <Z_Rotation Value="0.000000000000000000e+00" ID="ELHLWTFBKJF"/>
+        </XForm>
+      </ParmContainer>
+      <GeomBase>
+        <TypeName>Fuselage</TypeName>
+        <TypeID>4</TypeID>
+        <TypeFixed>0</TypeFixed>
+        <ParentID>LOENSIWPJA</ParentID>
+        <Child_List>
+          <Child>
+            <ID>ABRSEQBPKN</ID>
+          </Child>
+          <Child>
+            <ID>CXSHPYTTOU</ID>
+          </Child>
+        </Child_List>
+      </GeomBase>
+      <Material>
+        <Name>Default</Name>
+      </Material>
+      <Wire_Color>
+        <ParmContainer>
+          <ID>SAIRGNHZIY</ID>
+          <Name>Default</Name>
+          <Color_Parm>
+            <Alpha Value="2.550000000000000000e+02" ID="OZVTBRUPDBU"/>
+            <Blue Value="2.550000000000000000e+02" ID="IMABZEPNMCB"/>
+            <Green Value="0.000000000000000000e+00" ID="BNCLQPNKXTR"/>
+            <Red Value="0.000000000000000000e+00" ID="XGZAPUIIUGF"/>
+          </Color_Parm>
+        </ParmContainer>
+      </Wire_Color>
+      <Textures>
+        <Num_of_Tex>0</Num_of_Tex>
+      </Textures>
+      <Geom>
+        <Set_List>1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, </Set_List>
+        <SubSurfaces/>
+        <FeaStructures/>
+      </Geom>
+      <FuselageGeom>
+        <ParmContainer>
+          <ID>UTSLNWDMQG</ID>
+          <Name>Default</Name>
+        </ParmContainer>
+        <XSecSurf>
+          <XSec>
+            <ParmContainer>
+              <ID>OAHQBZTEMF</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="WNMGRUPUQZW"/>
+                <AllSym Value="0.000000000000000000e+00" ID="BNOEXPPLJIA"/>
+                <BottomLAngle Value="4.500000000000000000e+01" ID="NWFTGYQRYQP"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="DBSAWGRYZIV"/>
+                <BottomLCurve Value="1.840502975425566401e+00" ID="WRYFWXRXPLL"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="NFQHFJKPTEY"/>
+                <BottomLRAngleEq Value="1.000000000000000000e+00" ID="PLUMYLAVGRV"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="YGACXETJHXM"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="AFDUUQRKMAF"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="ISLPFOEMVGM"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="AVWBGIUOQML"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="OWBOQNBYHUJ"/>
+                <BottomLStrength Value="7.500000000000000000e-01" ID="STEUQMXOKBR"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="XIQHOCPHRRG"/>
+                <BottomRAngle Value="4.500000000000000000e+01" ID="WIQPZHSVPUL"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="WLFRGLLYYXV"/>
+                <BottomRCurve Value="1.840502972834015205e+00" ID="KJJOUPMOLOV"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="MXXXDBVLEDN"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="XHAHSXJJSPV"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="CQKWMDUQXGT"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="ITJKUNAFKRW"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="FVVALDRFGJK"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="MTSICGROFMX"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="ROZHTCYVQVG"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="HNJEQHDCOVB"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="NDFQXKXKILC"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="APLMVWKAZZC"/>
+                <LeftLAngle Value="4.500000000000000000e+01" ID="GMWVQFZEOMR"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="WRDYJFNKFSF"/>
+                <LeftLCurve Value="1.947290939287852796e+00" ID="EGLKPAACXLS"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="HDCJOVXORDE"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="KTXJBSNXGSG"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="JKVKMSPJQPD"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="ESBBTVCVVPP"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="BXSQCVYNGDG"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="TWDADMWUNRV"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="ZUAQHURVRCX"/>
+                <LeftLStrength Value="7.500000000000000000e-01" ID="HSFFZMHVHUW"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="PSEQNXTESJJ"/>
+                <LeftRAngle Value="4.500000000000000000e+01" ID="MMCIUMKJGMJ"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="LOIVCUTEKBH"/>
+                <LeftRCurve Value="1.947290936590385879e+00" ID="LBVZAPHXIOR"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="HSLRQFRDKGV"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="HXDMZRDHCIW"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="CDYBYULFSBZ"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="ERIORAYKLZJ"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="WOUIJDEMZXQ"/>
+                <RLSym Value="1.000000000000000000e+00" ID="IFVSWRDGQTJ"/>
+                <RefLength Value="2.100000000000000089e+00" ID="BAKOWWRWDPS"/>
+                <RightLAngle Value="4.500000000000000000e+01" ID="OZUJGNZBBGD"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="CQLDCHOMYID"/>
+                <RightLCurve Value="1.947290939287852796e+00" ID="XIHAUTSCEXU"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="FFSJLAHBZIK"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="DXNCTDSDALQ"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="FXWUMHNHISU"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="KQQKGSJFNWV"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="DQMBSRHURTL"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="PJODCPGZXKM"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="GRCRENHSLNW"/>
+                <RightLStrength Value="7.500000000000000000e-01" ID="FFMRVCYPKRM"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="PSXOOTTCCTP"/>
+                <RightRAngle Value="4.500000000000000000e+01" ID="SGSOMOJOXZP"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="VXVEMBGLQFY"/>
+                <RightRCurve Value="1.947290936590385879e+00" ID="VLPXJWCAJBL"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="IMUEGRCXSSW"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="PFUXMEFWOCU"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="WUZHXULQJEN"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="YEXGVWUSVTE"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="FAMXMMFFONA"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="TWUHRNTBLEU"/>
+                <Spin Value="0.000000000000000000e+00" ID="QRQEHTIDXRX"/>
+                <TBSym Value="1.000000000000000000e+00" ID="BRZOZRGBDTQ"/>
+                <TopLAngle Value="4.500000000000000000e+01" ID="MRTZINACQEY"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="FWPSFHCHXDB"/>
+                <TopLCurve Value="2.087484339984205128e+00" ID="DTOJILHHFPJ"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="MHSIGYFCWJR"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="GMUPXKEWJUC"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="HUNFUEOPXXQ"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="KSKANKJUCOT"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="KGCOIHMQBNR"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="PKVXRVLXRIO"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="ISZTRXBJVSC"/>
+                <TopLStrength Value="7.500000000000000000e-01" ID="XXQAJZGDORP"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="JNPXAEPPLTQ"/>
+                <TopRAngle Value="4.500000000000000000e+01" ID="OJXJZLIBBGM"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="WBUDIWRCOVF"/>
+                <TopRCurve Value="2.087484337121613631e+00" ID="YTAOAMOEACR"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="ACJEPTEWMZU"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="VCDWGFZXIKI"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="TGIMWPNEXCX"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="DWPERWVVLTK"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="UQYROPWPVND"/>
+                <XLocPercent Value="0.000000000000000000e+00" ID="DZBYAYJKCQV"/>
+                <XRotate Value="0.000000000000000000e+00" ID="VSXBOTURJHB"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="UCNRKYLNWYA"/>
+                <YRotate Value="0.000000000000000000e+00" ID="FTBDGOLPFUZ"/>
+                <ZLocPercent Value="5.801687763713080093e-02" ID="LSTDUQXKRZA"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="OAQTJVANSUS"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>UTYPTBQHFE</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="MVYAMZXLDXQ"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="WUSLHHVHORR"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="CDCSMXZZGAY"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="EUOBCYCBUGS"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="EMIYUCJAKOY"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="JQLXGWZMUKT"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="FXSZOJWXNGA"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="ZWKJAUPLUJT"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="QRSNHCSNQAX"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="GNYZXCWDWDJ"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="FRFZFVXYFIB"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="TQARMHDBVFH"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="AFKJQAZEMOP"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="XGRRHHJRZEG"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="XNVGFYTBAXM"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="IICRDBXTOXN"/>
+                    <Number Value="8.000000000000000000e+00" ID="PKGZZQCGQHC"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="QTURBXHQMTW"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="PFQNWATUTZU"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="QLGEPFPFCFE"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="RNCUUGFFHIU"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="KSCVKJRZMSX"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="VXDFJHYJIUL"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="HGQOGDPWDRS"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="GXGIVDNZRBH"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="QHXENEOUAVG"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="SSDMGRCVZYH"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="WNJCGWFSQCG"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="PZTDLBWXUCB"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="JTTPICSWHBH"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="XWOPEUERHYD"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="GVLKOVEZNEU"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="YKNAPFPPAKB"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="WUIAYKYRYUE"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="JFDDAWURFHH"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="ERIOBOBNTEO"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="MWRZNTPLOLD"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="MIAEUPRKIBG"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="JNKLJMKUABL"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="HADFKEDLPVU"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="RNTMARZQXLX"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="HHANLQZGZRR"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="OCEQMECTLWC"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="RFBZEIJNUQN"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="TTNGVRNKGDO"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="FRNQJZIAFHQ"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="JHDRPUYVELM"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="CCYHRWPPVKK"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="PITLUHNAIZR"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="RAXUFAJTACB"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="WZJNKXSFLUF"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="GKTKGKZILGQ"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="KPDCWTEICTS"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="ODIRBPFJUYC"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="DPPPLXPPADK"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="IQIRRWUAUUH"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="QLLNSTFAUPC"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="0.000000000000000000e+00" ID="KXBDQRMIVBU"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="UFBZGGQNQVC"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="BQKQDYDPHGD"/>
+                    <HWRatio Value="1.000000000000000000e+00" ID="UCTNATEVXIZ"/>
+                    <Scale Value="1.000000000000000000e+00" ID="MAARQKXBFUA"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="ZFGFEBYWDNV"/>
+                    <Theta Value="0.000000000000000000e+00" ID="EQMSYONWFRU"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="KKASGSHPLVG"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="WNWGURTQGWD"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="VXFCPGYHJFQ"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="ZTPZWQLNLDH"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="AXSSHOGHQLX"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="JJDHKUNVAUL"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="LDWNTZCROFY"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="OSAEJNIGVBM"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>0</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>NIOHMCOMCZ</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="XEGFUUUQJDL"/>
+                <AllSym Value="0.000000000000000000e+00" ID="AGNHXFNBQET"/>
+                <BottomLAngle Value="4.736842105263164626e+00" ID="OTSPZDGHWID"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="OKLNPJTSIHZ"/>
+                <BottomLCurve Value="-1.005137962405838081e+00" ID="INXXKWWPXDX"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="ZJULZOJMJYS"/>
+                <BottomLRAngleEq Value="0.000000000000000000e+00" ID="XXRWCJNIJYK"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="KDQBCGSIRGV"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="NABNPSEWMDT"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="RPONNBOAXTT"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="KYPVAXPVIVZ"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="FPLOUJSDRIG"/>
+                <BottomLStrength Value="1.000000000000000000e+00" ID="XUSPORPDNWB"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="FFRHTEHJEUT"/>
+                <BottomRAngle Value="0.000000000000000000e+00" ID="WNBHHWWYIFC"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="GDZIJFOHZNA"/>
+                <BottomRCurve Value="-3.637301593151403556e-01" ID="PYIOEHJUGMV"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="URVGBDYGMRR"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="OSGNDBWOUGH"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="YXOCUAWJRCS"/>
+                <BottomRStrength Value="1.090909090909090828e+00" ID="PPTTGYYESDL"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="RZDLZTBBSPY"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="XCDRBFYVECT"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="QHEGFGTJUEV"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="HXQXYPQNGKE"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="HIIMZZKLJEU"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="BCAZVELXVTK"/>
+                <LeftLAngle Value="0.000000000000000000e+00" ID="LFIHXHWDXQN"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="LKOOGASBKAK"/>
+                <LeftLCurve Value="-1.045789331960177426e+00" ID="RYCKXRABFCV"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="RKAESPILNZX"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="RCHXFUARFDB"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="WPKEWYEROXF"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="BVGLHWMBARU"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="ZYZTWFAMZSV"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="TCTEJKZEUGO"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="RQCYWQSQRQB"/>
+                <LeftLStrength Value="1.000000000000000000e+00" ID="OUJRVRSXMJJ"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="KTPXCOBTVKA"/>
+                <LeftRAngle Value="0.000000000000000000e+00" ID="OMTKPSWMPKD"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="JQSJFIGNYLS"/>
+                <LeftRCurve Value="-8.020330779186549477e-03" ID="ICHFHYBCREX"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="QQJRHEHJWBG"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="RHUMMUKDNOX"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="FNQSHPEJLYW"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="NJJAMHOYAGG"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="MCILPHERIVM"/>
+                <RLSym Value="1.000000000000000000e+00" ID="KVQTSDGXWPK"/>
+                <RefLength Value="2.100000000000000089e+00" ID="GCKBJZTQOWQ"/>
+                <RightLAngle Value="0.000000000000000000e+00" ID="LSPAIVVJWLA"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="KAWRFDJEOCJ"/>
+                <RightLCurve Value="-1.045789331960177204e+00" ID="JELOMHAZFHF"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="AOTIRBOPTEW"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="UOQRVYWCKKE"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="QEVQTCJVSCR"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="GDBNEPJDLPG"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="CWHKAPUJGUB"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="ZEXTESIXHWW"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="XEUCRVLAWJQ"/>
+                <RightLStrength Value="1.000000000000000000e+00" ID="OZUKEOPXRFW"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="MERVOENPGTL"/>
+                <RightRAngle Value="0.000000000000000000e+00" ID="XOVIDEXUJBB"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="XWTRPFWEFLB"/>
+                <RightRCurve Value="0.000000000000000000e+00" ID="PFYQYSPIDZT"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="WGXFQZGMMYB"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="CGSUZZYKNCS"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="HDTAMZCYEXZ"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="BDCRIBYHJRD"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="HQFRFKTNCPE"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="HPGFDYWGPAG"/>
+                <Spin Value="0.000000000000000000e+00" ID="HICRYOVCEOJ"/>
+                <TBSym Value="0.000000000000000000e+00" ID="NFZGJXPCAFV"/>
+                <TopLAngle Value="0.000000000000000000e+00" ID="VHALMIRBTCR"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="YQLMPVETHQD"/>
+                <TopLCurve Value="9.094578927186869333e-01" ID="MGNZKYNZGAP"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="EQFGQIUKPYF"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="AOFUBUSTHZC"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="SQFQWFVVNPD"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="KTWKAIKUGWQ"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="KLVWWGPNQHV"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="GDVJUPFQQDL"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="IPFPYTQVTAY"/>
+                <TopLStrength Value="1.000000000000000000e+00" ID="DKSIDGKWSVB"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="PLYHJNDQRHQ"/>
+                <TopRAngle Value="0.000000000000000000e+00" ID="APDMGCXJHVU"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="MLNJPUYUAEK"/>
+                <TopRCurve Value="8.020330779186865197e-03" ID="OPOLHEIGIWU"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="VVZQMISUTQR"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="MGVJKVLJIWW"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="EQOVGFRSFVV"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="HAJKICNAIHN"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="FZAVOQUTHQQ"/>
+                <XLocPercent Value="2.500000000000000000e-01" ID="KNRIOOWMTQI"/>
+                <XRotate Value="0.000000000000000000e+00" ID="YXASKEDFJSI"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="PKNSUHSDNTS"/>
+                <YRotate Value="0.000000000000000000e+00" ID="UEWJETJVSHR"/>
+                <ZLocPercent Value="4.148941689147124523e-02" ID="MYVJLDNTHYZ"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="EJPDZAADRYO"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>KYXJGZRTDV</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="EDETHZDBKTR"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="IXLQXVSDPRE"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="OJFSLNAJYFB"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="LIOWEUOKZJS"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="DDEDCLRYHKB"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="HKXSMEIFXTN"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="UIMOKAIYXSK"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="TABNBJRQCXL"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="ONJQOGEZSYY"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="UYDDZGMEMAK"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="CGYORPWWRIW"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="XMKAQBGTMSI"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="XFNBCWAEUZI"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="TOINPPCOGVF"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="RJNJNLABNYB"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="OKVZXCJMMXI"/>
+                    <Number Value="8.000000000000000000e+00" ID="JPXWETDRWSC"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="YVGPBXQQBML"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="LVPTLSTNUYY"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="MALSFQWWQZI"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="VMARNIYUAUJ"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="LZVPRVBKTCV"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="JYNJWDHPQSZ"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="ZCEYNXMWOMX"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="PVSJBQNCFHD"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="BSJZXIRDZOS"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="IZTWPROTBHR"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="XNYMLPHJSTO"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="UONPXSOPKAH"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="GBUCYWCDBLR"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="SHISLRQMPSC"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="QTQXRFOUXNT"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="TBTFCNJCLZP"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="DXOTQJVOLXF"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="TOBNZWIQTAU"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="FWAJBXEHBWG"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="SYMRHCAUVNG"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="AQIBHRFTGLK"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="UDIWMKITOCY"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="ZLSZLXXAMHP"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="QLEQOSZRRYP"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="HGUPUEUVOMY"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="PQKPHZANKCX"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="JUFBKPYYKIJ"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="ZIHBEVASKHA"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="OPWCGORCCDW"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="CDGKBBMMMDG"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="VQTMBAGHJAL"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="IFMPVELWQVE"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="KSKTGPCLNRN"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="GQFSGIEHXNJ"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="CXBRBRTLOWN"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="VVVUXGBDEJQ"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="PTEGLQCEAUE"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="GLUTYZCUTGJ"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="CDYSJBQLFMH"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="NBMGSJGDZTW"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="4.909109284730346634e-02" ID="ZINFBEXZDBW"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="PQZRGSZICCQ"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="HUNHCORIRVT"/>
+                    <Ellipse_Height Value="2.500000000000000000e-01" ID="NIXHKSKZFTS"/>
+                    <Ellipse_Width Value="2.500000000000000000e-01" ID="ZYSPLWCKAQU"/>
+                    <HWRatio Value="1.000000000000000000e+00" ID="QQEPVYGRUJG"/>
+                    <Scale Value="1.000000000000000000e+00" ID="SZZVXPBBVBV"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="VGARISLFERL"/>
+                    <Theta Value="0.000000000000000000e+00" ID="VQUOYCMLZPN"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="FKIDTIVEVZY"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="OJYQPDUQGJY"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="WGHMPHMWLCN"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="BHETOVYSSWG"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="OIHPWQQIDOX"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="JFMITAEXOUQ"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="WFYFZUUYDKZ"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="BUFMPPFEJEV"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>2</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>KRKPBXGBEU</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="JNCQHLUPOBU"/>
+                <AllSym Value="0.000000000000000000e+00" ID="FESERESRXMV"/>
+                <BottomLAngle Value="0.000000000000000000e+00" ID="ZWITJQPVBVT"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="HKEVHLDOOIC"/>
+                <BottomLCurve Value="1.820003461835718039e-01" ID="MBJPWURRFTC"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="LGOBYHLOQEX"/>
+                <BottomLRAngleEq Value="0.000000000000000000e+00" ID="EOJTSBGOMER"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="AWEFNKLUNXO"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="UVMNWVQOEEC"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="RCEVYKTUXOK"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="WWGPRSRSDGQ"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="VDARRBCZIAY"/>
+                <BottomLStrength Value="1.000000000000000000e+00" ID="TEDWRKNKFAQ"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="MWOQYUPERGI"/>
+                <BottomRAngle Value="-4.352773826458047779e+00" ID="UNTWMVSTIKB"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="VPJAWUGCVPW"/>
+                <BottomRCurve Value="-7.860471630506493668e-02" ID="HJUNMDJDIIJ"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="HIWTZKXHOWQ"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="EFMAZHYBGTF"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="SPMWUGINOWH"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="BWLYGSHHUUA"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="QTZXNACTUET"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="HJWFXWQOKTI"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="ZWZLKAFDIAY"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="DCHEJOLPXOR"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="WMWAFNAPQPE"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="ZPVRXXPVKEC"/>
+                <LeftLAngle Value="0.000000000000000000e+00" ID="KQQOUELFXSS"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="BEYMIRHIOZH"/>
+                <LeftLCurve Value="8.020330779186549477e-03" ID="LUNXFVUTUBY"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="MOPFIMFDSRI"/>
+                <LeftLRAngleEq Value="0.000000000000000000e+00" ID="ENSHYYFSLMV"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="DJACJNLIMUE"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="JWQWPZIGNYP"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="AIGHYVDJAJT"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="PSCOSXRYPCP"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="LABZTFQURPZ"/>
+                <LeftLStrength Value="1.000000000000000000e+00" ID="FWYLWNBWHSP"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="FYRAJEOZZEX"/>
+                <LeftRAngle Value="0.000000000000000000e+00" ID="RMBHXFBUBFR"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="BHMWTHGWIZH"/>
+                <LeftRCurve Value="-4.363563847631892201e-01" ID="KIYKBBMFCUC"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="BPIEEJUJVVO"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="RPFMCBWARHJ"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="MRBUGDMSXXI"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="DIUBMQDVFSQ"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="CKJLSFSOQHY"/>
+                <RLSym Value="1.000000000000000000e+00" ID="GVEKHMEOVVB"/>
+                <RefLength Value="2.100000000000000089e+00" ID="VFDFVWOLFYR"/>
+                <RightLAngle Value="0.000000000000000000e+00" ID="ODZSSGITPHY"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="VMOKHAQFJYJ"/>
+                <RightLCurve Value="0.000000000000000000e+00" ID="MNDJEEDMMFS"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="DZGOGQQSXYQ"/>
+                <RightLRAngleEq Value="0.000000000000000000e+00" ID="NTOWGIXBJKN"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="YEBAJAMBLKB"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="UVJBKYWBEXL"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="EFDTLJVPUID"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="FHETRXBALJP"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="OJNLJNRARVZ"/>
+                <RightLStrength Value="1.000000000000000000e+00" ID="MHHDTBHTTFV"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="VZOCURGTEQD"/>
+                <RightRAngle Value="0.000000000000000000e+00" ID="EYIZQTKCVQK"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="LAJZVOAZSXY"/>
+                <RightRCurve Value="0.000000000000000000e+00" ID="MGWSICBMARG"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="AAVTXJRQILV"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="JCYOECKLZDM"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="AJCGAMTXKSB"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="OGQGZDEKVRA"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="YGMTYIYVVME"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="IHOQGUOSCBQ"/>
+                <Spin Value="0.000000000000000000e+00" ID="WWPKVHWXYSY"/>
+                <TBSym Value="0.000000000000000000e+00" ID="TAQHNAILKQH"/>
+                <TopLAngle Value="0.000000000000000000e+00" ID="MQQDBFIUYCJ"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="TBYDHWREBTE"/>
+                <TopLCurve Value="-8.020330779186865197e-03" ID="MNOYFRGAQNS"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="DEMGWPJPGDD"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="KFOXMJXGFUX"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="CKMGWIWJHFX"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="PAMGLPXNVMU"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="FZXKXNFYWQU"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="BDRMKVKYFAC"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="RAXMQMNPULK"/>
+                <TopLStrength Value="1.000000000000000000e+00" ID="FUUIJWVIQTF"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="UVTHCGXOWKB"/>
+                <TopRAngle Value="0.000000000000000000e+00" ID="TNGBQODRBNU"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="RUKBFDHKUTA"/>
+                <TopRCurve Value="1.288953942457491016e-02" ID="VTGZEPZVXUA"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="ONLNDEEWVAC"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="KVHBBEYKMKP"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="UWJZZUKSXND"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="CCJKIBCYOJJ"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="PPULINPCRGG"/>
+                <XLocPercent Value="5.000000000000000000e-01" ID="AYPYRSHPEOQ"/>
+                <XRotate Value="0.000000000000000000e+00" ID="XSIOZTHQULV"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="BDPDFOAKAGG"/>
+                <YRotate Value="0.000000000000000000e+00" ID="IDRHLCOTUUY"/>
+                <ZLocPercent Value="4.182359756519333366e-02" ID="XTBVPWNHTJY"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="SXCOCFXINPH"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>CXOTGPCEHW</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="RLHNCDLZGUJ"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="MNDWTDAETZE"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="VZOZQIADUAW"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="FSSREESOCWZ"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="MEHAHAIYRFN"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="BNNSFEBJQHI"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="GPTGFVHADVR"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="LQAGQNZMHDZ"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="GRQWWBIVNDG"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="ZGYIQOEJOLR"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="ZDZORZKDTVR"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="KYVEPJHMAOK"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="WOUDFLEXDXZ"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="GYBOLPMAGZE"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="KGTEKQGMMTR"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="RSSCYIEBAYC"/>
+                    <Number Value="8.000000000000000000e+00" ID="DKMQXLADKDZ"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="VLFAJMSUUKY"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="VTVXYKNTCAG"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="KXWMYXFBOQY"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="AFQXIMCNJND"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="SYCAPGXIASN"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="WYJWOMXUSNE"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="DSRVOZOQZZE"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="NCMTZWOKZXT"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="GCOBHRQYCIS"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="NQYZHAHVHAT"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="TGCWJOODZJP"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="KJFKLDOBIFA"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="ZHGDJSZVVPM"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="QVQHJCODUPW"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="RQNYYHUSCRL"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="DPWSDWCITDP"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="TBZJTCYZHTO"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="WUCZYRXBXWK"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="QJQIOFQSFWM"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="HEJGZRYBMVQ"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="COMXNQPHDQU"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="PUDBKDKBZPH"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="IGLBEDMLLJJ"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="TNRPBPWCWLR"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="IZHTBVDDZYA"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="YEHNFPYONJB"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="DOFKHUSQIGR"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="KMVMTBDXASI"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="UYZGJJCDARL"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="UWSACAWDYKG"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="IRBZQEUAGJA"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="RPMOLCCGVHQ"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="UDKCOPMLKHV"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="MHQBURTXRAU"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="NWGXVHIVRVY"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="FAIABKNFOFM"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="RIQRAJSUJPT"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="OHTDOAPGDBD"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="KFTFWUAHUZG"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="RNQKUUVEVTY"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="4.909109284730346634e-02" ID="KDEPMINSYPE"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="PYYTGLCPBOP"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="NUNZTRVBDAS"/>
+                    <Ellipse_Height Value="2.500000000000000000e-01" ID="UGSECBEPDFO"/>
+                    <Ellipse_Width Value="2.500000000000000000e-01" ID="GGCPXCDFFET"/>
+                    <HWRatio Value="1.000000000000000000e+00" ID="OFVWITFMQJJ"/>
+                    <Scale Value="1.000000000000000000e+00" ID="TXBHBDFOVDF"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="GQDPYTZIEHI"/>
+                    <Theta Value="0.000000000000000000e+00" ID="LNWKKMEUICV"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="THODOIXXQUZ"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="DOLIBEOXJWR"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="KPWQEWGAMBO"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="APKGERXLHQS"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="WRHLTUMWLXN"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="TMVMHPAFZHS"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="YPPZYCSPGXX"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="VTQDWEDGWKX"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>2</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>QECIWJBYTW</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="QXTMYUXNHXC"/>
+                <AllSym Value="0.000000000000000000e+00" ID="EKUEQCCYIEF"/>
+                <BottomLAngle Value="-1.531578947368420529e+01" ID="LXOGNZFZVJM"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="GKMNUMDVCTS"/>
+                <BottomLCurve Value="-3.697795569023462070e-01" ID="RZWDJLEGCDI"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="ANYGGMITOUL"/>
+                <BottomLRAngleEq Value="1.000000000000000000e+00" ID="ICZVBLIACXV"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="IZBHFODUUAE"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="STMFYAEXZXV"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="YKZXCDSRAHP"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="KTRGIOHUCCU"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="QZXGHFPLDVV"/>
+                <BottomLStrength Value="1.000000000000000000e+00" ID="JSZGELKBVWT"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="CLDWKDNPOFA"/>
+                <BottomRAngle Value="-1.531578947368420529e+01" ID="SBEPVTBXGHA"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="GNCRNJKMRYL"/>
+                <BottomRCurve Value="-1.032577478163970053e+00" ID="WRUDCTACZHH"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="TGTBSQUUCIP"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="RAHLHSHIFSV"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="ZRJYMLNGDEV"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="NGLMRTSTPVY"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="VBZFNEPFPTQ"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="WGASZOVCUWO"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="RHBAXULMQNJ"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="XMAJGRMHJSI"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="ONOYSXQXKKU"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="BESUOVUDUQH"/>
+                <LeftLAngle Value="0.000000000000000000e+00" ID="HHUMRRLKPQP"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="AKOIHBETMBW"/>
+                <LeftLCurve Value="4.344747996324718753e-01" ID="MMGQRCYRDYX"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="SFXQLUAIQEQ"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="WYWPOEPQTQZ"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="TMMRJYSVGXT"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="UHHHQWJPRLA"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="TFXHHEZHNIS"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="SROGJENJHVB"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="HWYTFMANKYJ"/>
+                <LeftLStrength Value="1.000000000000000000e+00" ID="ZYQIPOYTDML"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="ESGSFODQTRN"/>
+                <LeftRAngle Value="0.000000000000000000e+00" ID="DYLYJPLHCJH"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="PHYXTIBAVMJ"/>
+                <LeftRCurve Value="-1.336552192311816212e+00" ID="PSGLZUJDFEC"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="MTDFJEAZAFP"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="EKQWVKVCPCA"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="IZYJBLHLPTR"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="CFLOEVXOZOW"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="FATSPXXDVBQ"/>
+                <RLSym Value="1.000000000000000000e+00" ID="MCDXNAPMADZ"/>
+                <RefLength Value="2.100000000000000089e+00" ID="EAFQTVILQXP"/>
+                <RightLAngle Value="0.000000000000000000e+00" ID="ETBIIMPHHFI"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="GTIAISCFODA"/>
+                <RightLCurve Value="0.000000000000000000e+00" ID="ZIKIIGZJRDW"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="LVWYYGJFEMF"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="TAAPZXMXDEF"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="SWWOBOVAMCU"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="YNPHWJCIUKG"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="ZIIJJZIEUNF"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="AVASLFAKRTM"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="IXIRVSZNXQB"/>
+                <RightLStrength Value="1.000000000000000000e+00" ID="LRCJSZEMFGB"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="RSRLJTCUCEZ"/>
+                <RightRAngle Value="0.000000000000000000e+00" ID="UIPNRGSQYQA"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="ASJWIDGJGBC"/>
+                <RightRCurve Value="-1.336552192311816212e+00" ID="KECCTUBROVA"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="NSGFHEUELPL"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="UOIWPLJVBPO"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="JRQPRQJEMYL"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="FCPYTCGRPVQ"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="RQLYWNNADZN"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="DEPDJZZUQAZ"/>
+                <Spin Value="0.000000000000000000e+00" ID="YUJJLQGYZQA"/>
+                <TBSym Value="0.000000000000000000e+00" ID="DILRBUCAMMA"/>
+                <TopLAngle Value="0.000000000000000000e+00" ID="CCREWCAMRBR"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="YIFEWJXKBNC"/>
+                <TopLCurve Value="-2.198160871972833913e-02" ID="SMFKCFFNQMU"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="GLUTTSWKFJL"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="QWHGVFJZYGU"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="ZOGPKESCBVG"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="EUTWBVGECIA"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="SHUHTZQNHWR"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="YSOMSLUTQDK"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="FJUMZZXKENB"/>
+                <TopLStrength Value="1.000000000000000000e+00" ID="PLNTOTOJBAA"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="ISXPBELGUNI"/>
+                <TopRAngle Value="0.000000000000000000e+00" ID="HWMYPPKUVFM"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="MBAIDKBGLHN"/>
+                <TopRCurve Value="-4.178042928166764702e-01" ID="INYXXBYDMWV"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="TUNQVBVIIDL"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="IOZORINBBAF"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="YCWFSREQHPX"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="RUUMETQRTFV"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="OPZIUWUYBRU"/>
+                <XLocPercent Value="7.500000000000000000e-01" ID="AUWLVGPDWKR"/>
+                <XRotate Value="0.000000000000000000e+00" ID="NJFXMJKVUMH"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="DGAZPCFPFHA"/>
+                <YRotate Value="0.000000000000000000e+00" ID="DMMEPJIWEOZ"/>
+                <ZLocPercent Value="5.999999999999999778e-02" ID="PMJASZMDIZA"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="JOROEPSPCRL"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>EDCYUDFSRK</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="MTEDXKTYDCA"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="GAKNSUFMGVY"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="AGGVHTFCZLJ"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="RREZYKAFYDO"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="WAZVKUSMILH"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="EPDQAKDFZOC"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="XTMUACIRFVP"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="URZMKMYGTOD"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="KABGZILJPUZ"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="HGMGGVJEDVT"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="OQPHCWLTOCG"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="NXFTNTUQAMP"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="OIGLWLNEDNI"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="OPOSEAIRYYX"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="BFLTQWAGGND"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="KRVUNKFJJBP"/>
+                    <Number Value="8.000000000000000000e+00" ID="FJCPMGQMKNJ"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="VPGKALHFRSE"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="MAXAYMXKZBN"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="QQODHVRELAT"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="AXOEBBNKRPC"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="ZTBRBGTRXSQ"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="WRBJVGTTTHV"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="SAOTRQKJOJX"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="AITYBSRDJMJ"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="SQSZZIQDBKS"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="OREUBFOTJCK"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="TPEKXHCOYJT"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="IRJCMYAUUCR"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="HVANQMGOLRH"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="HUUUULOKUPR"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="SDVCHKLJAWH"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="BSIHHLAXHZB"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="NQQWCKNSSNA"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="RFDQTTQSJMT"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="YRDTGFYGDOL"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="OACWYUVEDJX"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="SGEFJPLCINV"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="ZZVKXCCXOPR"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="RJHEGWALESK"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="ORVRMQQPFES"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="WBCKDMIEGZL"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="SEFFBGLPMMN"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="HEACXADJXPL"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="HPLMNUFGPNT"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="EYDIHBULAGJ"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="QFAEXOYQPGG"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="LXAXIQHKDBO"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="ZULUFFDRZPF"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="SZULBHDRUCV"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="FWPEKXPXFCE"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="FUQWXKVVFYE"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="WNYNGIDANBF"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="CAGIDAAGPKZ"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="UQLPFDDBXNO"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="OGGABBMRMPH"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="DIWJQALWHYO"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="3.436376499311242366e-02" ID="GVJFYCTDHTA"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="ACVZHCRWOAU"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="TEHWGEYWHNY"/>
+                    <Ellipse_Height Value="1.749999999999999889e-01" ID="PVMANESYWTU"/>
+                    <Ellipse_Width Value="2.500000000000000000e-01" ID="XNRDGBLWCVQ"/>
+                    <HWRatio Value="6.999999999999999556e-01" ID="EFEESDQXVZO"/>
+                    <Scale Value="1.000000000000000000e+00" ID="PKMSMMLWGTG"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="WFQVWWCJOQK"/>
+                    <Theta Value="0.000000000000000000e+00" ID="VAGZCBZFXFP"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="NPZDIDTODNV"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="ZJCTVLLHGHM"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="IFMAQSJTHKQ"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="MJGJTONXPQD"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="ARVXZDQPDIF"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="ZOWNXJJOTRC"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="SPHOJWNUIDC"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="LWUESWCFHIR"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>2</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>NLUGZZSAHU</ID>
+              <Name>Default</Name>
+              <XSec>
+                <AftCluster Value="1.000000000000000000e+00" ID="FTQWPNYLEFK"/>
+                <AllSym Value="0.000000000000000000e+00" ID="EJBPQHJNMRL"/>
+                <BottomLAngle Value="-4.500000000000000000e+01" ID="YILKEPUUUYL"/>
+                <BottomLAngleSet Value="1.000000000000000000e+00" ID="GLPDOXBBMKK"/>
+                <BottomLCurve Value="1.930250083497661251e+00" ID="HOOPXTIGZRF"/>
+                <BottomLCurveSet Value="0.000000000000000000e+00" ID="SGDBGDBCDAH"/>
+                <BottomLRAngleEq Value="1.000000000000000000e+00" ID="VGXRADJKEEB"/>
+                <BottomLRCurveEq Value="0.000000000000000000e+00" ID="NPPVQIIDPKV"/>
+                <BottomLRSlewEq Value="0.000000000000000000e+00" ID="FWFPDHBBJFF"/>
+                <BottomLRStrengthEq Value="0.000000000000000000e+00" ID="ZZUECJBXQOL"/>
+                <BottomLSlew Value="0.000000000000000000e+00" ID="FYTKRYPJIJW"/>
+                <BottomLSlewSet Value="1.000000000000000000e+00" ID="BFYNNTTTMNQ"/>
+                <BottomLStrength Value="7.500000000000000000e-01" ID="DPQHDVENOEB"/>
+                <BottomLStrengthSet Value="1.000000000000000000e+00" ID="BAKSTSAPHMI"/>
+                <BottomRAngle Value="-4.500000000000000000e+01" ID="KOZCKKDEYKL"/>
+                <BottomRAngleSet Value="1.000000000000000000e+00" ID="YVLCPUOYQXA"/>
+                <BottomRCurve Value="1.930250086405383758e+00" ID="WNYZDNSQPCS"/>
+                <BottomRCurveSet Value="0.000000000000000000e+00" ID="PWLQZAFCIPA"/>
+                <BottomRSlew Value="0.000000000000000000e+00" ID="ICDUZCMAXRO"/>
+                <BottomRSlewSet Value="1.000000000000000000e+00" ID="EGPVAHFIGGD"/>
+                <BottomRStrength Value="1.000000000000000000e+00" ID="OJQIFKHTEPE"/>
+                <BottomRStrengthSet Value="1.000000000000000000e+00" ID="NCUCAQBMQQK"/>
+                <ContinuityBottom Value="0.000000000000000000e+00" ID="AHZIMYQBAKU"/>
+                <ContinuityLeft Value="0.000000000000000000e+00" ID="NWWXHMWOCDD"/>
+                <ContinuityRight Value="0.000000000000000000e+00" ID="CNUZYFYEMFB"/>
+                <ContinuityTop Value="0.000000000000000000e+00" ID="BJQGOMZBDVL"/>
+                <FwdCluster Value="1.000000000000000000e+00" ID="ROWYJTAHGTK"/>
+                <LeftLAngle Value="-4.500000000000000000e+01" ID="YBBJSSNEHJR"/>
+                <LeftLAngleSet Value="1.000000000000000000e+00" ID="FZKWPQCHCRA"/>
+                <LeftLCurve Value="2.087126206574033471e+00" ID="RGMQLUJRJQJ"/>
+                <LeftLCurveSet Value="0.000000000000000000e+00" ID="PZRHOEBAAZN"/>
+                <LeftLRAngleEq Value="1.000000000000000000e+00" ID="CWYLJTXFXKH"/>
+                <LeftLRCurveEq Value="0.000000000000000000e+00" ID="TMLKZPSKYWG"/>
+                <LeftLRSlewEq Value="0.000000000000000000e+00" ID="ACNSOULRXQH"/>
+                <LeftLRStrengthEq Value="0.000000000000000000e+00" ID="SBFQMOLJSHC"/>
+                <LeftLSlew Value="0.000000000000000000e+00" ID="UFIDWKBSWDH"/>
+                <LeftLSlewSet Value="1.000000000000000000e+00" ID="MCBWAGLGPJM"/>
+                <LeftLStrength Value="7.500000000000000000e-01" ID="QQLEBNHGMCS"/>
+                <LeftLStrengthSet Value="1.000000000000000000e+00" ID="CWONVFWMHXO"/>
+                <LeftRAngle Value="-4.500000000000000000e+01" ID="OALAWKQHUTY"/>
+                <LeftRAngleSet Value="1.000000000000000000e+00" ID="GNKBWCHZHDG"/>
+                <LeftRCurve Value="2.087126209652672149e+00" ID="GQLAXPAQGGM"/>
+                <LeftRCurveSet Value="0.000000000000000000e+00" ID="LSOJTASUEIK"/>
+                <LeftRSlew Value="0.000000000000000000e+00" ID="PLDAWLDVXLG"/>
+                <LeftRSlewSet Value="1.000000000000000000e+00" ID="RTIUAWDAHOD"/>
+                <LeftRStrength Value="1.000000000000000000e+00" ID="LQYWQEULCBX"/>
+                <LeftRStrengthSet Value="1.000000000000000000e+00" ID="MXLJYRQZZUQ"/>
+                <RLSym Value="1.000000000000000000e+00" ID="GDYNNWGJHYM"/>
+                <RefLength Value="2.100000000000000089e+00" ID="NIVFRRPURZB"/>
+                <RightLAngle Value="-4.500000000000000000e+01" ID="NEISMMQVVUN"/>
+                <RightLAngleSet Value="1.000000000000000000e+00" ID="SEBIWTNHRIJ"/>
+                <RightLCurve Value="2.087126206574033471e+00" ID="RBGZICEMPFM"/>
+                <RightLCurveSet Value="0.000000000000000000e+00" ID="ECCINQEZPRC"/>
+                <RightLRAngleEq Value="1.000000000000000000e+00" ID="FXUYPXZXBBF"/>
+                <RightLRCurveEq Value="0.000000000000000000e+00" ID="TZZKRTIZEZV"/>
+                <RightLRSlewEq Value="0.000000000000000000e+00" ID="NMLELWWUPIV"/>
+                <RightLRStrengthEq Value="0.000000000000000000e+00" ID="OXMKMEGGCVI"/>
+                <RightLSlew Value="0.000000000000000000e+00" ID="OWXAZMXXEHV"/>
+                <RightLSlewSet Value="1.000000000000000000e+00" ID="MXZBLFLAUSG"/>
+                <RightLStrength Value="7.500000000000000000e-01" ID="LJFZGMYYEUA"/>
+                <RightLStrengthSet Value="1.000000000000000000e+00" ID="KSKPSCZZYCO"/>
+                <RightRAngle Value="-4.500000000000000000e+01" ID="ZNRDIERBIXM"/>
+                <RightRAngleSet Value="1.000000000000000000e+00" ID="OXNUJQZZQTG"/>
+                <RightRCurve Value="2.087126209652672149e+00" ID="TKBWNXHPOFR"/>
+                <RightRCurveSet Value="0.000000000000000000e+00" ID="KTHHBYKBTQK"/>
+                <RightRSlew Value="0.000000000000000000e+00" ID="JKMKLGXHVSO"/>
+                <RightRSlewSet Value="1.000000000000000000e+00" ID="NGEXJKBGWAL"/>
+                <RightRStrength Value="1.000000000000000000e+00" ID="GPXFFRXAJZS"/>
+                <RightRStrengthSet Value="1.000000000000000000e+00" ID="TQHGGLHMPZK"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="BURMSQRMGSG"/>
+                <Spin Value="0.000000000000000000e+00" ID="SCBUDBCPLXP"/>
+                <TBSym Value="0.000000000000000000e+00" ID="VGJCTDNVEWP"/>
+                <TopLAngle Value="0.000000000000000000e+00" ID="NVBECWOKJEF"/>
+                <TopLAngleSet Value="1.000000000000000000e+00" ID="OLIWDEAHANO"/>
+                <TopLCurve Value="8.350857580352554210e-01" ID="GWGGJMAHZEF"/>
+                <TopLCurveSet Value="0.000000000000000000e+00" ID="APPWCBPZZCY"/>
+                <TopLRAngleEq Value="1.000000000000000000e+00" ID="DBKALUORHUB"/>
+                <TopLRCurveEq Value="0.000000000000000000e+00" ID="BTGQOOFSYMV"/>
+                <TopLRSlewEq Value="0.000000000000000000e+00" ID="HWTLNMZIYSL"/>
+                <TopLRStrengthEq Value="0.000000000000000000e+00" ID="ZVAYTDOJENZ"/>
+                <TopLSlew Value="0.000000000000000000e+00" ID="JSFXMGEFAPC"/>
+                <TopLSlewSet Value="1.000000000000000000e+00" ID="GYNTCDUBEWS"/>
+                <TopLStrength Value="7.500000000000000000e-01" ID="QTQLYKDELUC"/>
+                <TopLStrengthSet Value="1.000000000000000000e+00" ID="GTGDVSJOOAT"/>
+                <TopRAngle Value="0.000000000000000000e+00" ID="HTWOKWSAKAM"/>
+                <TopRAngleSet Value="1.000000000000000000e+00" ID="CVOIJMKQNIO"/>
+                <TopRCurve Value="8.350857592736108392e-01" ID="YASSWHVUCEW"/>
+                <TopRCurveSet Value="0.000000000000000000e+00" ID="JVETEJYKQRU"/>
+                <TopRSlew Value="0.000000000000000000e+00" ID="HREBVDJZBJO"/>
+                <TopRSlewSet Value="1.000000000000000000e+00" ID="LGQNFEWYPLI"/>
+                <TopRStrength Value="1.000000000000000000e+00" ID="JXTSMUGQSAL"/>
+                <TopRStrengthSet Value="1.000000000000000000e+00" ID="XWABCFEIQSC"/>
+                <XLocPercent Value="1.000000000000000000e+00" ID="HDPYTORXHUY"/>
+                <XRotate Value="0.000000000000000000e+00" ID="QCWLBGPBUQC"/>
+                <YLocPercent Value="0.000000000000000000e+00" ID="WUVYLXRKHCU"/>
+                <YRotate Value="0.000000000000000000e+00" ID="RAQGCOINUXC"/>
+                <ZLocPercent Value="1.002356989693573980e-01" ID="HXATFSBFPZZ"/>
+                <ZRotate Value="0.000000000000000000e+00" ID="PBEIMPTENJX"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>0</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>LISMGRKINV</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="RVBGADKVDEI"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="TRXYBDLXQQG"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="AFVISZDZNCB"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="OZBGPWDOSYT"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="SYGLDGOKCRW"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="BLSDLURAHFP"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="RKFXOTIFFJZ"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="DYKQFPTIDKH"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="DHRSSUYOKTH"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="TCPRGBCDUNW"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="MFBLTDREAQC"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="YQLHHDINOXT"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="EPDRRCMUWSX"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="JIQJIFROSQV"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="FHFSODYBNYG"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="FNIJBBLIKSW"/>
+                    <Number Value="8.000000000000000000e+00" ID="SFPEMSWLTEO"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="TZDCBQZZZWB"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="LFHXSPXVFBU"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="WXRMJZSCPSQ"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="ARBOGAQVVGE"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="OXBMDNKBJYZ"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="OITMPMNXJDP"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="MHMORJLVQKW"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="BXLOIPVDTUM"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="TWMTFSBQWXA"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="VDABLEHYPUK"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="WIVZNTHYQML"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="GEIKOUTYSII"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="SLFKHYCVKZX"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="WZSYLRBEWEQ"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="BKAPTSORKIJ"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="KHEAENZNMGN"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="MTGLMBDURYR"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="MEZHBOSTKEM"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="ETRODIVBVIL"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="NAKRMGRYKRU"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="LUBLMYTPOTD"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="YLGUUNIVDJT"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="GQCEQIQVYPZ"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="GNYDSCABEEJ"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="BOOBECDRXRM"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="AMMTPERTMXQ"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="NDCMWECLROK"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="TYEKEYAECFZ"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="BXVAFCIVEUD"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="RIBKOJQRJXL"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="WQPUUNSBSUR"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="SGEVYSGNYPI"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="HKXFGBLQUYD"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="HUKHOLKLDIZ"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="EPXQEDCUWDQ"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="MNKIBGNEOPZ"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="AVYMAFUPVZW"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="SCNUHHVMFDH"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="UBUYVXLSSDI"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="TJZJJJSQTGR"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="0.000000000000000000e+00" ID="HQHVBICZIKR"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="MVFNODWMYXE"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="GNZLUTBKRZD"/>
+                    <HWRatio Value="1.000000000000000000e+00" ID="ZOCJIGNGEOT"/>
+                    <Scale Value="1.000000000000000000e+00" ID="TNYETQRXBZY"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="TFPWYSLTLIL"/>
+                    <Theta Value="0.000000000000000000e+00" ID="FMTDQPZKNQC"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="ZELPBVKEEPQ"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="EMGWYFAGNIJ"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="RQUMMEPHMHR"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="ITZHRFGIKOV"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="WAYMSFEYLEW"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="WWEMPFKFMUS"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="XRFCSTJDHMT"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="AFZKAFTGTIR"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>0</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+        </XSecSurf>
+      </FuselageGeom>
+    </Geom>
+    <Geom>
+      <ParmContainer>
+        <ID>ABRSEQBPKN</ID>
+        <Name>LiftRotor_2</Name>
+        <Attach>
+          <Eta_Attach_Location Value="0.000000000000000000e+00" ID="TMNSYSHUQZO"/>
+          <L_01 Value="1.000000000000000000e+00" ID="HLOUUZNVBMS"/>
+          <L_Attach_Location Value="6.210862014399813891e-01" ID="MZKLGFDKCGO"/>
+          <L_Attach_Location0Len Value="1.310977427880025248e+00" ID="TCEJRKDRWPK"/>
+          <M_Attach_Location Value="0.000000000000000000e+00" ID="DJEWZMNIHDD"/>
+          <N_Attach_Location Value="5.000000000000000000e-01" ID="YGQPGZFGLBR"/>
+          <R_01 Value="1.000000000000000000e+00" ID="LANEUOOMECR"/>
+          <R_Attach_Location Value="6.232057416267942074e-01" ID="JMAHINBTWOW"/>
+          <R_Attach_Location0N Value="2.492822966507176830e+00" ID="ALCKGHDELLG"/>
+          <Rots_Attach_Flag Value="1.000000000000000000e+00" ID="XLYYRBHPEDV"/>
+          <S_Attach_Location Value="0.000000000000000000e+00" ID="NXBBYRYSPJF"/>
+          <T_Attach_Location Value="5.000000000000000000e-01" ID="VTYYPXBXWLN"/>
+          <Trans_Attach_Flag Value="1.000000000000000000e+00" ID="WHNYYNECZEQ"/>
+          <U_01 Value="1.000000000000000000e+00" ID="KCJPYVRHGKA"/>
+          <U_Attach_Location Value="6.232057416267942074e-01" ID="WCRECABAGSQ"/>
+          <U_Attach_Location0N Value="2.492822966507176830e+00" ID="BLZGHFNQJWB"/>
+          <V_Attach_Location Value="0.000000000000000000e+00" ID="FPWOXZLDWXS"/>
+        </Attach>
+        <BBox>
+          <X_Len Value="1.402522517016349113e+00" ID="JNXNPVTHASS"/>
+          <X_Min Value="2.344688907926179233e+00" ID="LUOCMGRSBRL"/>
+          <Y_Len Value="1.402522517016348891e+00" ID="EQQXZPYHBRY"/>
+          <Y_Min Value="-2.304261258508174315e+00" ID="NADDZRTIHJB"/>
+          <Z_Len Value="5.605583212626674694e-02" ID="TQZTXSGSIFY"/>
+          <Z_Min Value="6.551419151470110336e-01" ID="UMAFQXESZBV"/>
+        </BBox>
+        <Design>
+          <AF Value="1.489186065046675083e+02" ID="RNGNRBZRYKE"/>
+          <AFLimit Value="4.000000000000000222e-01" ID="JZBIYLXDNMD"/>
+          <AxFoldAx Value="0.000000000000000000e+00" ID="WBCSRQSYDHR"/>
+          <AzFoldDir Value="0.000000000000000000e+00" ID="KNQMHAVLHJE"/>
+          <BalanceX1 Value="0.000000000000000000e+00" ID="CBAMGWNKHFQ"/>
+          <BalanceX2 Value="0.000000000000000000e+00" ID="IQIYEUPJUVG"/>
+          <Beta34 Value="2.000000000000000000e+01" ID="SWGOEGZAXTT"/>
+          <BladeAz_2 Value="9.000000000000000000e+01" ID="YEBLCAGAMJF"/>
+          <BladeAz_3 Value="1.800000000000000000e+02" ID="IVUWZELFJRV"/>
+          <BladeAz_4 Value="2.700000000000000000e+02" ID="GCZJJEXGBPG"/>
+          <BladeAzimuthDeltaFlag Value="0.000000000000000000e+00" ID="DFWEKRPKKWP"/>
+          <BladeAzimuthMode Value="0.000000000000000000e+00" ID="QQCMMENZTAO"/>
+          <CLi Value="5.240457003555305526e-01" ID="HOPEZIYEXAN"/>
+          <Chord Value="1.776562499999999878e-01" ID="VNHUULWAJHZ"/>
+          <ConstructXoC Value="5.000000000000000000e-01" ID="XGWNWATPFPB"/>
+          <CylindricalSectionsFlag Value="0.000000000000000000e+00" ID="AQOHATBYGKZ"/>
+          <DeltaAz_2 Value="0.000000000000000000e+00" ID="LVBOBIIUQLB"/>
+          <DeltaAz_3 Value="0.000000000000000000e+00" ID="DTHDDADNPJA"/>
+          <DeltaAz_4 Value="0.000000000000000000e+00" ID="QSPXWIZGAIU"/>
+          <Diameter Value="1.399999999999999911e+00" ID="PSCQKPXPZRU"/>
+          <ElFoldDir Value="0.000000000000000000e+00" ID="QNYYXRZRUDL"/>
+          <Feather Value="3.225249339548309280e+00" ID="ZELOUGSSECS"/>
+          <FeatherAxisXoC Value="5.000000000000000000e-01" ID="ICJNNTXVRPF"/>
+          <FeatherOffsetXoC Value="0.000000000000000000e+00" ID="BOMNQPAAANL"/>
+          <FoldAngle Value="0.000000000000000000e+00" ID="CHLMCEFCHOA"/>
+          <FoldAngle_1 Value="0.000000000000000000e+00" ID="PHQTAWDEJMD"/>
+          <FoldAngle_2 Value="0.000000000000000000e+00" ID="EJYNOEYZBXH"/>
+          <FoldAngle_3 Value="0.000000000000000000e+00" ID="BYSAGFKFPGA"/>
+          <InCluster Value="1.000000000000000000e+00" ID="MTPVQMVUECB"/>
+          <IndividualBladeFoldFlag Value="0.000000000000000000e+00" ID="QBULCMQCMFZ"/>
+          <LECluster Value="2.500000000000000000e-01" ID="PSZPIGCDZMT"/>
+          <NumBlade Value="4.000000000000000000e+00" ID="LONEMLFRRTR"/>
+          <OffFoldAx Value="0.000000000000000000e+00" ID="YOEHGTKONRJ"/>
+          <OutCluster Value="1.000000000000000000e+00" ID="SSQNVPIHQTR"/>
+          <PChord Value="1.942800443498498009e-01" ID="BFDCZJHFPBM"/>
+          <PSolidity Value="2.473650352191299751e-01" ID="XHIIICAZMAZ"/>
+          <Precone Value="0.000000000000000000e+00" ID="PYEOSBTHNJN"/>
+          <PropMode Value="0.000000000000000000e+00" ID="BNJLSSBMSXO"/>
+          <RFoldAx Value="2.000000000000000111e-01" ID="QILUXNULYZY"/>
+          <ReverseFlag Value="0.000000000000000000e+00" ID="CNYYYXRVLLN"/>
+          <Rotate Value="0.000000000000000000e+00" ID="ORXROUQMOWD"/>
+          <Solidity Value="2.261989628693562293e-01" ID="IBSSHQPNEJD"/>
+          <TChord Value="1.923498613911290012e-01" ID="HKOYHFZLKQI"/>
+          <TECluster Value="2.500000000000000000e-01" ID="UTSHUPOEXCW"/>
+          <TSolidity Value="2.449074499475127342e-01" ID="CYPMPEOQCQV"/>
+          <UseBeta34Flag Value="1.000000000000000000e+00" ID="YHZKTGEDGSI"/>
+        </Design>
+        <EndCap>
+          <CapUMaxLength Value="1.000000000000000000e+00" ID="EWIIJGKQBRS"/>
+          <CapUMaxOffset Value="0.000000000000000000e+00" ID="AVKMMXYSQYY"/>
+          <CapUMaxOption Value="2.000000000000000000e+00" ID="PGHVCZLNLDK"/>
+          <CapUMaxStrength Value="1.000000000000000000e+00" ID="DVAPLYIHWIY"/>
+          <CapUMaxSweepFlag Value="0.000000000000000000e+00" ID="FUWRFVEBBIF"/>
+          <CapUMinLength Value="1.000000000000000000e+00" ID="BIQIUVWVOIU"/>
+          <CapUMinOffset Value="0.000000000000000000e+00" ID="OFHACBNJRUJ"/>
+          <CapUMinOption Value="1.000000000000000000e+00" ID="QIHUGFRHNXK"/>
+          <CapUMinStrength Value="5.000000000000000000e-01" ID="MXZFNJJWNZL"/>
+          <CapUMinSweepFlag Value="0.000000000000000000e+00" ID="KZJHCAUQGDD"/>
+          <CapUMinTess Value="3.000000000000000000e+00" ID="ARGTBEGNXPO"/>
+        </EndCap>
+        <Index>
+          <ActiveBlade Value="1.000000000000000000e+00" ID="FUPNAJGOTPT"/>
+          <ActiveXSec Value="2.000000000000000000e+00" ID="DSRWBCEZHCY"/>
+        </Index>
+        <Mass_Props>
+          <CGx Value="0.000000000000000000e+00" ID="CCFQMSNUTDH"/>
+          <CGy Value="0.000000000000000000e+00" ID="KCXVODDJRQG"/>
+          <CGz Value="0.000000000000000000e+00" ID="PFHRGPUYDLJ"/>
+          <Density Value="1.000000000000000000e+00" ID="RWJIRDPHCLG"/>
+          <Ixx Value="0.000000000000000000e+00" ID="RNYWTZSCOVN"/>
+          <Ixy Value="0.000000000000000000e+00" ID="JDFJEFZDLDK"/>
+          <Ixz Value="0.000000000000000000e+00" ID="CNPXEFXOHHJ"/>
+          <Iyy Value="0.000000000000000000e+00" ID="ESDBKPTLKAY"/>
+          <Iyz Value="0.000000000000000000e+00" ID="QXUJODOGVIN"/>
+          <Izz Value="0.000000000000000000e+00" ID="SFMKBFEQFDV"/>
+          <Mass_Area Value="1.000000000000000000e+00" ID="MEHGMPIRBKI"/>
+          <Mass_Prior Value="0.000000000000000000e+00" ID="ZBFATHUIPVO"/>
+          <PointMass Value="0.000000000000000000e+00" ID="KIPJCABUDBC"/>
+          <Shell_Flag Value="0.000000000000000000e+00" ID="SRUSTTBMTAU"/>
+        </Mass_Props>
+        <Negative_Volume_Props>
+          <Negative_Volume_Flag Value="0.000000000000000000e+00" ID="XTPUBDRJLUR"/>
+        </Negative_Volume_Props>
+        <ParasiteDragProps>
+          <ExpandedList Value="0.000000000000000000e+00" ID="PFJXQTBTUWW"/>
+          <FFBodyEqnType Value="3.000000000000000000e+00" ID="RDXHWFKAQUL"/>
+          <FFUser Value="1.000000000000000000e+00" ID="RKSBVUEAOQS"/>
+          <FFWingEqnType Value="3.000000000000000000e+00" ID="GFPMMPPKQOC"/>
+          <IncorporatedGen Value="0.000000000000000000e+00" ID="IOPJTPJZYSC"/>
+          <PercLam Value="0.000000000000000000e+00" ID="NNVJJUTAQOW"/>
+          <Q Value="1.000000000000000000e+00" ID="BDGUCMTPRBX"/>
+          <Roughness Value="0.000000000000000000e+00" ID="KLLFHRDVTRT"/>
+          <TawTwRatio Value="1.000000000000000000e+00" ID="AJSCOKBMBWY"/>
+          <TeTwRatio Value="1.000000000000000000e+00" ID="UGTEPSBCGMP"/>
+        </ParasiteDragProps>
+        <PropGeom>
+          <MaxGrowth Value="1.963769402454648594e+00" ID="YBBMBVUVDJP"/>
+          <SmallPanelW Value="3.132476266568270744e-04" ID="KAWGJFYBIWB"/>
+        </PropGeom>
+        <Shape>
+          <Tess_U Value="1.200000000000000000e+01" ID="HACETIMCBPN"/>
+          <Tess_W Value="1.700000000000000000e+01" ID="IGRLJLLLQYD"/>
+          <Wake Value="0.000000000000000000e+00" ID="DKHNJDJAETU"/>
+        </Shape>
+        <Sym>
+          <Sym_Ancestor Value="4.000000000000000000e+00" ID="NWVVIDARFMD"/>
+          <Sym_Ancestor_Origin_Flag Value="0.000000000000000000e+00" ID="KMBJBZXUKFW"/>
+          <Sym_Axial_Flag Value="0.000000000000000000e+00" ID="QXPZZQDXXCU"/>
+          <Sym_Planar_Flag Value="0.000000000000000000e+00" ID="PGBHAOJNZSV"/>
+          <Sym_Rot_N Value="2.000000000000000000e+00" ID="DOWQOFGZNCE"/>
+        </Sym>
+        <WakeSettings>
+          <WakeAngle Value="0.000000000000000000e+00" ID="ABZAZYHCQHR"/>
+          <WakeScale Value="2.000000000000000000e+00" ID="TBGKKGAKFPK"/>
+        </WakeSettings>
+        <XForm>
+          <Abs_Or_Relitive_flag Value="1.000000000000000000e+00" ID="KXTNPKPOEAY"/>
+          <Last_Scale Value="1.000000000000000000e+00" ID="HIBCARVKVES"/>
+          <Origin Value="0.000000000000000000e+00" ID="ZDPUFMGYKLN"/>
+          <Scale Value="1.000000000000000000e+00" ID="LFXFSFSHYJC"/>
+          <X_Location Value="3.045950166434353790e+00" ID="LQOCWVWSLOY"/>
+          <X_Rel_Location Value="2.009514529718575915e+00" ID="BVCYMZSTJGW"/>
+          <X_Rel_Rotation Value="0.000000000000000000e+00" ID="FITVKXGRCSE"/>
+          <X_Rotation Value="0.000000000000000000e+00" ID="LHUCSUNLZOF"/>
+          <Y_Location Value="-1.602999999999999980e+00" ID="KITGAFFWNXK"/>
+          <Y_Rel_Location Value="0.000000000000000000e+00" ID="NKHUQDDKNZD"/>
+          <Y_Rel_Rotation Value="9.000000000000000000e+01" ID="YOJEHFYGQVX"/>
+          <Y_Rotation Value="9.000000000000000000e+01" ID="XUDXVOZHMQJ"/>
+          <Z_Location Value="6.821329609956905404e-01" ID="NTSEAOWZUNC"/>
+          <Z_Rel_Location Value="3.083624691924118366e-01" ID="FYHMNWUJCAY"/>
+          <Z_Rel_Rotation Value="0.000000000000000000e+00" ID="VBLUWRGWINT"/>
+          <Z_Rotation Value="0.000000000000000000e+00" ID="VYYPKRMWHDM"/>
+        </XForm>
+      </ParmContainer>
+      <GeomBase>
+        <TypeName>Propeller</TypeName>
+        <TypeID>11</TypeID>
+        <TypeFixed>0</TypeFixed>
+        <ParentID>OFLJSHOFTB</ParentID>
+        <Child_List/>
+      </GeomBase>
+      <Material>
+        <Name>Default</Name>
+      </Material>
+      <Wire_Color>
+        <ParmContainer>
+          <ID>PERBRVZLQE</ID>
+          <Name>Default</Name>
+          <Color_Parm>
+            <Alpha Value="2.550000000000000000e+02" ID="XHTWGRTSEKG"/>
+            <Blue Value="2.550000000000000000e+02" ID="IDBNWHJMCLY"/>
+            <Green Value="0.000000000000000000e+00" ID="PTGBVESDPFB"/>
+            <Red Value="0.000000000000000000e+00" ID="COBSLPNUUNA"/>
+          </Color_Parm>
+        </ParmContainer>
+      </Wire_Color>
+      <Textures>
+        <Num_of_Tex>0</Num_of_Tex>
+      </Textures>
+      <Geom>
+        <Set_List>1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, </Set_List>
+        <SubSurfaces/>
+        <FeaStructures/>
+      </Geom>
+      <PropellerGeom>
+        <ParmContainer>
+          <ID>MQJYSMUKNL</ID>
+          <Name>Default</Name>
+        </ParmContainer>
+        <XSecSurf>
+          <XSec>
+            <ParmContainer>
+              <ID>VHPFTKYTZK</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="2.000000000000000111e-01" ID="GQDYXZBFYMX"/>
+                <RefLength Value="6.999999999999999556e-01" ID="VIQLOADIOJM"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="LSMPLJFWBPY"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>EYJQTOVIZJ</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="KENUGSCITXY"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="LOZQKBRYTQQ"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="HHOGHTUMKKS"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="JGGJQXLTKTO"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="UBNZEAFXLLU"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="UBNVDZJKNSM"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="LIYXVAXIQNQ"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="XOZFCPZWKAV"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="KXOHBZCCBIK"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="BQLIAKUHCAH"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="ENUSOJKKSKS"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="NUTVKYAKBQB"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="VJSXNGZOMFX"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="VTMNFKWRDDK"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="LDRYYTCQENZ"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="NRZQLZTPSWF"/>
+                    <Number Value="8.000000000000000000e+00" ID="MVWBTUFMKVR"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="UBUJLLCEYKF"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="CHNKTNIMLUW"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="KRLWWHFRZGB"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="ITQIYZCAMSM"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="BBFMTDXYJTD"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="UAZATBSOVQD"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="BVPCBSHPTVH"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="XKMLEMYRQXS"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="MWHRNESDTMH"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="AIKFBSYHDDI"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="CTVJKWOWPER"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="CHQYDPJRWDG"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="YXRPYGCNZNG"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="IKOWOKDPSGF"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="AZKIIERZSXC"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="SWZKSNPYSAQ"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="XWSHOWCRRKR"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="MTDTHCMTEQI"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="SBGOZJHEDDJ"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="YRPZOSANLXM"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="FELBEYGLEXC"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="BNXASDOXYAW"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="VTDWJPQVGAT"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="DOATCQALUXA"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="UQUCULEVXWZ"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="JESKIETCHMC"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="RYDOJQJJUOO"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="PKJXUYPGFQQ"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="KFRHOZZFROL"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="CSDEGQYZESH"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="KLVFWGFDISP"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="WOCTLATVVGO"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="YUZCVUBIJKD"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="EHBSJVTQMOD"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="UBQTGYLWCAP"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="QOYLXXHGBPJ"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="RYUJEQGKQMP"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="YSMQEZLYROO"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="YFEDOFRYMCQ"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="XYYZCBQHQUF"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="1.231597337353149179e-03" ID="FCRKZVAOEEK"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="JFPUQFTYRCJ"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="XTNUOUDVRRR"/>
+                    <Ellipse_Height Value="2.799999999999999711e-02" ID="HCNCHIUJULV"/>
+                    <Ellipse_Width Value="5.599999999999999423e-02" ID="HJBRVGYDPTH"/>
+                    <HWRatio Value="5.000000000000000000e-01" ID="QCCZDOGMZOC"/>
+                    <Scale Value="1.000000000000000000e+00" ID="YRGWMYYGUOV"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="VFNTCJOVTGS"/>
+                    <Theta Value="0.000000000000000000e+00" ID="IJACKKSKYBE"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="IHMEVSSPLQI"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="PFHJNPDXTVV"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="NPICWFYHNLN"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="VQRFQLADDWT"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="KUYPCKJBWIN"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="JGLCILTHWME"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="WHHVLSFRIEB"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="VZCTSXIVYNG"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>2</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>WCOOOOPMKE</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="4.000009999999999954e-01" ID="SUDRSSHHYCI"/>
+                <RefLength Value="6.999999999999999556e-01" ID="WGPQNDOEVIE"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="NUCCBYQHGSC"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>UMZSBFQMVO</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="KHWLWGSGZNZ"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="YPGNFASNEYO"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="FUDQCLJQJNH"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="FUWFSPGPRMZ"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="PJCBRYWSGPM"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="CBQREAYFPWC"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="WVPSJPVJNQG"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="HQSTCWOHGPZ"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="RZXUIXCOVXQ"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="KTROBTGCQNS"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="ZIFCMOIMEBS"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="GJJSEJFUDFG"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="MHZMKLYWECQ"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="KORMNOQBTKJ"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="ETOMIVCLCNT"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="RUUMZSWMVTN"/>
+                    <Number Value="8.000000000000000000e+00" ID="IUKJIFYUNYJ"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="XPKWULSGQAT"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="ZENXBOCTRWY"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="UWLIBZPCYVL"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="JUAWDDOPZVZ"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="AAVWAEXUKWB"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="LGIQWYXZFHD"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="AGQWLZPLZSD"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="UKWFJFMQHUJ"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="QLQECNHPBAF"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="URLUUOIRHWE"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="FEPZSHTBUQY"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="WHUFOBMBJCE"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="ONBRPLDODOR"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="UGNHCLETQVD"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="OGZULBZZIOU"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="VFPIIEEJDKP"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="GANBPUFDFNE"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="LDDAFXFRAWH"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="XEBOQEGKTTB"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="XXNAVPEUWXA"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="CETWNXHWTBQ"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="APADVHDMNHX"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="HMJQHDEZGZJ"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="UIBSCTFPLLE"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="JJLGLRXJUSS"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="WWPNZNSOEJE"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="VAJVOCALEFH"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="QMIJVZELSTQ"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="RPQFUKDQVHV"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="CZGPDQKHVTM"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="VRXXOTOBUPH"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="WQBXISNBHTE"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="SLQUJQNPBBA"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="CPRUTZKEDCQ"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="PPTTKHVOSPI"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="XHBVPJPIWVR"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="OPDNWKNWTIQ"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="XCVYMLFPUST"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="MWEPNWOZNWN"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="YSQPDAMGYCZ"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="1.982433088306019206e-03" ID="GYHVWPARMYD"/>
+                    <Chord Value="1.163752231245406277e-01" ID="FIODPNFIBCD"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="KSBOMOQSUVE"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="TYAEUYAGKBQ"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="BNMUADDOPZN"/>
+                    <HWRatio Value="2.000371431728833194e-01" ID="VMWLLWDEYOL"/>
+                    <IdealCl Value="6.999999999152259900e-01" ID="RFVKLGWSQKT"/>
+                    <Invert Value="0.000000000000000000e+00" ID="KZAOJQUQTOV"/>
+                    <Scale Value="1.000000000000000000e+00" ID="BYXQTBRXSSX"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="DMBZTOYQJLI"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="EPBWIMEQRSL"/>
+                    <Theta Value="0.000000000000000000e+00" ID="KFICWYKWLWW"/>
+                    <ThickChord Value="2.000371431728833194e-01" ID="FUDAQUTGSNS"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="JXUUQVVDRHK"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="VQZHHPOHSEN"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="OZPVSEFYDOB"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="WPCDPQMTYFM"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="BTHRVUMXNMV"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="YAJXNIXRDQS"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="NFQVNRCWARZ"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="AQQACDVXJTF"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>18</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>JJHSKBIRXM</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="1.000000000000000000e+00" ID="DXHANWLLCBB"/>
+                <RefLength Value="6.999999999999999556e-01" ID="PYIQPEFGFPG"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="WZYMODLUHNH"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>OOEWBTRBST</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="WQYWMNRDOPB"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="RPVZCCWLYDQ"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="SAPGPERSXFQ"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="SZAFNRFCBAZ"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="EKWVKJLDIIV"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="SSOMOQEHKGS"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="GZWTIZSLLBY"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="JRZQAMGTXGH"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="LYSDLOCVXJL"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="AUXPYEVEURE"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="UWRUIUTFWCA"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="IYBGAEPROHB"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="MCTAVSNKEXM"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="RFXIMUYRFLE"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="WIFMTQYSQLH"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="NYAALFQDFUW"/>
+                    <Number Value="8.000000000000000000e+00" ID="UWWDHSFFZJM"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="MIFFWQUAISF"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="YUYKZNGOMWW"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="OCRVWTPZYFV"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="PXOXQEHWYEF"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="WZTFZNVCGAD"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="WOEEFGXOBPB"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="VMNQBRERYCS"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="TJIPTDVSDIC"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="KFHFRDSUGGY"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="PANMMFHEBOJ"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="WUIGSDABYTN"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="XVIZVQJKOBN"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="IEIPVNYMKUE"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="PEAOKSWUQNQ"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="ZYTGZQGKOFW"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="FCZMPJLNEWH"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="ULYOHMFJNLL"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="JYPHZXZHXYF"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="BMURDZYMODM"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="NHRSQMMSFBM"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="IHSDDNUIBRS"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="MALUFVCDKYU"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="AHNKPCJUMRA"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="RSHITILFBDL"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="AVCQUECCHXQ"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="WBPDDOFZHHP"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="NCDSFKFYAGS"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="LUCDXRBPLQZ"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="CQKHDSNXMEH"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="JELQCDSNWQH"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="CFXAAFSGVMZ"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="CLFQWIQERHB"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="WPGXNUNBHUG"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="NUBXAWUSQVU"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="XZHSDXAJOCU"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="PBXKEGPHJYE"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="TSMERJOFYIJ"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="IPCGOBHHZBP"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="ATFXQODWAWE"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="RXVNDMUZFFO"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="1.813775732647776432e-04" ID="FPJKJGUQFZN"/>
+                    <Chord Value="9.099999999999999756e-02" ID="UYCDETSKKEO"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="AAPBDJPBZWN"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="IRCKWBQSOLZ"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="UDHBWJEQEDV"/>
+                    <HWRatio Value="2.999999999999999889e-02" ID="XZYPNYYGCGC"/>
+                    <IdealCl Value="2.000000000000000111e-01" ID="UAUBMZHNZGN"/>
+                    <Invert Value="0.000000000000000000e+00" ID="BIVWSOHGJKO"/>
+                    <Scale Value="1.000000000000000000e+00" ID="MTOSVYOOTQS"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="QFJSDITAEAK"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="BRQFSVZBEFC"/>
+                    <Theta Value="0.000000000000000000e+00" ID="SLWQTSVZCNT"/>
+                    <ThickChord Value="2.999999999999999889e-02" ID="CTYHTJLPRBP"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="FPOKOSWNKOS"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="YMDTPSMMIGE"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="HMNVJTNLHTK"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="TQZUCAPLWTQ"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="RATIIKSMGZO"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="JPSTNPIBMMG"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="MHKERNWBVEZ"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="VSUMWQSSGSE"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>18</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+        </XSecSurf>
+        <Chord>
+          <PCurve>
+            <NumPts>10</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>FFFKYYCGOD</ID>
+            <Name>PCurve</Name>
+            <Chord>
+              <ConvType Value="2.000000000000000000e+00" ID="VDNKWNECMJJ"/>
+              <CrvType Value="2.000000000000000000e+00" ID="TLAGZTRBHGY"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="TRBZZKEHMRG"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="GPERKIMMURB"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="YTKVWHYGKXF"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="WZWJPNQRHCW"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="MKXSPDWWZFD"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="CVAXRMRUUAA"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="GKASYQGRIKH"/>
+              <G1_7 Value="0.000000000000000000e+00" ID="BIAIZTRTVPA"/>
+              <G1_8 Value="0.000000000000000000e+00" ID="WQJNAZHEXRV"/>
+              <G1_9 Value="0.000000000000000000e+00" ID="DHZCOASHAHZ"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="KWJNHSRDNLK"/>
+              <crd_0 Value="8.000000000000000167e-02" ID="YXDTTYOLCYL"/>
+              <crd_1 Value="1.499999999999999944e-01" ID="FPVINGVHWRQ"/>
+              <crd_2 Value="2.000000000000000111e-01" ID="ROVENZIKOTM"/>
+              <crd_3 Value="2.000000000000000111e-01" ID="YSDBQLATABK"/>
+              <crd_4 Value="2.000000000000000111e-01" ID="ICAMUDYMTPD"/>
+              <crd_5 Value="2.000000000000000111e-01" ID="AGJBBJKVYJX"/>
+              <crd_6 Value="2.000000000000000111e-01" ID="JHCCMSUXOAW"/>
+              <crd_7 Value="2.000000000000000111e-01" ID="WBYXBKPRDUL"/>
+              <crd_8 Value="2.000000000000000111e-01" ID="XOABRALAJZB"/>
+              <crd_9 Value="1.300000000000000044e-01" ID="HYNCNVMCEYI"/>
+              <r_0 Value="2.000000000000000111e-01" ID="RWEDDACFQHZ"/>
+              <r_1 Value="3.333333333333333703e-01" ID="IGDBUZOZVJE"/>
+              <r_2 Value="4.666666666666666741e-01" ID="WGXFXSGDDEV"/>
+              <r_3 Value="5.999999999999999778e-01" ID="LPGOXFPXCSX"/>
+              <r_4 Value="7.166666666666666741e-01" ID="CZOHURNRCXX"/>
+              <r_5 Value="8.333333333333332593e-01" ID="OIUUIJJLRYS"/>
+              <r_6 Value="9.499999999999999556e-01" ID="QQHSOGBCTDH"/>
+              <r_7 Value="9.666666666666666741e-01" ID="QEDTTLXBQEU"/>
+              <r_8 Value="9.833333333333332815e-01" ID="FAMREJJWXAQ"/>
+              <r_9 Value="1.000000000000000000e+00" ID="YMEDYTBAOMA"/>
+            </Chord>
+          </ParmContainer>
+        </Chord>
+        <Twist>
+          <PCurve>
+            <NumPts>7</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>EDBEFAHANH</ID>
+            <Name>PCurve</Name>
+            <Twist>
+              <ConvType Value="2.000000000000000000e+00" ID="NXRXZSCAGEE"/>
+              <CrvType Value="2.000000000000000000e+00" ID="IABFXHGLNUP"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="GOCGQNJLBII"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="KJYCOADPSQT"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="KOETSYDMRSN"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="ZYSNPEMSGVO"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="CSDECIZNJJQ"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="GSZJJPNETYW"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="GXMRPNLBYTL"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="XGIVXBWZGDH"/>
+              <r_0 Value="2.000000000000000111e-01" ID="ZYMUXTPAQFE"/>
+              <r_1 Value="3.344706911636046165e-01" ID="EXLEHSBZGBH"/>
+              <r_2 Value="4.689413823272091664e-01" ID="PHOKXQFKVOT"/>
+              <r_3 Value="6.034120734908137162e-01" ID="EHULKOBUCZK"/>
+              <r_4 Value="7.356080489938757738e-01" ID="JQMIKRLGWZK"/>
+              <r_5 Value="8.678040244969379424e-01" ID="JWUROYMBSVW"/>
+              <r_6 Value="1.000000000000000000e+00" ID="HMMLREEFRWL"/>
+              <tw_0 Value="3.116666666666666785e+01" ID="NOIHOTMUFFA"/>
+              <tw_1 Value="2.342592592592592382e+01" ID="VZFZETFJXDK"/>
+              <tw_2 Value="2.077777777777777857e+01" ID="KYNKXAAAOXE"/>
+              <tw_3 Value="1.874074074074074048e+01" ID="VWCSBCCYRGK"/>
+              <tw_4 Value="1.670370370370370594e+01" ID="UYQNKRUHOUN"/>
+              <tw_5 Value="1.548148148148148096e+01" ID="SKQEJFEJZUC"/>
+              <tw_6 Value="1.425925925925925952e+01" ID="MNZURAOVDZJ"/>
+            </Twist>
+          </ParmContainer>
+        </Twist>
+        <Rake>
+          <PCurve>
+            <NumPts>2</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>MOWNHVDCKT</ID>
+            <Name>PCurve</Name>
+            <Rake>
+              <ConvType Value="2.000000000000000000e+00" ID="KZCTMGRBVAW"/>
+              <CrvType Value="0.000000000000000000e+00" ID="UJSCWLNCEBM"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="BZXIORUDGVR"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="PWTGNIBTAWT"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="NUMOADOPKIC"/>
+              <r_0 Value="2.000000000000000111e-01" ID="JQSIDRYCCOA"/>
+              <r_1 Value="1.000000000000000000e+00" ID="PKOISNKGRJL"/>
+              <rak_0 Value="0.000000000000000000e+00" ID="MZXRFJVRWZE"/>
+              <rak_1 Value="0.000000000000000000e+00" ID="WJGDKCCLXYW"/>
+            </Rake>
+          </ParmContainer>
+        </Rake>
+        <Skew>
+          <PCurve>
+            <NumPts>2</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>HPUYLPDBEJ</ID>
+            <Name>PCurve</Name>
+            <Skew>
+              <ConvType Value="2.000000000000000000e+00" ID="UMJXSUMFKQI"/>
+              <CrvType Value="0.000000000000000000e+00" ID="SUGUUXMRRSZ"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="BJSMZAIXJKU"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="TXTVBSKWVAR"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="TFSUFBNPWWB"/>
+              <r_0 Value="2.000000000000000111e-01" ID="GLEHVDMZXYU"/>
+              <r_1 Value="1.000000000000000000e+00" ID="KNIYNNVMUCP"/>
+              <skw_0 Value="0.000000000000000000e+00" ID="MFADZCAUURK"/>
+              <skw_1 Value="0.000000000000000000e+00" ID="IQKKNTSHTJH"/>
+            </Skew>
+          </ParmContainer>
+        </Skew>
+        <Sweep>
+          <PCurve>
+            <NumPts>2</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>BDKRRFQZOO</ID>
+            <Name>PCurve</Name>
+            <Sweep>
+              <ConvType Value="2.000000000000000000e+00" ID="VZGLOYDDXZQ"/>
+              <CrvType Value="0.000000000000000000e+00" ID="FMXHKGOYWER"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="CGIGUPUYPHA"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="RCMBZKJDCXN"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="SMMBDLNOMDP"/>
+              <r_0 Value="2.000000000000000111e-01" ID="DZPBXJBTQEM"/>
+              <r_1 Value="1.000000000000000000e+00" ID="BCIRNTKFDHN"/>
+              <sw_0 Value="0.000000000000000000e+00" ID="ZZKHNUUWETE"/>
+              <sw_1 Value="0.000000000000000000e+00" ID="GGVQTJEDGJT"/>
+            </Sweep>
+          </ParmContainer>
+        </Sweep>
+        <Thick>
+          <PCurve>
+            <NumPts>10</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>UXPAZYHZSF</ID>
+            <Name>PCurve</Name>
+            <Thick>
+              <ConvType Value="2.000000000000000000e+00" ID="QQOXYATHSBY"/>
+              <CrvType Value="2.000000000000000000e+00" ID="IVNKMXLRJIK"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="KMKRHKHPWNX"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="LNXXAWMSKRF"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="YTIPBSWBUUS"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="ETBBROUMYYZ"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="SLPJFNCZNWI"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="NYWKIZLSCNO"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="NLBCFMORTMH"/>
+              <G1_7 Value="0.000000000000000000e+00" ID="RVIAPMZSSEU"/>
+              <G1_8 Value="0.000000000000000000e+00" ID="PFTQJQJUZMR"/>
+              <G1_9 Value="0.000000000000000000e+00" ID="RDNFTOZPRQX"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="KWMAAILINBH"/>
+              <r_0 Value="2.000000000000000111e-01" ID="TIQCNACRXXP"/>
+              <r_1 Value="2.666999999999999926e-01" ID="WFUVSEHOFLA"/>
+              <r_2 Value="3.334000000000000297e-01" ID="KSMNRZVSDVS"/>
+              <r_3 Value="4.001000000000000112e-01" ID="LKXHVBJDHDL"/>
+              <r_4 Value="4.667333333333333334e-01" ID="GBEBEPUOEKJ"/>
+              <r_5 Value="5.333666666666666556e-01" ID="TUOZPGKZHYW"/>
+              <r_6 Value="5.999999999999999778e-01" ID="JTOLDXOXKEH"/>
+              <r_7 Value="7.333333333333332815e-01" ID="YTACSHNRJZJ"/>
+              <r_8 Value="8.666666666666666963e-01" ID="NESJFWENFBL"/>
+              <r_9 Value="1.000000000000000000e+00" ID="SKYZWGYQMQI"/>
+              <toc_0 Value="5.000000000000000000e-01" ID="HVTQCHJFBBM"/>
+              <toc_1 Value="2.999999999999999889e-01" ID="MPDAPIOSSRB"/>
+              <toc_2 Value="2.250000000000000056e-01" ID="MQCRYGAVNVW"/>
+              <toc_3 Value="2.000000000000000111e-01" ID="XHAUBQKFRVE"/>
+              <toc_4 Value="1.250000000000000000e-01" ID="YVBNEQUKWWG"/>
+              <toc_5 Value="1.150000000000000050e-01" ID="UENUCCLAIYW"/>
+              <toc_6 Value="1.000000000000000056e-01" ID="YCILBLSJRFZ"/>
+              <toc_7 Value="7.499999999999999722e-02" ID="CNBBDKUNVMC"/>
+              <toc_8 Value="5.500000000000000028e-02" ID="IJBLAJLGHTH"/>
+              <toc_9 Value="2.999999999999999889e-02" ID="TCXEORQHILO"/>
+            </Thick>
+          </ParmContainer>
+        </Thick>
+        <CLI>
+          <PCurve>
+            <NumPts>10</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>EPPTRVADCE</ID>
+            <Name>PCurve</Name>
+            <CLI>
+              <ConvType Value="2.000000000000000000e+00" ID="PATZFSOAGTH"/>
+              <CrvType Value="2.000000000000000000e+00" ID="MUNLBTHUZFD"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="OXTETRAABOW"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="JTYPQNXEQMK"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="CDINJCUVPKO"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="CXHWWNHOICM"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="SMGQUKRRTQZ"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="FOFYTWTUPGX"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="RMZPZBHUCUP"/>
+              <G1_7 Value="0.000000000000000000e+00" ID="TTIGTTOBCPW"/>
+              <G1_8 Value="0.000000000000000000e+00" ID="KHOBMNUUVFT"/>
+              <G1_9 Value="0.000000000000000000e+00" ID="WVOVPLTGCPX"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="TTRTGVPURLL"/>
+              <cli_0 Value="0.000000000000000000e+00" ID="SNRCEVARMIN"/>
+              <cli_1 Value="6.999999999999999556e-01" ID="AKWFWKTHGAC"/>
+              <cli_2 Value="6.999999999999999556e-01" ID="OVCSYCDACMG"/>
+              <cli_3 Value="6.999999999999999556e-01" ID="GFQBPSAMUGD"/>
+              <cli_4 Value="6.999999999999999556e-01" ID="UOYGOJQWVKG"/>
+              <cli_5 Value="6.999999999999999556e-01" ID="ZWMQGQKXBZN"/>
+              <cli_6 Value="6.999999999999999556e-01" ID="SLSSJKHVVFI"/>
+              <cli_7 Value="6.999999999999999556e-01" ID="GBJHFFVGGTC"/>
+              <cli_8 Value="6.999999999999999556e-01" ID="OALHGTZPUZN"/>
+              <cli_9 Value="2.000000000000000111e-01" ID="VHXJPJCWVXI"/>
+              <r_0 Value="2.000000000000000111e-01" ID="EAVUGNZNQPO"/>
+              <r_1 Value="2.666999999999999926e-01" ID="PLKTYPJWYJE"/>
+              <r_2 Value="3.334000000000000297e-01" ID="ERHVSARHBZC"/>
+              <r_3 Value="4.001000000000000112e-01" ID="ARHILKNAFIH"/>
+              <r_4 Value="4.667333333333333334e-01" ID="HUSRVTKUNZE"/>
+              <r_5 Value="5.333666666666666556e-01" ID="VLVQOFHYRZH"/>
+              <r_6 Value="5.999999999999999778e-01" ID="FRKPIDOALKU"/>
+              <r_7 Value="7.333333333333332815e-01" ID="FFDGMPAMVNK"/>
+              <r_8 Value="8.666666666666666963e-01" ID="GJDAYMAXNPS"/>
+              <r_9 Value="1.000000000000000000e+00" ID="QCPQYHEVNRT"/>
+            </CLI>
+          </ParmContainer>
+        </CLI>
+        <Axial>
+          <PCurve>
+            <NumPts>2</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>QHSLXWRFDG</ID>
+            <Name>PCurve</Name>
+            <Axial>
+              <ConvType Value="2.000000000000000000e+00" ID="SRAFVQKGIUX"/>
+              <CrvType Value="0.000000000000000000e+00" ID="CBDAHSQTXGA"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="JJWNTLTTPSU"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="CDXHFGOOIYG"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="KVLLYCLWAET"/>
+              <ax_0 Value="0.000000000000000000e+00" ID="QDJRKQKPLWT"/>
+              <ax_1 Value="0.000000000000000000e+00" ID="RLWLDBXFRIM"/>
+              <r_0 Value="2.000000000000000111e-01" ID="JOVUFDPODAE"/>
+              <r_1 Value="1.000000000000000000e+00" ID="XDJKMOQXUUR"/>
+            </Axial>
+          </ParmContainer>
+        </Axial>
+        <Tangential>
+          <PCurve>
+            <NumPts>2</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>XJSOHQOEKA</ID>
+            <Name>PCurve</Name>
+            <Tangential>
+              <ConvType Value="2.000000000000000000e+00" ID="MIBTJEOYJSH"/>
+              <CrvType Value="0.000000000000000000e+00" ID="TROYDFSHMRT"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="MIJLPPLRFAI"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="QVHFNVAWZBB"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="IITHXBCKWFK"/>
+              <r_0 Value="2.000000000000000111e-01" ID="OPICYBTUSUO"/>
+              <r_1 Value="1.000000000000000000e+00" ID="LFAGWCIVBLY"/>
+              <tan_0 Value="0.000000000000000000e+00" ID="CEDDBGPPUGW"/>
+              <tan_1 Value="0.000000000000000000e+00" ID="CEUZJOLSOOH"/>
+            </Tangential>
+          </ParmContainer>
+        </Tangential>
+      </PropellerGeom>
+    </Geom>
+    <Geom>
+      <ParmContainer>
+        <ID>CXSHPYTTOU</ID>
+        <Name>HingeGeom_2</Name>
+        <Attach>
+          <Eta_Attach_Location Value="0.000000000000000000e+00" ID="URPFLBBXRSR"/>
+          <L_01 Value="1.000000000000000000e+00" ID="DAPWVCBXAVB"/>
+          <L_Attach_Location Value="0.000000000000000000e+00" ID="PLMOOMSTJMA"/>
+          <L_Attach_Location0Len Value="0.000000000000000000e+00" ID="BUEBGJTOLSS"/>
+          <M_Attach_Location Value="5.000000000000000000e-01" ID="FWZYKDOKOKV"/>
+          <N_Attach_Location Value="5.000000000000000000e-01" ID="JOKOWRPVNVZ"/>
+          <R_01 Value="1.000000000000000000e+00" ID="HKTCGHMHYUT"/>
+          <R_Attach_Location Value="0.000000000000000000e+00" ID="WPCHJEDDGML"/>
+          <R_Attach_Location0N Value="0.000000000000000000e+00" ID="RCNDPFPEQGV"/>
+          <Rots_Attach_Flag Value="1.000000000000000000e+00" ID="EBEBPALJFSZ"/>
+          <S_Attach_Location Value="5.000000000000000000e-01" ID="LTOQOMCZYHI"/>
+          <T_Attach_Location Value="5.000000000000000000e-01" ID="TDLOPCITRMC"/>
+          <Trans_Attach_Flag Value="1.000000000000000000e+00" ID="PUDPGDPDRCZ"/>
+          <U_01 Value="1.000000000000000000e+00" ID="VCRURFDPDFE"/>
+          <U_Attach_Location Value="0.000000000000000000e+00" ID="VBZQSQJDCBO"/>
+          <U_Attach_Location0N Value="0.000000000000000000e+00" ID="NJGFDNDHACK"/>
+          <V_Attach_Location Value="0.000000000000000000e+00" ID="WRJFYCWIWOX"/>
+        </Attach>
+        <BBox>
+          <X_Len Value="0.000000000000000000e+00" ID="XPWMOHZBLPR"/>
+          <X_Min Value="0.000000000000000000e+00" ID="QKLFXRXUYIZ"/>
+          <Y_Len Value="0.000000000000000000e+00" ID="DSNFXSGMXAC"/>
+          <Y_Min Value="0.000000000000000000e+00" ID="GVMPGQYKANV"/>
+          <Z_Len Value="0.000000000000000000e+00" ID="DYKLTKBOSKA"/>
+          <Z_Min Value="0.000000000000000000e+00" ID="PANJECKBLSH"/>
+        </BBox>
+        <EndCap>
+          <CapUMaxLength Value="1.000000000000000000e+00" ID="GKZQMTVFNRX"/>
+          <CapUMaxOffset Value="0.000000000000000000e+00" ID="RZTCZOQXMQL"/>
+          <CapUMaxOption Value="0.000000000000000000e+00" ID="UWDASTISXAA"/>
+          <CapUMaxStrength Value="5.000000000000000000e-01" ID="VYAWUHBBBQC"/>
+          <CapUMaxSweepFlag Value="0.000000000000000000e+00" ID="SWZUGVHITHU"/>
+          <CapUMinLength Value="1.000000000000000000e+00" ID="UZZBFSZMKKY"/>
+          <CapUMinOffset Value="0.000000000000000000e+00" ID="RQHUBTNCOYY"/>
+          <CapUMinOption Value="0.000000000000000000e+00" ID="WELUDTIRIGM"/>
+          <CapUMinStrength Value="5.000000000000000000e-01" ID="CWFTSXHYZER"/>
+          <CapUMinSweepFlag Value="0.000000000000000000e+00" ID="BQURZSXDQBJ"/>
+          <CapUMinTess Value="3.000000000000000000e+00" ID="CRXTFAUFVAI"/>
+        </EndCap>
+        <Hinge>
+          <JointRotMax Value="3.600000000000000000e+02" ID="IUJIKLXKVXX"/>
+          <JointRotMaxFlag Value="0.000000000000000000e+00" ID="OTGEPOVVAKF"/>
+          <JointRotMin Value="-3.600000000000000000e+02" ID="TXVQJTQMLXV"/>
+          <JointRotMinFlag Value="0.000000000000000000e+00" ID="KNWLNSBYWDI"/>
+          <JointRotate Value="0.000000000000000000e+00" ID="UGOMZXEGPUQ"/>
+          <JointRotateFlag Value="1.000000000000000000e+00" ID="NXFKBGMVWPB"/>
+          <JointTransMax Value="1.000000000000000000e+03" ID="QWPMVEWQQKN"/>
+          <JointTransMaxFlag Value="0.000000000000000000e+00" ID="IZUANZOSGZR"/>
+          <JointTransMin Value="-1.000000000000000000e+03" ID="YMLLPZZPGEW"/>
+          <JointTransMinFlag Value="0.000000000000000000e+00" ID="GHISEEPHJAW"/>
+          <JointTranslate Value="0.000000000000000000e+00" ID="BKBCSUFOTUI"/>
+          <JointTranslateFlag Value="0.000000000000000000e+00" ID="AANKREKCFGF"/>
+          <OrientRotFlag Value="0.000000000000000000e+00" ID="GVJYECJIIIM"/>
+          <PrimOffAbsRelFlag Value="1.000000000000000000e+00" ID="LJJWJIPHBCU"/>
+          <PrimType Value="0.000000000000000000e+00" ID="TFMDNTPSEUA"/>
+          <PrimULoc Value="0.000000000000000000e+00" ID="BNIAYIFUBEI"/>
+          <PrimVecAbsRelFlag Value="1.000000000000000000e+00" ID="TRETBFKWUSN"/>
+          <PrimWLoc Value="0.000000000000000000e+00" ID="PAZAYKJZIIM"/>
+          <PrimXOff Value="0.000000000000000000e+00" ID="TLZTQMPRXHC"/>
+          <PrimXOffRel Value="0.000000000000000000e+00" ID="UXFJPYFRVYZ"/>
+          <PrimXVec Value="0.000000000000000000e+00" ID="PDSNIWPAVZA"/>
+          <PrimXVecRel Value="0.000000000000000000e+00" ID="XZMAFOXPCXG"/>
+          <PrimYOff Value="0.000000000000000000e+00" ID="ZHSWQHTHAPP"/>
+          <PrimYOffRel Value="0.000000000000000000e+00" ID="IPKHPTDKBHO"/>
+          <PrimYVec Value="1.000000000000000000e+00" ID="ROVQXMMHYAZ"/>
+          <PrimYVecRel Value="1.000000000000000000e+00" ID="PZQOWORBCNG"/>
+          <PrimZOff Value="0.000000000000000000e+00" ID="FPROMKZISUH"/>
+          <PrimZOffRel Value="0.000000000000000000e+00" ID="XENXJZFIXCT"/>
+          <PrimZVec Value="0.000000000000000000e+00" ID="GPJIKQCDKVM"/>
+          <PrimZVecRel Value="0.000000000000000000e+00" ID="NGUHSVNDSDJ"/>
+          <PrimaryDir Value="1.000000000000000000e+00" ID="BVFSHWUUPWG"/>
+          <SecVecAbsRelFlag Value="1.000000000000000000e+00" ID="TKYWKTBFBCC"/>
+          <SecondaryDir Value="0.000000000000000000e+00" ID="EUEQGIVKQRB"/>
+          <SecondaryVecDir Value="1.000000000000000000e+00" ID="NGNDDEVUFYI"/>
+        </Hinge>
+        <Mass_Props>
+          <CGx Value="0.000000000000000000e+00" ID="GWZBWYIOQPF"/>
+          <CGy Value="0.000000000000000000e+00" ID="EXKRBMPLOHI"/>
+          <CGz Value="0.000000000000000000e+00" ID="RYXTZEDVQTD"/>
+          <Density Value="1.000000000000000000e+00" ID="PISLLSCGINW"/>
+          <Ixx Value="0.000000000000000000e+00" ID="UEFNDSCFNJW"/>
+          <Ixy Value="0.000000000000000000e+00" ID="WOYQRWPLYPV"/>
+          <Ixz Value="0.000000000000000000e+00" ID="LTWMSMFAAMS"/>
+          <Iyy Value="0.000000000000000000e+00" ID="RHUWRDMYKVE"/>
+          <Iyz Value="0.000000000000000000e+00" ID="LMAKEAVRQQD"/>
+          <Izz Value="0.000000000000000000e+00" ID="IOROWJLYYWF"/>
+          <Mass_Area Value="1.000000000000000000e+00" ID="JTGSCXZSQBQ"/>
+          <Mass_Prior Value="0.000000000000000000e+00" ID="UQFFCRCTYGF"/>
+          <PointMass Value="0.000000000000000000e+00" ID="SBKJKKKMNQJ"/>
+          <Shell_Flag Value="0.000000000000000000e+00" ID="UOXDPDSBEQC"/>
+        </Mass_Props>
+        <Negative_Volume_Props>
+          <Negative_Volume_Flag Value="0.000000000000000000e+00" ID="LFMPJUYANAN"/>
+        </Negative_Volume_Props>
+        <ParasiteDragProps>
+          <ExpandedList Value="0.000000000000000000e+00" ID="UNNDEUTFJNX"/>
+          <FFBodyEqnType Value="3.000000000000000000e+00" ID="ZYWIZUALNBD"/>
+          <FFUser Value="1.000000000000000000e+00" ID="NWOCRTDXEVI"/>
+          <FFWingEqnType Value="3.000000000000000000e+00" ID="JHSWEKQAGPC"/>
+          <IncorporatedGen Value="0.000000000000000000e+00" ID="WJBFWZFZFPZ"/>
+          <PercLam Value="0.000000000000000000e+00" ID="SBZPYCFPJGC"/>
+          <Q Value="1.000000000000000000e+00" ID="XNOOTEKGSZB"/>
+          <Roughness Value="0.000000000000000000e+00" ID="PLCKABYEWWN"/>
+          <TawTwRatio Value="1.000000000000000000e+00" ID="VHBZLCHGQTS"/>
+          <TeTwRatio Value="1.000000000000000000e+00" ID="XMUJACOGORD"/>
+        </ParasiteDragProps>
+        <Shape>
+          <Tess_U Value="8.000000000000000000e+00" ID="HINXRTRDJCL"/>
+          <Tess_W Value="9.000000000000000000e+00" ID="FOZGJCETAFR"/>
+          <Wake Value="0.000000000000000000e+00" ID="IADOMETIXPI"/>
+        </Shape>
+        <Sym>
+          <Sym_Ancestor Value="2.000000000000000000e+00" ID="HHZYIVUXLNO"/>
+          <Sym_Ancestor_Origin_Flag Value="0.000000000000000000e+00" ID="VRIOTYGHCKE"/>
+          <Sym_Axial_Flag Value="0.000000000000000000e+00" ID="DMCANPPYUSR"/>
+          <Sym_Planar_Flag Value="0.000000000000000000e+00" ID="UHNSTUJZPAC"/>
+          <Sym_Rot_N Value="2.000000000000000000e+00" ID="OOFRUXHFJJS"/>
+        </Sym>
+        <WakeSettings>
+          <WakeAngle Value="0.000000000000000000e+00" ID="UVLVQUOQMGL"/>
+          <WakeScale Value="2.000000000000000000e+00" ID="VSUYSBVGXQM"/>
+        </WakeSettings>
+        <XForm>
+          <Abs_Or_Relitive_flag Value="1.000000000000000000e+00" ID="NKQYTHYXHWG"/>
+          <Last_Scale Value="1.000000000000000000e+00" ID="BAOUBLLELMQ"/>
+          <Origin Value="0.000000000000000000e+00" ID="TJRETDXTBGA"/>
+          <Scale Value="1.000000000000000000e+00" ID="BNZPIFRXLWT"/>
+          <X_Location Value="9.664356367157778127e-01" ID="MIYSQIUCJJX"/>
+          <X_Rel_Location Value="-7.000000000000000666e-02" ID="VEGJCJXAUEI"/>
+          <X_Rel_Rotation Value="0.000000000000000000e+00" ID="XCDWANLDYOH"/>
+          <X_Rotation Value="0.000000000000000000e+00" ID="QETCRUOJEST"/>
+          <Y_Location Value="-1.602999999999999980e+00" ID="PPKHGHFGJRD"/>
+          <Y_Rel_Location Value="0.000000000000000000e+00" ID="SQOJOXAUOLH"/>
+          <Y_Rel_Rotation Value="0.000000000000000000e+00" ID="JLFJEEWGXWN"/>
+          <Y_Rotation Value="0.000000000000000000e+00" ID="UHROFIYRNXA"/>
+          <Z_Location Value="4.737704918032786816e-01" ID="NTKVOUHACVF"/>
+          <Z_Rel_Location Value="1.000000000000000056e-01" ID="UAYZNQTBPUN"/>
+          <Z_Rel_Rotation Value="0.000000000000000000e+00" ID="EYKVCQIUJVR"/>
+          <Z_Rotation Value="0.000000000000000000e+00" ID="XEFDJRZSOCX"/>
+        </XForm>
+      </ParmContainer>
+      <GeomBase>
+        <TypeName>Hinge</TypeName>
+        <TypeID>12</TypeID>
+        <TypeFixed>0</TypeFixed>
+        <ParentID>OFLJSHOFTB</ParentID>
+        <Child_List>
+          <Child>
+            <ID>TJMPKPSRQX</ID>
+          </Child>
+        </Child_List>
+      </GeomBase>
+      <Material>
+        <Name>Default</Name>
+      </Material>
+      <Wire_Color>
+        <ParmContainer>
+          <ID>AYGYWPFTUB</ID>
+          <Name>Default</Name>
+          <Color_Parm>
+            <Alpha Value="2.550000000000000000e+02" ID="QWQBYMJLFMI"/>
+            <Blue Value="2.550000000000000000e+02" ID="OVXKOAIYRIY"/>
+            <Green Value="0.000000000000000000e+00" ID="MBGJLBGSJYL"/>
+            <Red Value="0.000000000000000000e+00" ID="LDSWEFBLKKY"/>
+          </Color_Parm>
+        </ParmContainer>
+      </Wire_Color>
+      <Textures>
+        <Num_of_Tex>0</Num_of_Tex>
+      </Textures>
+      <Geom>
+        <Set_List>1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, </Set_List>
+        <SubSurfaces/>
+        <FeaStructures/>
+      </Geom>
+    </Geom>
+    <Geom>
+      <ParmContainer>
+        <ID>TJMPKPSRQX</ID>
+        <Name>CruiseProp_2</Name>
+        <Attach>
+          <Eta_Attach_Location Value="0.000000000000000000e+00" ID="NNIWIFKLPIC"/>
+          <L_01 Value="1.000000000000000000e+00" ID="AMWJBWJZFLZ"/>
+          <L_Attach_Location Value="0.000000000000000000e+00" ID="OIILWUQAPTS"/>
+          <L_Attach_Location0Len Value="0.000000000000000000e+00" ID="NXZHGHGQWWX"/>
+          <M_Attach_Location Value="-nan(ind)" ID="SGMECQOCAUV"/>
+          <N_Attach_Location Value="5.000000000000000000e-01" ID="TUKPCLAEVOU"/>
+          <R_01 Value="1.000000000000000000e+00" ID="XWHUSGMPPBE"/>
+          <R_Attach_Location Value="0.000000000000000000e+00" ID="UNKZQBECUYV"/>
+          <R_Attach_Location0N Value="0.000000000000000000e+00" ID="TGYWLBWXLHJ"/>
+          <Rots_Attach_Flag Value="1.000000000000000000e+00" ID="ODPZINNBUGB"/>
+          <S_Attach_Location Value="3.125000000000000000e-02" ID="OFQJVMUGHPZ"/>
+          <T_Attach_Location Value="5.000000000000000000e-01" ID="MOBNPBVCNHF"/>
+          <Trans_Attach_Flag Value="1.000000000000000000e+00" ID="AVNTSHTXWMX"/>
+          <U_01 Value="1.000000000000000000e+00" ID="JNAEMGGFVWU"/>
+          <U_Attach_Location Value="0.000000000000000000e+00" ID="TKCHFGWEEOY"/>
+          <U_Attach_Location0N Value="0.000000000000000000e+00" ID="BRKOSANQXBQ"/>
+          <V_Attach_Location Value="9.843750000000000000e-01" ID="JBQVROVLYSX"/>
+        </Attach>
+        <BBox>
+          <X_Len Value="5.161994505472933259e-02" ID="ICTLKEVFZAG"/>
+          <X_Min Value="7.370925252153396334e-01" ID="XSSPDHFLLBF"/>
+          <Y_Len Value="1.293576370307742751e+00" ID="CWCJIXXDWBX"/>
+          <Y_Min Value="-2.195416427797993286e+00" ID="ZCIJLCNDZRW"/>
+          <Z_Len Value="1.351902167440927727e+00" ID="VQHIKYTHOQW"/>
+          <Z_Min Value="-1.990404555078302273e-01" ID="WTNBPTAPTWW"/>
+        </BBox>
+        <Design>
+          <AF Value="1.038843911064995638e+02" ID="NXUQLCEUGXH"/>
+          <AFLimit Value="2.000000000000000111e-01" ID="HGNMISRSDZJ"/>
+          <AxFoldAx Value="0.000000000000000000e+00" ID="OFZFDWMHCTK"/>
+          <AzFoldDir Value="0.000000000000000000e+00" ID="DNCXIRNXSSE"/>
+          <BalanceX1 Value="0.000000000000000000e+00" ID="DKGXYISVJKQ"/>
+          <BalanceX2 Value="0.000000000000000000e+00" ID="GIXHHTOACLV"/>
+          <Beta34 Value="2.000000000000000000e+01" ID="GRZWZUFMZLE"/>
+          <BladeAz_2 Value="7.200000000000000000e+01" ID="BELRZSMRIWK"/>
+          <BladeAz_3 Value="1.440000000000000000e+02" ID="CDXKYEUMHGH"/>
+          <BladeAz_4 Value="2.160000000000000000e+02" ID="OHFERGKCMUA"/>
+          <BladeAz_5 Value="2.880000000000000000e+02" ID="AVWJFACDATE"/>
+          <BladeAzimuthDeltaFlag Value="0.000000000000000000e+00" ID="SRIBKGRLWJQ"/>
+          <BladeAzimuthMode Value="0.000000000000000000e+00" ID="SHPMFXNHLOO"/>
+          <CLi Value="5.387977274373372261e-01" ID="JZUYFRBUVSO"/>
+          <Chord Value="1.324074074074073903e-01" ID="CAKSPVUARBN"/>
+          <ConstructXoC Value="5.000000000000000000e-01" ID="SBMKOEMUONX"/>
+          <CylindricalSectionsFlag Value="0.000000000000000000e+00" ID="JIFTSMMYCEO"/>
+          <DeltaAz_2 Value="0.000000000000000000e+00" ID="FZUNGNUUXAK"/>
+          <DeltaAz_3 Value="0.000000000000000000e+00" ID="JPJGIGEYXYG"/>
+          <DeltaAz_4 Value="0.000000000000000000e+00" ID="LSVAHGNQGVS"/>
+          <DeltaAz_5 Value="0.000000000000000000e+00" ID="GRYAACCULTC"/>
+          <Diameter Value="1.399999999999999911e+00" ID="OLHLSQHPPAQ"/>
+          <ElFoldDir Value="0.000000000000000000e+00" ID="XSQSUSOJIKY"/>
+          <Feather Value="7.968749999999996447e+00" ID="GYIILOWSNKH"/>
+          <FeatherAxisXoC Value="5.000000000000000000e-01" ID="SKJLVJQCVVR"/>
+          <FeatherOffsetXoC Value="0.000000000000000000e+00" ID="ZELLLPCMKZC"/>
+          <FoldAngle Value="0.000000000000000000e+00" ID="RFIRKVSJBOB"/>
+          <FoldAngle_1 Value="0.000000000000000000e+00" ID="SIRHPNMDYKB"/>
+          <FoldAngle_2 Value="0.000000000000000000e+00" ID="XWTZIIZIUBG"/>
+          <FoldAngle_3 Value="0.000000000000000000e+00" ID="NDFCFDFCKIK"/>
+          <FoldAngle_4 Value="0.000000000000000000e+00" ID="OKXYBTRVNDK"/>
+          <InCluster Value="1.000000000000000000e+00" ID="HOUQYXWRMZL"/>
+          <IndividualBladeFoldFlag Value="0.000000000000000000e+00" ID="XHBJGLLTDCH"/>
+          <LECluster Value="2.500000000000000000e-01" ID="ZULGVTZWNCC"/>
+          <NumBlade Value="5.000000000000000000e+00" ID="QXXXPBHVMFQ"/>
+          <OffFoldAx Value="0.000000000000000000e+00" ID="WBCGNHQSVSY"/>
+          <OutCluster Value="1.000000000000000000e+00" ID="AIMLNVEDQSF"/>
+          <PChord Value="1.331851168032045785e-01" ID="CEATMQHMLFL"/>
+          <PSolidity Value="2.119706968550145731e-01" ID="ABOCOKQXYQC"/>
+          <Precone Value="0.000000000000000000e+00" ID="BJWEMGBAZNP"/>
+          <PropMode Value="0.000000000000000000e+00" ID="PRGWDIBFRYS"/>
+          <RFoldAx Value="2.000000000000000111e-01" ID="QPBTCUMDZPG"/>
+          <ReverseFlag Value="0.000000000000000000e+00" ID="ZOLBGEVTVHD"/>
+          <Rotate Value="0.000000000000000000e+00" ID="PAZMTATDYLF"/>
+          <Solidity Value="2.107329339087132547e-01" ID="LFNWUQYJPDN"/>
+          <TChord Value="1.347756869772998856e-01" ID="FACILAMVWPV"/>
+          <TECluster Value="2.500000000000000000e-01" ID="TRDWAFBANBE"/>
+          <TSolidity Value="2.145021679104326395e-01" ID="MSUEKTMIHDL"/>
+          <UseBeta34Flag Value="1.000000000000000000e+00" ID="NRYPRMDUZQG"/>
+        </Design>
+        <EndCap>
+          <CapUMaxLength Value="1.000000000000000000e+00" ID="ICFHORGWYXZ"/>
+          <CapUMaxOffset Value="0.000000000000000000e+00" ID="KPDADGKGXCJ"/>
+          <CapUMaxOption Value="2.000000000000000000e+00" ID="YNYUCXEQUMD"/>
+          <CapUMaxStrength Value="1.000000000000000000e+00" ID="QNPTDLSABMA"/>
+          <CapUMaxSweepFlag Value="0.000000000000000000e+00" ID="FMDAOCSWYYV"/>
+          <CapUMinLength Value="1.000000000000000000e+00" ID="XJVVWBXCEBL"/>
+          <CapUMinOffset Value="0.000000000000000000e+00" ID="CHYGEXHDYKP"/>
+          <CapUMinOption Value="1.000000000000000000e+00" ID="FLQOODGTPSD"/>
+          <CapUMinStrength Value="5.000000000000000000e-01" ID="PATWRQUCOTG"/>
+          <CapUMinSweepFlag Value="0.000000000000000000e+00" ID="GAGUAAUYQYS"/>
+          <CapUMinTess Value="3.000000000000000000e+00" ID="ZOXHCIXNVJI"/>
+        </EndCap>
+        <Index>
+          <ActiveBlade Value="1.000000000000000000e+00" ID="NHBFNEPBCRI"/>
+          <ActiveXSec Value="0.000000000000000000e+00" ID="LMREPZWJYKP"/>
+        </Index>
+        <Mass_Props>
+          <CGx Value="0.000000000000000000e+00" ID="VFVCAVKBEEU"/>
+          <CGy Value="0.000000000000000000e+00" ID="CTNSHNXWVVT"/>
+          <CGz Value="0.000000000000000000e+00" ID="IBYTSOYLIXO"/>
+          <Density Value="1.000000000000000000e+00" ID="NQAGWVUKHZQ"/>
+          <Ixx Value="0.000000000000000000e+00" ID="HHRIBIWMQUN"/>
+          <Ixy Value="0.000000000000000000e+00" ID="XIPJBAXIOJL"/>
+          <Ixz Value="0.000000000000000000e+00" ID="QSMRDPSANTE"/>
+          <Iyy Value="0.000000000000000000e+00" ID="IAZNNOQZSQP"/>
+          <Iyz Value="0.000000000000000000e+00" ID="ZFEOFQTCIYY"/>
+          <Izz Value="0.000000000000000000e+00" ID="OISHWXWBNQJ"/>
+          <Mass_Area Value="1.000000000000000000e+00" ID="TGMWWFZNBHA"/>
+          <Mass_Prior Value="0.000000000000000000e+00" ID="ABVAJOGBTYA"/>
+          <PointMass Value="0.000000000000000000e+00" ID="DWAINFEHMSH"/>
+          <Shell_Flag Value="0.000000000000000000e+00" ID="OVGXVVFFIRL"/>
+        </Mass_Props>
+        <Negative_Volume_Props>
+          <Negative_Volume_Flag Value="1.000000000000000000e+00" ID="MDADQUPIMEW"/>
+        </Negative_Volume_Props>
+        <ParasiteDragProps>
+          <ExpandedList Value="0.000000000000000000e+00" ID="WMPJTKCUBDP"/>
+          <FFBodyEqnType Value="3.000000000000000000e+00" ID="APGYOQCRKVD"/>
+          <FFUser Value="1.000000000000000000e+00" ID="UKPDBNUVWXV"/>
+          <FFWingEqnType Value="3.000000000000000000e+00" ID="ABMRQHGZFND"/>
+          <IncorporatedGen Value="0.000000000000000000e+00" ID="GLTRWHVYHIX"/>
+          <PercLam Value="0.000000000000000000e+00" ID="PSZLYAQMYXO"/>
+          <Q Value="1.000000000000000000e+00" ID="DQLQKUFNEFT"/>
+          <Roughness Value="0.000000000000000000e+00" ID="WCNKOZHHEEM"/>
+          <TawTwRatio Value="1.000000000000000000e+00" ID="RVBISHLELOU"/>
+          <TeTwRatio Value="1.000000000000000000e+00" ID="GKJMQESTWUW"/>
+        </ParasiteDragProps>
+        <PropGeom>
+          <MaxGrowth Value="1.963769402454648594e+00" ID="ZQAVSZBXZVF"/>
+          <SmallPanelW Value="1.695692545796784016e-03" ID="GWZFWZVONEU"/>
+        </PropGeom>
+        <Shape>
+          <Tess_U Value="1.200000000000000000e+01" ID="HLUHRUZWLVS"/>
+          <Tess_W Value="1.700000000000000000e+01" ID="NSHBXGXINDB"/>
+          <Wake Value="0.000000000000000000e+00" ID="DZXLFFBNDUO"/>
+        </Shape>
+        <Sym>
+          <Sym_Ancestor Value="4.000000000000000000e+00" ID="PSVIJAUQQXL"/>
+          <Sym_Ancestor_Origin_Flag Value="0.000000000000000000e+00" ID="CLXNAZDREKT"/>
+          <Sym_Axial_Flag Value="0.000000000000000000e+00" ID="HJYAONVSBCY"/>
+          <Sym_Planar_Flag Value="0.000000000000000000e+00" ID="AHJXEMBTNDV"/>
+          <Sym_Rot_N Value="2.000000000000000000e+00" ID="NJVWGUGRPFL"/>
+        </Sym>
+        <WakeSettings>
+          <WakeAngle Value="0.000000000000000000e+00" ID="KXBOCRXCIYI"/>
+          <WakeScale Value="2.000000000000000000e+00" ID="CTSJINFNDCD"/>
+        </WakeSettings>
+        <XForm>
+          <Abs_Or_Relitive_flag Value="1.000000000000000000e+00" ID="CPQFFCSWJHQ"/>
+          <Last_Scale Value="1.000000000000000000e+00" ID="JABYVYVQJZT"/>
+          <Origin Value="0.000000000000000000e+00" ID="GSQBHOKDDJX"/>
+          <Scale Value="1.000000000000000000e+00" ID="WHVAPCXRSLP"/>
+          <X_Location Value="7.664356367157778571e-01" ID="WNSGIMZUMLZ"/>
+          <X_Rel_Location Value="-2.000000000000000111e-01" ID="LBSUUVRNUSU"/>
+          <X_Rel_Rotation Value="0.000000000000000000e+00" ID="GSCJSFRTMYN"/>
+          <X_Rotation Value="0.000000000000000000e+00" ID="OQRIBPKUCOA"/>
+          <Y_Location Value="-1.602999999999999980e+00" ID="BLSFCTSDBNF"/>
+          <Y_Rel_Location Value="0.000000000000000000e+00" ID="XSZXDVERIKT"/>
+          <Y_Rel_Rotation Value="0.000000000000000000e+00" ID="FIKDKUFUJEV"/>
+          <Y_Rotation Value="0.000000000000000000e+00" ID="AEATEHTJVNR"/>
+          <Z_Location Value="4.737704918032786816e-01" ID="YIDVQZDTMAD"/>
+          <Z_Rel_Location Value="0.000000000000000000e+00" ID="GNCLXGKPBYA"/>
+          <Z_Rel_Rotation Value="0.000000000000000000e+00" ID="LPPNJQUISPF"/>
+          <Z_Rotation Value="0.000000000000000000e+00" ID="MEPEEHOYTCM"/>
+        </XForm>
+      </ParmContainer>
+      <GeomBase>
+        <TypeName>Propeller</TypeName>
+        <TypeID>11</TypeID>
+        <TypeFixed>0</TypeFixed>
+        <ParentID>CXSHPYTTOU</ParentID>
+        <Child_List/>
+      </GeomBase>
+      <Material>
+        <Name>Default</Name>
+      </Material>
+      <Wire_Color>
+        <ParmContainer>
+          <ID>NOEGJTQYCM</ID>
+          <Name>Default</Name>
+          <Color_Parm>
+            <Alpha Value="2.550000000000000000e+02" ID="IPAFMWYPCMJ"/>
+            <Blue Value="2.550000000000000000e+02" ID="GAYPCQOZQYP"/>
+            <Green Value="0.000000000000000000e+00" ID="TNHEBONAWEW"/>
+            <Red Value="0.000000000000000000e+00" ID="LBBBGBPYKOI"/>
+          </Color_Parm>
+        </ParmContainer>
+      </Wire_Color>
+      <Textures>
+        <Num_of_Tex>0</Num_of_Tex>
+      </Textures>
+      <Geom>
+        <Set_List>1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, </Set_List>
+        <SubSurfaces/>
+        <FeaStructures/>
+      </Geom>
+      <PropellerGeom>
+        <ParmContainer>
+          <ID>RPOBMXAWZL</ID>
+          <Name>Default</Name>
+        </ParmContainer>
+        <XSecSurf>
+          <XSec>
+            <ParmContainer>
+              <ID>NTLBKMQEPW</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="2.000000000000000111e-01" ID="SDXNRSWYSBG"/>
+                <RefLength Value="6.999999999999999556e-01" ID="NFYPTHXAYBQ"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="ABZOAROCKCA"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>MWZDKEGJTK</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="TDOBYNVBOQR"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="JCDGLQDXSIR"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="TRWJGPHEGXY"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="LGMRAQJFMMH"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="WLTEWHLOAVT"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="UYSRPXGTIUZ"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="HQYYRVBSDOS"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="OSDHYYZALCE"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="IMGSXDYTBOT"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="GMIFXVJKMOX"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="BGKDPLDOEHC"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="PYFGEDULYFW"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="RLNVQYFWRLZ"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="WPYJSMGQXBY"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="RRSQVTMUDLV"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="KIWGQBCBEUB"/>
+                    <Number Value="8.000000000000000000e+00" ID="CESDVEVGFMZ"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="IFJCMCVDSFS"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="VOQBHYFOAOH"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="EBNGEKKHEYY"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="OUOZZRQYWNH"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="UZDLUPRRPMD"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="EAUGHXZIMNI"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="ZWMYTCQGCLL"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="UELHQGETSKW"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="SIUNNVMJVPH"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="AWZYUTUXQKM"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="NUKRRGWMCBE"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="TCBAKKQZJYB"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="CTFYHDZETGE"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="PGPHBGCJYDI"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="XJOQXNIMMNV"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="OZCPBLIUOYN"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="RYMZAYGPADH"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="WQTUVSWQKRY"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="QGCGJEDAJXJ"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="XZQGGRTKIGW"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="UNHRIYMFGPW"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="DYZNVFFWZVR"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="ZPWPTUBIDCI"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="DMLKJHKSZUG"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="VXVESLHLGCC"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="FQKHPLQGHZH"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="ISRDHVEZDBU"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="JOPWCNNPVSE"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="FLUXOPJVOUO"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="INLMCXADAAG"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="BYUUIJWCEPY"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="DQTSTPYXZNS"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="EWBVSHRSELT"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="FWYSDNXIRLG"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="WYJJJYVGXBW"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="TNEOPXDVUAB"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="LZXRDXLQPTI"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="YPGZFYYMBBV"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="SIIYINKRAEB"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="DRAFRBVGIKY"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="2.980449878548511642e-04" ID="RNFVJZZCINP"/>
+                    <CamberLoc Value="1.499999999999999944e-01" ID="EHUOPRJHKFB"/>
+                    <Chord Value="5.599999999999999423e-02" ID="ZNUSIOSBEGZ"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="PYLVSZPCBVR"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="HBQGYNGUALJ"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="EBXOYTUPPRJ"/>
+                    <HWRatio Value="1.400000000000000133e-01" ID="LBSCHEPSYFP"/>
+                    <IdealCl Value="0.000000000000000000e+00" ID="TYLCKLGKFCY"/>
+                    <Invert Value="0.000000000000000000e+00" ID="SPHFTLZWCBZ"/>
+                    <Scale Value="1.000000000000000000e+00" ID="DNMJJDERCAY"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="KXYANLFPYPA"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="IOFWEPEKJCS"/>
+                    <Theta Value="0.000000000000000000e+00" ID="TDEBWNLOBTE"/>
+                    <ThickChord Value="1.400000000000000133e-01" ID="DIBDKMTNCAW"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="NSRLZXHVUUG"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="WCGBJSCOFCQ"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="VNUGASJOFIP"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="HBJILZSLFYN"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="PDTILJBVBPW"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="XFOYMVXZCOI"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="RWPSXEOYOAZ"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="MMMQFYOTUYN"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>16</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>UWNHQWQQYF</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="4.000000000000000222e-01" ID="DWZTRZSISYP"/>
+                <RefLength Value="6.999999999999999556e-01" ID="OCLCUHCATSB"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="VBEDFWSLLKO"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>QVDAOYILWS</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="KRJMNWFWNYC"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="KAOHVLICMIC"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="DBSNSZTTVVU"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="KJZZSJGIDFR"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="QRQZGJHXVMR"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="FILZLXCOILC"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="BHRMJZKVQOC"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="INOBNEOIRDL"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="QLPIGWPBLRR"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="ORXSILRUKHM"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="IUKPRNXHFKT"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="NWBIFNLNODW"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="DHEECHXKQWM"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="DLNVNFNMKAD"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="ZRRTHAIRJML"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="ITIOGXLAVAO"/>
+                    <Number Value="8.000000000000000000e+00" ID="LKCPPMOWWXZ"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="JYTPPUZZYWZ"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="UHNLTNOHBNQ"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="PDDEBJBUQRY"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="AWRXJGDNLMI"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="CGZZMPRWTMO"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="AIXAMSKQPLD"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="XLFVMEFDCPF"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="GCNMPCXFMLN"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="WEXNEEFSFYN"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="OXAGSBQQAQZ"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="BGAHCBDKCFP"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="IHCAEQGTJID"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="RGPBTSSJIOO"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="KUHFEJZVGXX"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="ZEWVTFYKJMZ"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="XCHLTKZQXOJ"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="PINKTPIJNLR"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="QSZGLACBTLZ"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="JPKLISKBKPF"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="LXSYCQDMDGS"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="RBDGWKCJALO"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="MEIXMLWMHWP"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="XAVOYILHICB"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="PBXMCOUIXUH"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="AQRRNVUHQJV"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="KGOKYGSJANO"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="MFYFKURFHHW"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="XBHYIBCFJZM"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="WDLBCONJDEM"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="ISLAMWIVATM"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="VAJIUSSWUGJ"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="LJNOMNHJDJN"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="XXDVLPBIGUX"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="IAGLMBRRJZC"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="FLENEHCJUZS"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="XDISZPSGTSH"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="HZBWOCWALNR"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="FITEZMXSQHZ"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="IJVNOEXPLFM"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="TUQCTUXCOKH"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="7.297473759736762284e-04" ID="CVCEIDPUPVH"/>
+                    <CamberLoc Value="1.499999999999999944e-01" ID="CGNFNBZIRJV"/>
+                    <Chord Value="9.540740740740738524e-02" ID="RWVBOMAUJBF"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="OVNJBEAFNQZ"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="BHKWDTLWXIX"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="BWAQLEQRMWY"/>
+                    <HWRatio Value="1.173104956268221366e-01" ID="MNHDGZASDER"/>
+                    <IdealCl Value="6.999999999999999556e-01" ID="COHAVECFNXN"/>
+                    <Invert Value="0.000000000000000000e+00" ID="MXBYUPQDLIN"/>
+                    <Scale Value="1.000000000000000000e+00" ID="KEKOCTONFAQ"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="DQKZOWVCCJZ"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="CYALWQVWNDU"/>
+                    <Theta Value="0.000000000000000000e+00" ID="WHZBHMJTOTL"/>
+                    <ThickChord Value="1.173104956268221366e-01" ID="UUMKZTLQMEK"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="BAEPPHWKPOD"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="AVZQATRZCTJ"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="NLMJVDTKVHF"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="ZVWDGGNUJTP"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="LQHKJVHJINZ"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="ACDJEWJMCAT"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="ELULYMCJBUP"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="PBNZQKLPHUG"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>16</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+          <XSec>
+            <ParmContainer>
+              <ID>RUFSKWVVXV</ID>
+              <Name>Default</Name>
+              <XSec>
+                <RadiusFrac Value="1.000000000000000000e+00" ID="GTQJYUHJEHZ"/>
+                <RefLength Value="6.999999999999999556e-01" ID="WYMMZQKSLJN"/>
+                <SectTess_U Value="6.000000000000000000e+00" ID="NVKMGQAQUOO"/>
+              </XSec>
+            </ParmContainer>
+            <XSec>
+              <Type>4</Type>
+              <GroupName>XSec</GroupName>
+              <XSecCurve>
+                <ParmContainer>
+                  <ID>HHXTWVNKRQ</ID>
+                  <Name>Default</Name>
+                  <Cap>
+                    <LE_Cap_Length Value="1.000000000000000000e+00" ID="GNUMBONMGJI"/>
+                    <LE_Cap_Offset Value="0.000000000000000000e+00" ID="ULTBQFTCYIL"/>
+                    <LE_Cap_Strength Value="5.000000000000000000e-01" ID="WCTRSVYHGWM"/>
+                    <LE_Cap_Type Value="1.000000000000000000e+00" ID="KILVKHIQZSK"/>
+                    <TE_Cap_Length Value="1.000000000000000000e+00" ID="FATQFQYXSIS"/>
+                    <TE_Cap_Offset Value="0.000000000000000000e+00" ID="MAXGNPOEZAZ"/>
+                    <TE_Cap_Strength Value="5.000000000000000000e-01" ID="TAYOQSPRUFM"/>
+                    <TE_Cap_Type Value="1.000000000000000000e+00" ID="GFNDQDNPIGY"/>
+                  </Cap>
+                  <Chevron>
+                    <AllSym Value="1.000000000000000000e+00" ID="ATZYSLWYLIF"/>
+                    <BottomAmplitude Value="1.000000000000000000e+00" ID="ZYCBLMFNFYZ"/>
+                    <Bottom_Angle Value="0.000000000000000000e+00" ID="DLGQKCEJWHY"/>
+                    <Bottom_Slew Value="0.000000000000000000e+00" ID="JZUBAIFXGOY"/>
+                    <Chevron_Type Value="0.000000000000000000e+00" ID="NJDPZKSYMDO"/>
+                    <LeftAmplitude Value="1.000000000000000000e+00" ID="JLZTKVFGSTX"/>
+                    <Left_Angle Value="0.000000000000000000e+00" ID="GWYYYVHCJXG"/>
+                    <Left_Slew Value="0.000000000000000000e+00" ID="AYIETOZMSMR"/>
+                    <Number Value="8.000000000000000000e+00" ID="ZJMONZJMSIM"/>
+                    <Off_Duty Value="0.000000000000000000e+00" ID="GPMPNDKEOJX"/>
+                    <On_Duty Value="0.000000000000000000e+00" ID="GMLRIYPQZZL"/>
+                    <Peak_Radius Value="0.000000000000000000e+00" ID="VEQSZHBCKLV"/>
+                    <RLSym Value="1.000000000000000000e+00" ID="XFGCHNOJHAN"/>
+                    <RightAmplitude Value="1.000000000000000000e+00" ID="UYNJCVOGKEM"/>
+                    <Right_Angle Value="0.000000000000000000e+00" ID="XMFTLKYQXTW"/>
+                    <Right_Slew Value="0.000000000000000000e+00" ID="HJNFURIYVAI"/>
+                    <TBSym Value="1.000000000000000000e+00" ID="YKSQXYFUJNQ"/>
+                    <TopAmplitude Value="1.000000000000000000e+00" ID="RJCSRKPNSNQ"/>
+                    <Top_Angle Value="0.000000000000000000e+00" ID="HJPECIALVNJ"/>
+                    <Top_Slew Value="0.000000000000000000e+00" ID="KSGACMKFBWS"/>
+                    <Valley_Radius Value="0.000000000000000000e+00" ID="IYKTWYKIBKW"/>
+                    <W01_Center Value="2.500000000000000000e-01" ID="CVSIZRGQOLV"/>
+                    <W01_Center_Guide Value="5.000000000000000000e+00" ID="GHJTDMRHTUM"/>
+                    <W01_End Value="5.000000000000000000e-01" ID="ZUDPDCWGWQN"/>
+                    <W01_End_Guide Value="5.000000000000000000e+00" ID="SSSEHTBIVUF"/>
+                    <W01_Mode Value="0.000000000000000000e+00" ID="UJNARBRGJVF"/>
+                    <W01_Start Value="0.000000000000000000e+00" ID="LQSEIHJAIMA"/>
+                    <W01_Start_Guide Value="5.000000000000000000e+00" ID="WKYLQUNXOUH"/>
+                    <W01_Width Value="5.000000000000000000e-01" ID="YQYVHELDBRA"/>
+                  </Chevron>
+                  <Close>
+                    <LE_Close_AbsRel Value="0.000000000000000000e+00" ID="OFFMRMONZJK"/>
+                    <LE_Close_Thick Value="0.000000000000000000e+00" ID="FNWSSTRLXHR"/>
+                    <LE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="SENXQPYRGBA"/>
+                    <LE_Close_Type Value="0.000000000000000000e+00" ID="SKZFBVRYICD"/>
+                    <TE_Close_AbsRel Value="0.000000000000000000e+00" ID="MKVCFFYJSPE"/>
+                    <TE_Close_Thick Value="0.000000000000000000e+00" ID="NYWEAEJKECI"/>
+                    <TE_Close_Thick_Chord Value="0.000000000000000000e+00" ID="DFGHWWNIOPZ"/>
+                    <TE_Close_Type Value="0.000000000000000000e+00" ID="HNLJHTTKDIL"/>
+                  </Close>
+                  <Trim>
+                    <LE_Trim_AbsRel Value="0.000000000000000000e+00" ID="PEWHROJMMKX"/>
+                    <LE_Trim_Thick Value="0.000000000000000000e+00" ID="MBBBMDTYIDK"/>
+                    <LE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="CSRVSHOLDVB"/>
+                    <LE_Trim_Type Value="0.000000000000000000e+00" ID="RHZXSWCOKWB"/>
+                    <LE_Trim_X Value="0.000000000000000000e+00" ID="LDHNLGOKJKL"/>
+                    <LE_Trim_X_Chord Value="0.000000000000000000e+00" ID="DDMXLMVABFI"/>
+                    <TE_Trim_AbsRel Value="0.000000000000000000e+00" ID="DEXUJBLDQUE"/>
+                    <TE_Trim_Thick Value="0.000000000000000000e+00" ID="DJEYSXOQSNH"/>
+                    <TE_Trim_Thick_Chord Value="0.000000000000000000e+00" ID="WVQASXRKLVY"/>
+                    <TE_Trim_Type Value="0.000000000000000000e+00" ID="RJZPRGSJYCM"/>
+                    <TE_Trim_X Value="0.000000000000000000e+00" ID="MQRNJZJUIAY"/>
+                    <TE_Trim_X_Chord Value="0.000000000000000000e+00" ID="CZLHLXDSYCM"/>
+                  </Trim>
+                  <XSecCurve>
+                    <Area Value="9.984846773124649879e-05" ID="RJDCRSECTXO"/>
+                    <CamberLoc Value="1.499999999999999944e-01" ID="ZSAFMBTLTRJ"/>
+                    <Chord Value="6.999999999999999278e-02" ID="VRKCLUKDLTQ"/>
+                    <DeltaX Value="0.000000000000000000e+00" ID="MHEQFKMFLGS"/>
+                    <DeltaY Value="0.000000000000000000e+00" ID="ISQRGTIVHRA"/>
+                    <FitDegree Value="7.000000000000000000e+00" ID="MNFBZFAPFDS"/>
+                    <HWRatio Value="2.999999999999999889e-02" ID="UEXADJTIDGX"/>
+                    <IdealCl Value="2.000000000000000111e-01" ID="DQLOKDCVENC"/>
+                    <Invert Value="0.000000000000000000e+00" ID="UNUUSZAUEPJ"/>
+                    <Scale Value="1.000000000000000000e+00" ID="KHUTZGIQQQU"/>
+                    <SharpTEFlag Value="1.000000000000000000e+00" ID="UCYEJSVKHFT"/>
+                    <ShiftLE Value="0.000000000000000000e+00" ID="UIFVQGNFOBV"/>
+                    <Theta Value="0.000000000000000000e+00" ID="YKSAHKXCFXP"/>
+                    <ThickChord Value="2.999999999999999889e-02" ID="ESSAGVTZQVC"/>
+                  </XSecCurve>
+                  <XSecCurve_Background>
+                    <XSecFlipImageFlag Value="0.000000000000000000e+00" ID="HTPUZHCRQXL"/>
+                    <XSecImageFlag Value="0.000000000000000000e+00" ID="MYEVMAJTWGA"/>
+                    <XSecImageH Value="1.000000000000000000e+00" ID="PYVNAEDOODW"/>
+                    <XSecImagePreserveAR Value="1.000000000000000000e+00" ID="SZPEDGJOPAP"/>
+                    <XSecImageW Value="1.000000000000000000e+00" ID="SAMYIZTECFG"/>
+                    <XSecImageXOffset Value="0.000000000000000000e+00" ID="RMCWKKBKLOY"/>
+                    <XSecImageYOffset Value="0.000000000000000000e+00" ID="LHQQRQCIYHF"/>
+                    <XSecLockImageFlag Value="0.000000000000000000e+00" ID="RNPYODFTGKT"/>
+                  </XSecCurve_Background>
+                </ParmContainer>
+                <XSecCurve>
+                  <Type>16</Type>
+                  <XSecCurveDriverGroup>
+                    <NumVar>4</NumVar>
+                    <NumChoices>2</NumChoices>
+                    <ChoiceVec>0, 2, </ChoiceVec>
+                  </XSecCurveDriverGroup>
+                </XSecCurve>
+              </XSecCurve>
+            </XSec>
+          </XSec>
+        </XSecSurf>
+        <Chord>
+          <PCurve>
+            <NumPts>10</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>CVRYNLJBKN</ID>
+            <Name>PCurve</Name>
+            <Chord>
+              <ConvType Value="2.000000000000000000e+00" ID="KLLMZLOSWWM"/>
+              <CrvType Value="2.000000000000000000e+00" ID="NUKXIVSVPKH"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="HGUTNWDLDHQ"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="WAJJDSGLUYN"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="HIXSQMEPTZE"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="UZUOFYKCDWS"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="FSLSCPAOLEA"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="DSVAJESZKID"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="QEOBXZWPSDY"/>
+              <G1_7 Value="0.000000000000000000e+00" ID="UAYWOTUZEIN"/>
+              <G1_8 Value="0.000000000000000000e+00" ID="AENFHTHTHCX"/>
+              <G1_9 Value="0.000000000000000000e+00" ID="VIFNQLOIWDF"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="SSRGNFYUXGH"/>
+              <crd_0 Value="8.000000000000000167e-02" ID="EFKFBJXKADS"/>
+              <crd_1 Value="9.333333333333333759e-02" ID="RYOVSKZLKAT"/>
+              <crd_2 Value="1.199999999999999817e-01" ID="HVXADWWZBCK"/>
+              <crd_3 Value="1.362962962962962765e-01" ID="WIDAVWNVGOP"/>
+              <crd_4 Value="1.525925925925925575e-01" ID="PZVWCBXZXFN"/>
+              <crd_5 Value="1.499999999999999944e-01" ID="JNSKRJCUWZN"/>
+              <crd_6 Value="1.499999999999999944e-01" ID="ALWMYQPJACR"/>
+              <crd_7 Value="1.499999999999999944e-01" ID="FMSQVEZZKOO"/>
+              <crd_8 Value="1.499999999999999944e-01" ID="QEFLUAMLLWK"/>
+              <crd_9 Value="1.000000000000000056e-01" ID="ZUXXBHEMRAJ"/>
+              <r_0 Value="2.000000000000000111e-01" ID="QNYOFTWLLJP"/>
+              <r_1 Value="2.666666666666666630e-01" ID="KTODSCMZPNG"/>
+              <r_2 Value="3.333333333333333703e-01" ID="PVQWNOHWNEE"/>
+              <r_3 Value="4.000000000000000222e-01" ID="CGIFLQMQAER"/>
+              <r_4 Value="4.666666666666666741e-01" ID="JJMVSEHNOVQ"/>
+              <r_5 Value="5.333333333333333259e-01" ID="SCYMBZONBRY"/>
+              <r_6 Value="5.999999999999999778e-01" ID="DKCWHADARTP"/>
+              <r_7 Value="7.333333333333332815e-01" ID="JYBHADJPHCP"/>
+              <r_8 Value="8.666666666666666963e-01" ID="KZYEAPCXSXZ"/>
+              <r_9 Value="1.000000000000000000e+00" ID="VZMFWJTAPBI"/>
+            </Chord>
+          </ParmContainer>
+        </Chord>
+        <Twist>
+          <PCurve>
+            <NumPts>7</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>MLARUHEKLS</ID>
+            <Name>PCurve</Name>
+            <Twist>
+              <ConvType Value="2.000000000000000000e+00" ID="JDIUVWTFIQH"/>
+              <CrvType Value="2.000000000000000000e+00" ID="ADWGRFGRAMP"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="OKMKVNVBFDJ"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="DXFXFNDFJJZ"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="UTRLHLQMHQN"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="IPURVMBQWZS"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="IXLUWAOEZNS"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="BNELNNXVVMJ"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="QHQACJNUVRW"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="FDBRPALNMUG"/>
+              <r_0 Value="2.000000000000000111e-01" ID="IFCIDYBBTMY"/>
+              <r_1 Value="3.333333333333333703e-01" ID="LGYSTAWBVMC"/>
+              <r_2 Value="4.666666666666666741e-01" ID="DWSRGETYLAX"/>
+              <r_3 Value="5.999999999999999778e-01" ID="SWDXSURTWSL"/>
+              <r_4 Value="7.333333333333332815e-01" ID="RXGHXSAWXGI"/>
+              <r_5 Value="8.666666666666666963e-01" ID="UDRAZPPSHJY"/>
+              <r_6 Value="1.000000000000000000e+00" ID="ATDEZZNGCWJ"/>
+              <tw_0 Value="3.000000000000000000e+01" ID="JEWOQBUFSSF"/>
+              <tw_1 Value="2.337500000000000000e+01" ID="MSUTYIMVWAR"/>
+              <tw_2 Value="1.955555555555555358e+01" ID="UARIOEFCHRH"/>
+              <tw_3 Value="1.500000000000000000e+01" ID="LNFDACDODWK"/>
+              <tw_4 Value="1.161111111111111072e+01" ID="RYBFGCCBYNQ"/>
+              <tw_5 Value="1.038888888888888751e+01" ID="ABAFTKZARTT"/>
+              <tw_6 Value="1.000000000000000000e+01" ID="MGGAXGYCDSW"/>
+            </Twist>
+          </ParmContainer>
+        </Twist>
+        <Rake>
+          <PCurve>
+            <NumPts>4</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>XFXHWGXIMM</ID>
+            <Name>PCurve</Name>
+            <Rake>
+              <ConvType Value="2.000000000000000000e+00" ID="ITWFFUAMTKL"/>
+              <CrvType Value="2.000000000000000000e+00" ID="HSFGKLARHHE"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="YCJSLCDURYZ"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="QWOUREURKJC"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="DXKABOWFTEH"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="QQBHTTOVNKK"/>
+              <SplitPt Value="6.784776902887139638e-01" ID="OURSLCCANRG"/>
+              <r_0 Value="2.000000000000000111e-01" ID="JRSYFDWLKMO"/>
+              <r_1 Value="4.666666666666666741e-01" ID="VVCYFXYOAVN"/>
+              <r_2 Value="7.333333333333333925e-01" ID="NYHYBUPEMGN"/>
+              <r_3 Value="1.000000000000000000e+00" ID="SONJTWKFFZM"/>
+              <rak_0 Value="0.000000000000000000e+00" ID="RPTDDXUUBZD"/>
+              <rak_1 Value="0.000000000000000000e+00" ID="QOCIAFCSYTK"/>
+              <rak_2 Value="0.000000000000000000e+00" ID="BJADAAADQVH"/>
+              <rak_3 Value="0.000000000000000000e+00" ID="LOPNKTQVSAT"/>
+            </Rake>
+          </ParmContainer>
+        </Rake>
+        <Skew>
+          <PCurve>
+            <NumPts>4</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>QBAAJCVRNT</ID>
+            <Name>PCurve</Name>
+            <Skew>
+              <ConvType Value="2.000000000000000000e+00" ID="JBUGEEHSUKU"/>
+              <CrvType Value="2.000000000000000000e+00" ID="MDJCGEEZEHZ"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="YRFQXMRCAXI"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="IJAJVSFFTLM"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="KZADEFTIXGK"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="RGMFPJOBIMB"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="OMXUTLFNWSD"/>
+              <r_0 Value="2.000000000000000111e-01" ID="CDEEKXZTKGB"/>
+              <r_1 Value="4.666666666666666741e-01" ID="JUEFAYYPYIP"/>
+              <r_2 Value="7.333333333333333925e-01" ID="DDMNGQPKSFI"/>
+              <r_3 Value="1.000000000000000000e+00" ID="KUIJGVKMLER"/>
+              <skw_0 Value="0.000000000000000000e+00" ID="YIKYRUFSRBF"/>
+              <skw_1 Value="0.000000000000000000e+00" ID="CLWEVWYWOGR"/>
+              <skw_2 Value="0.000000000000000000e+00" ID="PUZVRTGLFNG"/>
+              <skw_3 Value="0.000000000000000000e+00" ID="TCJTUOYERJT"/>
+            </Skew>
+          </ParmContainer>
+        </Skew>
+        <Sweep>
+          <PCurve>
+            <NumPts>7</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>GNXLJADQSO</ID>
+            <Name>PCurve</Name>
+            <Sweep>
+              <ConvType Value="1.000000000000000000e+00" ID="EEZCMGCFQAV"/>
+              <CrvType Value="2.000000000000000000e+00" ID="WEEZXTYEFVE"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="QBATLJWSETT"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="CQGAWVNOMMV"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="OWQQLWLTDDC"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="JIBXBTFBMHF"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="YEJTHKPQFOF"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="YXPBCUOHJTR"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="JYZNFONLUOS"/>
+              <SplitPt Value="3.839895013123360012e-01" ID="FKFUXOTDXSP"/>
+              <r_0 Value="2.000000000000000111e-01" ID="OHLPNBISJSJ"/>
+              <r_1 Value="3.267716535433071723e-01" ID="IXDZPDWBCPP"/>
+              <r_2 Value="4.535433070866142780e-01" ID="AHLACRCYNYD"/>
+              <r_3 Value="5.803149606299213836e-01" ID="PVQXFCFAAXI"/>
+              <r_4 Value="7.202099737532808854e-01" ID="DIRHSWTYSXF"/>
+              <r_5 Value="8.601049868766404982e-01" ID="YVPTMRERJSJ"/>
+              <r_6 Value="1.000000000000000000e+00" ID="BXRKSFKWHWP"/>
+              <sw_0 Value="0.000000000000000000e+00" ID="QWOGUEJKYPV"/>
+              <sw_1 Value="-1.626086956521739291e+00" ID="ECMJDAXOTUN"/>
+              <sw_2 Value="-3.000000000000000000e+00" ID="FYAFNEREKXH"/>
+              <sw_3 Value="-3.000000000000000000e+00" ID="DZFKYYLJMKW"/>
+              <sw_4 Value="-3.000000000000000000e+00" ID="QGRDSZWHVTL"/>
+              <sw_5 Value="-1.639130434782608781e+00" ID="CXVVZOHJLEB"/>
+              <sw_6 Value="1.000000000000000000e+00" ID="CDNTQFDTCTT"/>
+            </Sweep>
+          </ParmContainer>
+        </Sweep>
+        <Thick>
+          <PCurve>
+            <NumPts>4</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>SLSQWNKCHD</ID>
+            <Name>PCurve</Name>
+            <Thick>
+              <ConvType Value="2.000000000000000000e+00" ID="LAYGHCNXQUQ"/>
+              <CrvType Value="2.000000000000000000e+00" ID="KSDUFXGWQIX"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="NPAIJCTUQME"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="WSVVNYXPMBH"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="AFITYSSWLKQ"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="BBEQFBQZGCS"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="ZHJWVSHPUQL"/>
+              <r_0 Value="2.000000000000000111e-01" ID="ECKAQWLCOKE"/>
+              <r_1 Value="4.666666666666666741e-01" ID="QWNEMTSVLXG"/>
+              <r_2 Value="7.333333333333333925e-01" ID="CYCCBQYXCUQ"/>
+              <r_3 Value="1.000000000000000000e+00" ID="RLVGYBRZAIV"/>
+              <toc_0 Value="1.400000000000000133e-01" ID="NLNKZGGSSBK"/>
+              <toc_1 Value="1.118853255587949902e-01" ID="XJGMAQQYOYR"/>
+              <toc_2 Value="7.521865889212828171e-02" ID="SYIVDMIWPDS"/>
+              <toc_3 Value="3.000000000000000236e-02" ID="PYBMKSKVNHY"/>
+            </Thick>
+          </ParmContainer>
+        </Thick>
+        <CLI>
+          <PCurve>
+            <NumPts>10</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>HLXQPRQSQJ</ID>
+            <Name>PCurve</Name>
+            <CLI>
+              <ConvType Value="2.000000000000000000e+00" ID="YATTYDRTBIB"/>
+              <CrvType Value="2.000000000000000000e+00" ID="IMNSQJTZBIL"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="JQKCOWFKDKM"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="AOHJLCQMZKZ"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="XNPMONZSIPQ"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="IEQTIQOZSXF"/>
+              <G1_4 Value="0.000000000000000000e+00" ID="UMYLZUDOAQY"/>
+              <G1_5 Value="0.000000000000000000e+00" ID="GVUAVPSOMGI"/>
+              <G1_6 Value="0.000000000000000000e+00" ID="XUXRFHEFXKJ"/>
+              <G1_7 Value="0.000000000000000000e+00" ID="NZGYYGSDJZT"/>
+              <G1_8 Value="0.000000000000000000e+00" ID="APZOJPZJEOI"/>
+              <G1_9 Value="0.000000000000000000e+00" ID="FVOMCNGPGSM"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="RUQCAYDKFPV"/>
+              <cli_0 Value="0.000000000000000000e+00" ID="AXOSHNYAIBX"/>
+              <cli_1 Value="6.999999999999999556e-01" ID="OTMYYBPUGPQ"/>
+              <cli_2 Value="6.999999999999999556e-01" ID="DLYJREXJDST"/>
+              <cli_3 Value="6.999999999999999556e-01" ID="XINCMFRNAWS"/>
+              <cli_4 Value="6.999999999999999556e-01" ID="BGRSDOHACQD"/>
+              <cli_5 Value="6.999999999999999556e-01" ID="GHEKZVTMLDH"/>
+              <cli_6 Value="6.999999999999999556e-01" ID="RSJORAXEKQP"/>
+              <cli_7 Value="6.999999999999999556e-01" ID="NHUHSZIMTXS"/>
+              <cli_8 Value="6.999999999999999556e-01" ID="KBBCOXRUKTM"/>
+              <cli_9 Value="2.000000000000000111e-01" ID="IGKOATDMFBR"/>
+              <r_0 Value="2.000000000000000111e-01" ID="OWYPGSRTESA"/>
+              <r_1 Value="2.666666666666666630e-01" ID="GOIYXGXAAGP"/>
+              <r_2 Value="3.333333333333333703e-01" ID="XQXDLSEHBXL"/>
+              <r_3 Value="4.000000000000000222e-01" ID="NAALUBHJVWR"/>
+              <r_4 Value="4.666666666666666741e-01" ID="KWYGRNLLTCT"/>
+              <r_5 Value="5.333333333333333259e-01" ID="NQRHWFIRYLB"/>
+              <r_6 Value="5.999999999999999778e-01" ID="OCDDYEPMMRP"/>
+              <r_7 Value="7.333333333333332815e-01" ID="QCXQIKGCWFX"/>
+              <r_8 Value="8.666666666666666963e-01" ID="ILYCFCITXPJ"/>
+              <r_9 Value="1.000000000000000000e+00" ID="FUQLZGHOMCD"/>
+            </CLI>
+          </ParmContainer>
+        </CLI>
+        <Axial>
+          <PCurve>
+            <NumPts>4</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>MBMPZGPORO</ID>
+            <Name>PCurve</Name>
+            <Axial>
+              <ConvType Value="2.000000000000000000e+00" ID="XSMVYUJYDHV"/>
+              <CrvType Value="2.000000000000000000e+00" ID="ITYRTVFSXKP"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="KRKIBJXQUOM"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="GGLSLWBXORE"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="AFSJQCFJWME"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="LGGPEJFWKNP"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="RYIWISYNRBP"/>
+              <ax_0 Value="0.000000000000000000e+00" ID="ITVUFFPZEHA"/>
+              <ax_1 Value="0.000000000000000000e+00" ID="FJUJCSOBJUC"/>
+              <ax_2 Value="0.000000000000000000e+00" ID="DZPOMETSLEW"/>
+              <ax_3 Value="0.000000000000000000e+00" ID="VUCSPIUZSNP"/>
+              <r_0 Value="2.000000000000000111e-01" ID="SQVRGZYKJGT"/>
+              <r_1 Value="4.666666666666666741e-01" ID="CWZUVGQEDDC"/>
+              <r_2 Value="7.333333333333333925e-01" ID="SZTXKXTTQNT"/>
+              <r_3 Value="1.000000000000000000e+00" ID="NWAPOENKIRZ"/>
+            </Axial>
+          </ParmContainer>
+        </Axial>
+        <Tangential>
+          <PCurve>
+            <NumPts>4</NumPts>
+          </PCurve>
+          <ParmContainer>
+            <ID>GJJVIYLBSD</ID>
+            <Name>PCurve</Name>
+            <Tangential>
+              <ConvType Value="2.000000000000000000e+00" ID="ZTAYHFCOVHU"/>
+              <CrvType Value="2.000000000000000000e+00" ID="MSENYPHEDQY"/>
+              <G1_0 Value="0.000000000000000000e+00" ID="QKKSRJZCBCL"/>
+              <G1_1 Value="0.000000000000000000e+00" ID="WNEUWLOVRJD"/>
+              <G1_2 Value="0.000000000000000000e+00" ID="SVLJXNMSYID"/>
+              <G1_3 Value="0.000000000000000000e+00" ID="EPDJGUKJREI"/>
+              <SplitPt Value="5.000000000000000000e-01" ID="EIKAARPQWLW"/>
+              <r_0 Value="2.000000000000000111e-01" ID="UQSUSFEUTMG"/>
+              <r_1 Value="4.666666666666666741e-01" ID="BYPWITDGSTM"/>
+              <r_2 Value="7.333333333333333925e-01" ID="NUOMHJUKPXL"/>
+              <r_3 Value="1.000000000000000000e+00" ID="BRRXZYBJHZD"/>
+              <tan_0 Value="0.000000000000000000e+00" ID="FMLTXGTCWYT"/>
+              <tan_1 Value="0.000000000000000000e+00" ID="BQAXFUCXCIP"/>
+              <tan_2 Value="0.000000000000000000e+00" ID="EGQPDOVVPZY"/>
+              <tan_3 Value="0.000000000000000000e+00" ID="OQBXLFRBMBD"/>
+            </Tangential>
+          </ParmContainer>
+        </Tangential>
+      </PropellerGeom>
+    </Geom>
+  </Vehicle>
+  <Materials/>
+  <UserParmContainer>
+    <NumUserParms>16</NumUserParms>
+    <UserParm Value="0.000000000000000000e+00" ID="User_0" Name="User_0" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_1" Name="User_1" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_2" Name="User_2" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_3" Name="User_3" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_4" Name="User_4" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_5" Name="User_5" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_6" Name="User_6" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_7" Name="User_7" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_8" Name="User_8" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_9" Name="User_9" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_10" Name="User_10" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_11" Name="User_11" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_12" Name="User_12" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_13" Name="User_13" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_14" Name="User_14" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+    <UserParm Value="0.000000000000000000e+00" ID="User_15" Name="User_15" GroupName="User_Group" GroupDisplaySuffix="-1" Descript="Default Description" Type="0" UpperLimit="1.000000000000000000e+12" LowerLimit="-1.000000000000000000e+12"/>
+  </UserParmContainer>
+  <LinkMgr/>
+  <AdvLinkMgr/>
+  <VSPAEROSettings>
+    <ParmContainer>
+      <ID>BCNHMFEJJL</ID>
+      <Name>VSPAEROSettings</Name>
+      <VSPAERO>
+        <ActuatorDiskFlag Value="0.000000000000000000e+00" ID="KGKZOYAYXKK"/>
+        <AlphaEnd Value="1.000000000000000000e+01" ID="RXWOYXSAIKO"/>
+        <AlphaNpts Value="1.000000000000000000e+00" ID="NDJRTYVZLCX"/>
+        <AlphaStart Value="0.000000000000000000e+00" ID="ZKDUNKIRQSD"/>
+        <AlternateInputFormatFlag Value="0.000000000000000000e+00" ID="XMXUJGZHDWK"/>
+        <AnalysisMethod Value="0.000000000000000000e+00" ID="KMUPJMZQXQY"/>
+        <AutoTimeNumRevs Value="5.000000000000000000e+00" ID="JTFTSEZZRAA"/>
+        <AutoTimeStepFlag Value="1.000000000000000000e+00" ID="KAMHAPUGDLS"/>
+        <BetaEnd Value="0.000000000000000000e+00" ID="HGRARCFQFGB"/>
+        <BetaNpts Value="1.000000000000000000e+00" ID="WQAEFMVAHHI"/>
+        <BetaStart Value="0.000000000000000000e+00" ID="PVVXNIHYZOX"/>
+        <Clmax Value="-1.000000000000000000e+00" ID="IHPQOEYIINB"/>
+        <ClmaxToggle Value="2.000000000000000000e+00" ID="DBIYMLRCFGM"/>
+        <CpSliceFlag Value="1.000000000000000000e+00" ID="LHEQXWLEDSE"/>
+        <CpSlicePlotLinesFlag Value="1.000000000000000000e+00" ID="BDZDSWINELB"/>
+        <CpSliceYAxisFlipFlag Value="0.000000000000000000e+00" ID="YBDWSPIBLIY"/>
+        <FarDist Value="-1.000000000000000000e+00" ID="PMIRAFZGVIB"/>
+        <FarDistToggle Value="0.000000000000000000e+00" ID="SKFQITYTLOF"/>
+        <FixedWakeFlag Value="0.000000000000000000e+00" ID="JZHJPIBATEH"/>
+        <FromSteadyState Value="0.000000000000000000e+00" ID="UNQTAREKAKU"/>
+        <GeomSet Value="1.000000000000000000e+00" ID="LEUFYZWVWSV"/>
+        <GroundEffect Value="-1.000000000000000000e+00" ID="MFASNXUODWB"/>
+        <GroundEffectToggle Value="0.000000000000000000e+00" ID="EAAFIHORHVG"/>
+        <HoverRamp Value="0.000000000000000000e+00" ID="YBIFCBRVBCK"/>
+        <HoverRampFlag Value="0.000000000000000000e+00" ID="TJPGVZCESWN"/>
+        <KTCorrection Value="0.000000000000000000e+00" ID="NEEMGUPIYNF"/>
+        <LoadDistSelectType Value="0.000000000000000000e+00" ID="KTADHAMICUA"/>
+        <MachEnd Value="0.000000000000000000e+00" ID="ZNDPFGCJQWN"/>
+        <MachNpts Value="1.000000000000000000e+00" ID="AORGEUFBZPJ"/>
+        <MachStart Value="0.000000000000000000e+00" ID="DFLUORGQFAI"/>
+        <Machref Value="3.430000000000000000e+02" ID="XBJTUTZHMPN"/>
+        <ManualVrefFlag Value="1.000000000000000000e+00" ID="TSQGJOFTGLG"/>
+        <MassSet Value="1.000000000000000000e+00" ID="NJBIADKWVIM"/>
+        <MassSliceDir Value="0.000000000000000000e+00" ID="BDKRTXZHMAQ"/>
+        <MaxTurnAngle Value="-1.000000000000000000e+00" ID="FFLVCCSHQWO"/>
+        <MaxTurnToggle Value="0.000000000000000000e+00" ID="REYMWUNRKFY"/>
+        <NCPU Value="4.000000000000000000e+00" ID="CXJZESWXBVP"/>
+        <NoiseCalcFlag Value="0.000000000000000000e+00" ID="WPSTLZQBVKN"/>
+        <NoiseCalcType Value="0.000000000000000000e+00" ID="GXGFAXAJWKH"/>
+        <NoiseUnits Value="0.000000000000000000e+00" ID="DQQPKLNRXLD"/>
+        <NumMassSlice Value="1.000000000000000000e+01" ID="ONCCXHIFRSK"/>
+        <NumTimeSteps Value="1.000000000000000000e+02" ID="XDKBUXNDMHL"/>
+        <Precondition Value="0.000000000000000000e+00" ID="OZKDBPDSJGN"/>
+        <ReCref Value="1.000000000000000000e+07" ID="GAKGYWUNWSC"/>
+        <ReCrefEnd Value="2.000000000000000000e+07" ID="RMYILFQIRFD"/>
+        <ReCrefNpts Value="1.000000000000000000e+00" ID="KDFZJUDRZQS"/>
+        <RefFlag Value="1.000000000000000000e+00" ID="ZLLPPYMOOFM"/>
+        <Rho Value="1.125000000000000000e+00" ID="ROKGWMSXQKL"/>
+        <RootWakeNodes Value="6.400000000000000000e+01" ID="PSBSRHZJIMX"/>
+        <RotateBladesFlag Value="1.000000000000000000e+00" ID="EUSDVNYEDCA"/>
+        <Sref Value="3.453125000000000000e+00" ID="EAQXQCIFZUV"/>
+        <Symmetry Value="0.000000000000000000e+00" ID="FOECYOGQHOY"/>
+        <TimeStepSize Value="1.250000000000000026e-03" ID="RUCSYYEGGAY"/>
+        <UniformPropRPMFlag Value="1.000000000000000000e+00" ID="RBXMBXZVYUX"/>
+        <UnsteadyGroupSelectType Value="0.000000000000000000e+00" ID="VTGAZBFLEWU"/>
+        <UnsteadyType Value="0.000000000000000000e+00" ID="PKSTRHGCKNQ"/>
+        <Vinf Value="6.000000000000000000e+01" ID="QLEKWBQFYWC"/>
+        <Vref Value="6.000000000000000000e+01" ID="LQGMBFAHKON"/>
+        <WakeNumIter Value="3.000000000000000000e+00" ID="LEPBKJRXEEO"/>
+        <Write2DFEMFlag Value="0.000000000000000000e+00" ID="JIYFIQSWPZY"/>
+        <Xcg Value="0.000000000000000000e+00" ID="FFGGZDTUPSD"/>
+        <Ycg Value="0.000000000000000000e+00" ID="DCVPPGECRUC"/>
+        <Zcg Value="0.000000000000000000e+00" ID="JCSENRFKBYM"/>
+        <bref Value="4.500000000000000000e+00" ID="HSPOAIFQGCI"/>
+        <cref Value="7.673611111111111605e-01" ID="MGKFCMHFJTP"/>
+        <m_ConvergenceXMax Value="1.000000000000000000e+00" ID="IPRSZGQTFTY"/>
+        <m_ConvergenceXMaxIsManual Value="0.000000000000000000e+00" ID="BXPSFRKDMJL"/>
+        <m_ConvergenceXMin Value="0.000000000000000000e+00" ID="MGCCHAXHSCJ"/>
+        <m_ConvergenceXMinIsManual Value="0.000000000000000000e+00" ID="FDFMDVTJRHP"/>
+        <m_ConvergenceYMax Value="1.000000000000000000e+00" ID="HFEPMCVNVKH"/>
+        <m_ConvergenceYMaxIsManual Value="0.000000000000000000e+00" ID="DODNCZBQDXM"/>
+        <m_ConvergenceYMin Value="0.000000000000000000e+00" ID="VJWHGPKYNVL"/>
+        <m_ConvergenceYMinIsManual Value="0.000000000000000000e+00" ID="AUJMWVDJXYT"/>
+        <m_CpSliceXMax Value="1.000000000000000000e+00" ID="NWCWMUQBCQZ"/>
+        <m_CpSliceXMaxIsManual Value="0.000000000000000000e+00" ID="BCTLNWPFIPR"/>
+        <m_CpSliceXMin Value="-1.000000000000000000e+00" ID="IVSZXIBKMXB"/>
+        <m_CpSliceXMinIsManual Value="0.000000000000000000e+00" ID="HWHXZWHYYGP"/>
+        <m_CpSliceYMax Value="1.000000000000000000e+00" ID="RXWOBAYCTAF"/>
+        <m_CpSliceYMaxIsManual Value="0.000000000000000000e+00" ID="FLDSAZKSQEJ"/>
+        <m_CpSliceYMin Value="-1.000000000000000000e+00" ID="CXGNSGAUDMU"/>
+        <m_CpSliceYMinIsManual Value="0.000000000000000000e+00" ID="LABBEKFQTVY"/>
+        <m_LoadDistXMax Value="1.000000000000000000e+00" ID="JBEVHPOYKQK"/>
+        <m_LoadDistXMaxIsManual Value="0.000000000000000000e+00" ID="RDVIRLXNUZS"/>
+        <m_LoadDistXMin Value="-1.000000000000000000e+00" ID="FRJZMOHAYBW"/>
+        <m_LoadDistXMinIsManual Value="0.000000000000000000e+00" ID="YAKKKBWIIFF"/>
+        <m_LoadDistYMax Value="1.000000000000000000e+00" ID="OELRUVKQUKY"/>
+        <m_LoadDistYMaxIsManual Value="0.000000000000000000e+00" ID="SDMBZYASIYE"/>
+        <m_LoadDistYMin Value="-1.000000000000000000e+00" ID="DXICFMQZBHX"/>
+        <m_LoadDistYMinIsManual Value="0.000000000000000000e+00" ID="ZPYOKKTNSWL"/>
+        <m_SweepXMax Value="1.000000000000000000e+00" ID="TWOFDVWMZKY"/>
+        <m_SweepXMaxIsManual Value="0.000000000000000000e+00" ID="HWMCCTXMSOS"/>
+        <m_SweepXMin Value="0.000000000000000000e+00" ID="JZKLSOYDKNP"/>
+        <m_SweepXMinIsManual Value="0.000000000000000000e+00" ID="MAGQIXYTYEA"/>
+        <m_SweepYMax Value="1.000000000000000000e+00" ID="IEWADWUPHNG"/>
+        <m_SweepYMaxIsManual Value="0.000000000000000000e+00" ID="BFKVTZUGUIP"/>
+        <m_SweepYMin Value="0.000000000000000000e+00" ID="XBOOCOOTYXI"/>
+        <m_SweepYMinIsManual Value="0.000000000000000000e+00" ID="APFPKEIANOV"/>
+        <m_UnsteadyXMax Value="1.000000000000000000e+00" ID="FOTTBADQHER"/>
+        <m_UnsteadyXMaxIsManual Value="0.000000000000000000e+00" ID="KDTNEEVVPBO"/>
+        <m_UnsteadyXMin Value="-1.000000000000000000e+00" ID="ZERSVZBQKRM"/>
+        <m_UnsteadyXMinIsManual Value="0.000000000000000000e+00" ID="SFACLNQCEOK"/>
+        <m_UnsteadyYMax Value="1.000000000000000000e+00" ID="DETMESOXUOB"/>
+        <m_UnsteadyYMaxIsManual Value="0.000000000000000000e+00" ID="ICJFPJHSHQJ"/>
+        <m_UnsteadyYMin Value="-1.000000000000000000e+00" ID="OQTDDXYMJXV"/>
+        <m_UnsteadyYMinIsManual Value="0.000000000000000000e+00" ID="RAZDROMGKUY"/>
+      </VSPAERO>
+    </ParmContainer>
+    <ControlSurfaceGroupCount>0</ControlSurfaceGroupCount>
+    <RotorDiskCount>0</RotorDiskCount>
+    <CpSliceCount>1</CpSliceCount>
+    <CpSlice>
+      <ParmContainer>
+        <ID>NFYKWLTCPB</ID>
+        <Name>Y = 0</Name>
+        <CpSlice>
+          <CutPosition Value="0.000000000000000000e+00" ID="MVZIYAHVBBM"/>
+          <CutType Value="1.000000000000000000e+00" ID="XFWTEZFNOEZ"/>
+          <DrawCutFlag Value="1.000000000000000000e+00" ID="UJVYYEZFEAH"/>
+        </CpSlice>
+      </ParmContainer>
+    </CpSlice>
+    <UnsteadyGroupCount>5</UnsteadyGroupCount>
+    <Unsteady_Group>
+      <NumberOfComponents>4</NumberOfComponents>
+      <Component>
+        <CompID>OHEAIBPMDY</CompID>
+        <SurfIndex>1</SurfIndex>
+      </Component>
+      <Component>
+        <CompID>LOENSIWPJA</CompID>
+        <SurfIndex>1</SurfIndex>
+      </Component>
+      <Component>
+        <CompID>LIYGGQUBGZ</CompID>
+        <SurfIndex>1</SurfIndex>
+      </Component>
+      <Component>
+        <CompID>LIYGGQUBGZ</CompID>
+        <SurfIndex>2</SurfIndex>
+      </Component>
+      <ParmContainer>
+        <ID>SPAIFOBSKD</ID>
+        <Name>Fixed_Group</Name>
+        <UnsteadyGroup>
+          <Ax Value="0.000000000000000000e+00" ID="MITWCFPDISK"/>
+          <Ay Value="0.000000000000000000e+00" ID="ASZXTGHTGUZ"/>
+          <Az Value="0.000000000000000000e+00" ID="KAGNLQIRCEA"/>
+          <GeomPropertyType Value="0.000000000000000000e+00" ID="ZVGFDMYMDZW"/>
+          <Ixx Value="0.000000000000000000e+00" ID="MACOCQPFFKQ"/>
+          <Ixy Value="0.000000000000000000e+00" ID="WGZHYZGISVJ"/>
+          <Ixz Value="0.000000000000000000e+00" ID="SNUNOCXGGRH"/>
+          <Iyy Value="0.000000000000000000e+00" ID="AZJCHOKIWPM"/>
+          <Iyz Value="0.000000000000000000e+00" ID="LFNWDPRMEXH"/>
+          <Izz Value="0.000000000000000000e+00" ID="PLCDRHVRTJK"/>
+          <Mass Value="0.000000000000000000e+00" ID="IIMQBBNGMBN"/>
+          <Ox Value="0.000000000000000000e+00" ID="PNNYSFOQCAV"/>
+          <Oy Value="0.000000000000000000e+00" ID="MZIRKGUFSAX"/>
+          <Oz Value="0.000000000000000000e+00" ID="THPVOIHRFJG"/>
+          <RPM Value="0.000000000000000000e+00" ID="HZWUZAQLGZK"/>
+          <RotorDia Value="0.000000000000000000e+00" ID="DPSUNROJBOJ"/>
+          <Rx Value="0.000000000000000000e+00" ID="QQFOBLWEAOX"/>
+          <Ry Value="0.000000000000000000e+00" ID="UWTOMOQEMQJ"/>
+          <Rz Value="0.000000000000000000e+00" ID="PGEOVKYEFTI"/>
+          <Vx Value="0.000000000000000000e+00" ID="NFAXXEJCBVG"/>
+          <Vy Value="0.000000000000000000e+00" ID="YDHUQEQJYTR"/>
+          <Vz Value="0.000000000000000000e+00" ID="JDVYIEWDJRM"/>
+        </UnsteadyGroup>
+      </ParmContainer>
+    </Unsteady_Group>
+    <Unsteady_Group>
+      <NumberOfComponents>1</NumberOfComponents>
+      <Component>
+        <CompID>RUQEKSIBDM</CompID>
+        <SurfIndex>1</SurfIndex>
+      </Component>
+      <ParmContainer>
+        <ID>JCAJFTUUGT</ID>
+        <Name>CruiseProp</Name>
+        <UnsteadyGroup>
+          <Ax Value="0.000000000000000000e+00" ID="GRVMTIHVAXM"/>
+          <Ay Value="0.000000000000000000e+00" ID="SYDBVGMBUFZ"/>
+          <Az Value="0.000000000000000000e+00" ID="JOKPGVNJBDC"/>
+          <GeomPropertyType Value="2.000000000000000000e+00" ID="MUOUGIXBOLW"/>
+          <Ixx Value="0.000000000000000000e+00" ID="QWKJRISSSNA"/>
+          <Ixy Value="0.000000000000000000e+00" ID="MJMVQHKVLUV"/>
+          <Ixz Value="0.000000000000000000e+00" ID="NCUXNSZNQIP"/>
+          <Iyy Value="0.000000000000000000e+00" ID="YLPBGSEMZKK"/>
+          <Iyz Value="0.000000000000000000e+00" ID="CWSMMDDLJJT"/>
+          <Izz Value="0.000000000000000000e+00" ID="IPWJXVZICKZ"/>
+          <Mass Value="0.000000000000000000e+00" ID="ORBVUGWJBZF"/>
+          <Ox Value="1.186980941606374351e+00" ID="QRKFZVPZCFK"/>
+          <Oy Value="1.602999999999999980e+00" ID="NCWFUKMHXRG"/>
+          <Oz Value="5.522247099603287968e-01" ID="KWWWSXGIKKQ"/>
+          <RPM Value="2.000000000000000000e+03" ID="FXWAZGXRVZL"/>
+          <RotorDia Value="1.000000000000000000e+00" ID="ZLRNSTZNILN"/>
+          <Rx Value="-8.660254037844387076e-01" ID="ROLPOZTZSOT"/>
+          <Ry Value="0.000000000000000000e+00" ID="IWCDLMMMTIO"/>
+          <Rz Value="5.000000000000000000e-01" ID="GXVXESHLBIC"/>
+          <Vx Value="0.000000000000000000e+00" ID="WWHFAKTLQUS"/>
+          <Vy Value="0.000000000000000000e+00" ID="PMUQLPNDQFJ"/>
+          <Vz Value="0.000000000000000000e+00" ID="OQBBJWVTEAW"/>
+        </UnsteadyGroup>
+      </ParmContainer>
+    </Unsteady_Group>
+    <Unsteady_Group>
+      <NumberOfComponents>1</NumberOfComponents>
+      <Component>
+        <CompID>PDXWMKKXNN</CompID>
+        <SurfIndex>1</SurfIndex>
+      </Component>
+      <ParmContainer>
+        <ID>ZXIRUDOVMU</ID>
+        <Name>LiftRotor</Name>
+        <UnsteadyGroup>
+          <Ax Value="0.000000000000000000e+00" ID="HHXWXHSQPBI"/>
+          <Ay Value="0.000000000000000000e+00" ID="CQBOBUDWVDK"/>
+          <Az Value="0.000000000000000000e+00" ID="NPREFZSTHDK"/>
+          <GeomPropertyType Value="2.000000000000000000e+00" ID="NXMQJZDCANE"/>
+          <Ixx Value="0.000000000000000000e+00" ID="QGCGJXOGUKI"/>
+          <Ixy Value="0.000000000000000000e+00" ID="ZHITNXGCPPV"/>
+          <Ixz Value="0.000000000000000000e+00" ID="YIXDQNWLAJN"/>
+          <Iyy Value="0.000000000000000000e+00" ID="ZORDCWEBLLA"/>
+          <Iyz Value="0.000000000000000000e+00" ID="JFIAFKLSUGA"/>
+          <Izz Value="0.000000000000000000e+00" ID="HVGLGZYRWCH"/>
+          <Mass Value="0.000000000000000000e+00" ID="ZPYIDXEYMCN"/>
+          <Ox Value="3.209884592663862612e+00" ID="LQNTTEDKPUX"/>
+          <Oy Value="1.602999999999999980e+00" ID="PRRSLMLZTER"/>
+          <Oz Value="6.821329609956905404e-01" ID="CKLCRMIZHUF"/>
+          <RPM Value="2.000000000000000000e+03" ID="UNOULINTNGQ"/>
+          <RotorDia Value="1.000000000000000000e+00" ID="SQKZVNDPUCB"/>
+          <Rx Value="0.000000000000000000e+00" ID="GQGGDIAJBBD"/>
+          <Ry Value="0.000000000000000000e+00" ID="UBBMBHMPSWJ"/>
+          <Rz Value="1.000000000000000000e+00" ID="CHSDDEVNLJN"/>
+          <Vx Value="0.000000000000000000e+00" ID="WZMNXNLHKGY"/>
+          <Vy Value="0.000000000000000000e+00" ID="UZHCSOSPRTJ"/>
+          <Vz Value="0.000000000000000000e+00" ID="CELAADFXQWY"/>
+        </UnsteadyGroup>
+      </ParmContainer>
+    </Unsteady_Group>
+    <Unsteady_Group>
+      <NumberOfComponents>1</NumberOfComponents>
+      <Component>
+        <CompID>RUQEKSIBDM</CompID>
+        <SurfIndex>2</SurfIndex>
+      </Component>
+      <ParmContainer>
+        <ID>APAAMVCHHT</ID>
+        <Name>CruiseProp</Name>
+        <UnsteadyGroup>
+          <Ax Value="0.000000000000000000e+00" ID="KODGDZMMIYQ"/>
+          <Ay Value="0.000000000000000000e+00" ID="EMJODBIRHMX"/>
+          <Az Value="0.000000000000000000e+00" ID="VUORZJZXFWL"/>
+          <GeomPropertyType Value="2.000000000000000000e+00" ID="ADZDVNBBKIU"/>
+          <Ixx Value="0.000000000000000000e+00" ID="ICRAMLTKAZY"/>
+          <Ixy Value="0.000000000000000000e+00" ID="NKEZOMENTKZ"/>
+          <Ixz Value="0.000000000000000000e+00" ID="FODICPHGDOJ"/>
+          <Iyy Value="0.000000000000000000e+00" ID="OQTEEWDUFEV"/>
+          <Iyz Value="0.000000000000000000e+00" ID="NWUHVHYHAIT"/>
+          <Izz Value="0.000000000000000000e+00" ID="PPNNKQFKDFC"/>
+          <Mass Value="0.000000000000000000e+00" ID="UGXEXFHYHRC"/>
+          <Ox Value="1.186980941606374351e+00" ID="BBYRIJDWXVN"/>
+          <Oy Value="-1.602999999999999980e+00" ID="KEFPVGHVHAD"/>
+          <Oz Value="5.522247099603287968e-01" ID="PSERZKMWWEC"/>
+          <RPM Value="2.000000000000000000e+03" ID="HEEPZBBWFSJ"/>
+          <RotorDia Value="1.000000000000000000e+00" ID="XGHDNHQETAK"/>
+          <Rx Value="-8.660254037844387076e-01" ID="XKCUBXEGSDN"/>
+          <Ry Value="0.000000000000000000e+00" ID="UANPQFKTIRQ"/>
+          <Rz Value="5.000000000000000000e-01" ID="ITYRSFIXNPZ"/>
+          <Vx Value="0.000000000000000000e+00" ID="BSGPZCRMXLB"/>
+          <Vy Value="0.000000000000000000e+00" ID="JIHVXWAUYSI"/>
+          <Vz Value="0.000000000000000000e+00" ID="DANNOOVEOPM"/>
+        </UnsteadyGroup>
+      </ParmContainer>
+    </Unsteady_Group>
+    <Unsteady_Group>
+      <NumberOfComponents>1</NumberOfComponents>
+      <Component>
+        <CompID>PDXWMKKXNN</CompID>
+        <SurfIndex>2</SurfIndex>
+      </Component>
+      <ParmContainer>
+        <ID>OUVYOSDORQ</ID>
+        <Name>LiftRotor</Name>
+        <UnsteadyGroup>
+          <Ax Value="0.000000000000000000e+00" ID="GYFPAJKANVC"/>
+          <Ay Value="0.000000000000000000e+00" ID="WZQRUTAYBBM"/>
+          <Az Value="0.000000000000000000e+00" ID="MQSOWKCMOWD"/>
+          <GeomPropertyType Value="2.000000000000000000e+00" ID="STNJSBXXVVL"/>
+          <Ixx Value="0.000000000000000000e+00" ID="ZAPKWPWQGSX"/>
+          <Ixy Value="0.000000000000000000e+00" ID="FEXKKETCEPG"/>
+          <Ixz Value="0.000000000000000000e+00" ID="XCMYWCQAWKC"/>
+          <Iyy Value="0.000000000000000000e+00" ID="VMNGQAVZARU"/>
+          <Iyz Value="0.000000000000000000e+00" ID="IGINFMCMBYM"/>
+          <Izz Value="0.000000000000000000e+00" ID="KVGVRIKYQXS"/>
+          <Mass Value="0.000000000000000000e+00" ID="JNNVTSDCBWM"/>
+          <Ox Value="3.209884592663862612e+00" ID="CEFFUAEJXPM"/>
+          <Oy Value="-1.602999999999999980e+00" ID="LLHKKHGJPVB"/>
+          <Oz Value="6.821329609956905404e-01" ID="YKRETMJBFPT"/>
+          <RPM Value="2.000000000000000000e+03" ID="FRJUJROTGFW"/>
+          <RotorDia Value="1.000000000000000000e+00" ID="WSIMVLFEIEP"/>
+          <Rx Value="0.000000000000000000e+00" ID="SJFMSJEIYEU"/>
+          <Ry Value="0.000000000000000000e+00" ID="LWSHSWRGJZA"/>
+          <Rz Value="1.000000000000000000e+00" ID="GALITMRTCVG"/>
+          <Vx Value="0.000000000000000000e+00" ID="OPESIIYUUYV"/>
+          <Vy Value="0.000000000000000000e+00" ID="LYXKQZKFFJK"/>
+          <Vz Value="0.000000000000000000e+00" ID="UVKAKQIHLXB"/>
+        </UnsteadyGroup>
+      </ParmContainer>
+    </Unsteady_Group>
+  </VSPAEROSettings>
+  <VariablePresets>
+    <NumGroups>0</NumGroups>
+    <NumSettingsPerGroup/>
+    <NumParmsPerGroup/>
+    <CurrentGroupIndex>-1</CurrentGroupIndex>
+    <CurrentSettingIndex>-1</CurrentSettingIndex>
+  </VariablePresets>
+  <CFDMeshSettings>
+    <FarGeomID/>
+    <ParmContainer>
+      <ID>ZRECLUMWWR</ID>
+      <Name>CFDMeshSettings</Name>
+      <DrawMesh>
+        <ColorReasonFlag Value="0.000000000000000000e+00" ID="YUSWLPBNYFJ"/>
+        <ColorTagsFlag Value="1.000000000000000000e+00" ID="IBMTAMZCFAU"/>
+        <DrawBadElementsFlag Value="1.000000000000000000e+00" ID="HJDAUZNDVOZ"/>
+        <DrawBinAdaptFlag Value="1.000000000000000000e+00" ID="VKGYUZTNPTP"/>
+        <DrawBorderFlag Value="0.000000000000000000e+00" ID="QBPGJMIXRXP"/>
+        <DrawCurveFlag Value="1.000000000000000000e+00" ID="VIUWKLGYXLC"/>
+        <DrawFarField Value="1.000000000000000000e+00" ID="LIXOQSRIPJR"/>
+        <DrawFarFieldPreview Value="1.000000000000000000e+00" ID="NYOSWCNCXJQ"/>
+        <DrawIsectFlag Value="0.000000000000000000e+00" ID="TJKRSLBAYWZ"/>
+        <DrawMeshFlag Value="1.000000000000000000e+00" ID="WBUFITIUUUJ"/>
+        <DrawPntsFlag Value="1.000000000000000000e+00" ID="GCXKXODRPJQ"/>
+        <DrawRawFlag Value="0.000000000000000000e+00" ID="CQLMYECQCOW"/>
+        <DrawSourceWake Value="1.000000000000000000e+00" ID="ABJGSTOYOCQ"/>
+        <DrawSymmetryPlane Value="1.000000000000000000e+00" ID="XDRIVROOJDG"/>
+        <DrawWake Value="1.000000000000000000e+00" ID="QZCLGLVQTKE"/>
+      </DrawMesh>
+      <ExportCFD>
+        <DAT_Export Value="1.000000000000000000e+00" ID="ZIXVDXGSMYM"/>
+        <ExportRawFlag Value="0.000000000000000000e+00" ID="IEIFGECVVGM"/>
+        <FACET_Export Value="1.000000000000000000e+00" ID="POBJHWZYONK"/>
+        <GMSH_Export Value="1.000000000000000000e+00" ID="BTTLMUFIQCU"/>
+        <KEY_Export Value="1.000000000000000000e+00" ID="DCHRBYDIIPQ"/>
+        <OBJ_Export Value="1.000000000000000000e+00" ID="KGNXMTZKRJF"/>
+        <POLY_Export Value="1.000000000000000000e+00" ID="EJJMDIFPDHP"/>
+        <SRF_XYZIntCurve Value="0.000000000000000000e+00" ID="OUMJDYYGYTP"/>
+        <STL_Export Value="1.000000000000000000e+00" ID="HTLHZCDCDVB"/>
+        <TKEY_Export Value="1.000000000000000000e+00" ID="MWXLLFDTPZK"/>
+        <TRI_Export Value="1.000000000000000000e+00" ID="LIXQUSOUGRQ"/>
+        <VSPGEOM_Export Value="1.000000000000000000e+00" ID="AHZPGSNNBII"/>
+      </ExportCFD>
+      <FarField>
+        <FarAbsSize Value="0.000000000000000000e+00" ID="NSYKWADDXRG"/>
+        <FarComp Value="0.000000000000000000e+00" ID="XRRGJEONHBL"/>
+        <FarHeight Value="4.000000000000000000e+00" ID="YJMOIJJALIM"/>
+        <FarLength Value="4.000000000000000000e+00" ID="RLLAJHPDBXG"/>
+        <FarManualLoc Value="0.000000000000000000e+00" ID="RWENLPZZKUH"/>
+        <FarMesh Value="0.000000000000000000e+00" ID="SAGWQIRFUGL"/>
+        <FarWidth Value="4.000000000000000000e+00" ID="AMPOVUYLBIC"/>
+        <FarXLocation Value="0.000000000000000000e+00" ID="RNLBVLUTRVC"/>
+        <FarXScale Value="4.000000000000000000e+00" ID="QKRXIEDFLKI"/>
+        <FarYLocation Value="0.000000000000000000e+00" ID="IZHFNBAKADY"/>
+        <FarYScale Value="4.000000000000000000e+00" ID="XPCAMLAIJCI"/>
+        <FarZLocation Value="0.000000000000000000e+00" ID="GZJFKXPQFNT"/>
+        <FarZScale Value="4.000000000000000000e+00" ID="UUWNVCACVSA"/>
+        <HalfMesh Value="0.000000000000000000e+00" ID="OFCYBQMLJKW"/>
+        <SymmetrySplitting Value="0.000000000000000000e+00" ID="QQXRZGYZKHS"/>
+      </FarField>
+      <Global>
+        <ConvertToQuadsFlag Value="0.000000000000000000e+00" ID="XGPNUMRXQMY"/>
+        <CubicSurfTolerance Value="9.999999999999999547e-07" ID="AQKSXXJPAQV"/>
+        <DegenSet Value="-1.000000000000000000e+00" ID="DNFZWRTWZOX"/>
+        <DemoteSurfsCubicFlag Value="0.000000000000000000e+00" ID="KTFIMSRTIQS"/>
+        <HighOrderElementFlag Value="0.000000000000000000e+00" ID="BAQVZKSIMLO"/>
+        <IntersectSubSurfs Value="1.000000000000000000e+00" ID="QGRENYMVJRU"/>
+        <RelCurveTol Value="5.000000000000000104e-03" ID="TTHARNYUZDU"/>
+        <Set Value="1.000000000000000000e+00" ID="OUNPYXKLNKL"/>
+      </Global>
+    </ParmContainer>
+  </CFDMeshSettings>
+  <SurfaceIntersectSettings>
+    <ParmContainer>
+      <ID>RMFOAMKWNO</ID>
+      <Name>SurfaceIntersectSettings</Name>
+      <DrawMesh>
+        <ColorReasonFlag Value="0.000000000000000000e+00" ID="LSENXZAZIVE"/>
+        <ColorTagsFlag Value="1.000000000000000000e+00" ID="RKHDBANCEIY"/>
+        <DrawBinAdaptFlag Value="1.000000000000000000e+00" ID="PTYUOTBWVFQ"/>
+        <DrawBorderFlag Value="1.000000000000000000e+00" ID="KBSWTLVESVD"/>
+        <DrawCurveFlag Value="1.000000000000000000e+00" ID="WXGVFJYSIWC"/>
+        <DrawIsectFlag Value="1.000000000000000000e+00" ID="WUNKUIDILJB"/>
+        <DrawMeshFlag Value="1.000000000000000000e+00" ID="PFCURFKBVEG"/>
+        <DrawPntsFlag Value="1.000000000000000000e+00" ID="KWCLOKIZYGG"/>
+        <DrawRawFlag Value="0.000000000000000000e+00" ID="OHOREFNTUAH"/>
+        <DrawSourceWake Value="1.000000000000000000e+00" ID="CICOXIFNDHQ"/>
+      </DrawMesh>
+      <ExportIntersect>
+        <CADLabelDelim Value="0.000000000000000000e+00" ID="HKAPSSJQQAL"/>
+        <CADLabelID Value="1.000000000000000000e+00" ID="XYVTFBLBEGO"/>
+        <CADLabelName Value="1.000000000000000000e+00" ID="FXUYJZANCFZ"/>
+        <CADLabelSplitNo Value="1.000000000000000000e+00" ID="WTTCXGRPJGC"/>
+        <CADLabelSurfNo Value="1.000000000000000000e+00" ID="QFOYKKVSYZS"/>
+        <CADLenUnit Value="4.000000000000000000e+00" ID="IRGIXMHLKVK"/>
+        <CURV_Export Value="1.000000000000000000e+00" ID="AUFARWIEEWX"/>
+        <ExportRawFlag Value="0.000000000000000000e+00" ID="ZAVAQKYPXFM"/>
+        <IGES_Export Value="1.000000000000000000e+00" ID="YHZOQGYFBYH"/>
+        <PLOT3D_Export Value="1.000000000000000000e+00" ID="AMUZTZMFZCK"/>
+        <SRF_Export Value="1.000000000000000000e+00" ID="UIZPNWHRZQO"/>
+        <SRF_XYZIntCurve Value="0.000000000000000000e+00" ID="UUZAISSMCOI"/>
+        <STEPMergePoints Value="0.000000000000000000e+00" ID="FPLVPWNBWET"/>
+        <STEPRepresentation Value="1.000000000000000000e+00" ID="PLRBFVEALVH"/>
+        <STEPTol Value="9.999999999999999547e-07" ID="UUCMBEQHTNJ"/>
+        <STEP_Export Value="1.000000000000000000e+00" ID="UGNBXBXWBWC"/>
+      </ExportIntersect>
+      <FarField>
+        <FarComp Value="0.000000000000000000e+00" ID="SCNUNJZBMEQ"/>
+        <FarMesh Value="0.000000000000000000e+00" ID="ZRVKXQCCWXM"/>
+        <HalfMesh Value="0.000000000000000000e+00" ID="XVTYENGXIOX"/>
+        <SymmetrySplitting Value="0.000000000000000000e+00" ID="GIMEYTZSRUM"/>
+      </FarField>
+      <Global>
+        <ConvertToQuadsFlag Value="0.000000000000000000e+00" ID="FVYBJLTEGES"/>
+        <CubicSurfTolerance Value="9.999999999999999547e-07" ID="ZSBKIWHCRJY"/>
+        <DegenSet Value="-1.000000000000000000e+00" ID="RODGFOAUMQU"/>
+        <DemoteSurfsCubicFlag Value="0.000000000000000000e+00" ID="HXUQOISMGKJ"/>
+        <HighOrderElementFlag Value="0.000000000000000000e+00" ID="PTGZCNRWZDC"/>
+        <IntersectSubSurfs Value="1.000000000000000000e+00" ID="RQIVZIEOALF"/>
+        <RelCurveTol Value="5.000000000000000104e-03" ID="WZIAUJKKYUT"/>
+        <Set Value="1.000000000000000000e+00" ID="JKFXPZEBZWI"/>
+      </Global>
+    </ParmContainer>
+  </SurfaceIntersectSettings>
+  <CFDGridDensity>
+    <ParmContainer>
+      <ID>ADIJRPTNMC</ID>
+      <Name>CFDGridDensity</Name>
+      <CFDGridDensity>
+        <BaseAbsRel Value="0.000000000000000000e+00" ID="MRJWFJJBJRR"/>
+        <BaseLen Value="5.000000000000000000e-01" ID="QSUPCCNMDFY"/>
+        <BaseLenFrac Value="1.000000000000000021e-02" ID="BAFMMLZEXUW"/>
+        <FarAbsRel Value="0.000000000000000000e+00" ID="GPZHOBXJKLT"/>
+        <FarFrac Value="2.000000000000000000e+00" ID="PNMQUMYDEJD"/>
+        <FarMaxGapAbsRel Value="0.000000000000000000e+00" ID="FJCPREOBLEE"/>
+        <FarMaxGapFrac Value="5.000000000000000278e-02" ID="BCHLZXUCKEW"/>
+        <FarNCircSeg Value="1.600000000000000000e+01" ID="MLYJMWBCLVX"/>
+        <GrowRatio Value="1.300000000000000044e+00" ID="EQZQYXREISU"/>
+        <MaxFar Value="2.000000000000000000e+00" ID="GNOZHFZWWUW"/>
+        <MaxFarGap Value="2.000000000000000042e-02" ID="MYOAKVBTBUT"/>
+        <MaxGap Value="5.000000000000000104e-03" ID="BZAOWZNSOQZ"/>
+        <MaxGapAbsRel Value="0.000000000000000000e+00" ID="EDMIHJSRHOF"/>
+        <MaxGapFrac Value="5.000000000000000278e-02" ID="MFDEGWAMMQU"/>
+        <MinAbsRel Value="0.000000000000000000e+00" ID="QCOLISIVSYR"/>
+        <MinFrac Value="5.000000000000000278e-02" ID="HJHEOXNMXVK"/>
+        <MinLen Value="2.500000000000000139e-02" ID="KWPMFGHIQVP"/>
+        <NCircSeg Value="1.600000000000000000e+01" ID="WVFLBZINMDT"/>
+        <RigorLimit Value="0.000000000000000000e+00" ID="VZDQLZGQKOE"/>
+      </CFDGridDensity>
+    </ParmContainer>
+  </CFDGridDensity>
+  <StructureMgr>
+    <ParmContainer>
+      <ID>QQRUINBGWE</ID>
+      <Name>Default</Name>
+      <Struct>
+        <CurrStructIndex Value="-1.000000000000000000e+00" ID="BRMLJVHGXBT"/>
+      </Struct>
+    </ParmContainer>
+    <FeaPropertyInfo>
+      <ParmContainer>
+        <ID>YATRZIXLAG</ID>
+        <Name>DefaultShell</Name>
+        <FeaProperty>
+          <CrossSecArea Value="1.000000000000000056e-01" ID="JILZXJXTFRN"/>
+          <CrossSecArea_FEM Value="1.000000000000000056e-01" ID="HMWCDSNLWBN"/>
+          <CrossSectType Value="0.000000000000000000e+00" ID="VDOSYOQDYCN"/>
+          <Dim1 Value="1.000000000000000056e-01" ID="ENMYPZWIIUO"/>
+          <Dim1_FEM Value="1.000000000000000056e-01" ID="PMELPJCVLDQ"/>
+          <Dim2 Value="1.000000000000000056e-01" ID="PALQJBRZAEZ"/>
+          <Dim2_FEM Value="1.000000000000000056e-01" ID="IVCHNVRRMBL"/>
+          <Dim3 Value="1.000000000000000056e-01" ID="HTINBCKLPEN"/>
+          <Dim3_FEM Value="1.000000000000000056e-01" ID="NABCOZJWVLM"/>
+          <Dim4 Value="1.000000000000000056e-01" ID="RVWZIQYPRDB"/>
+          <Dim4_FEM Value="1.000000000000000056e-01" ID="CVRPHLVMLGY"/>
+          <Dim5 Value="1.000000000000000056e-01" ID="JFUGLKCCTIQ"/>
+          <Dim5_FEM Value="1.000000000000000056e-01" ID="UCRSZAXLWVL"/>
+          <Dim6 Value="1.000000000000000056e-01" ID="LEYNJCLBKUW"/>
+          <Dim6_FEM Value="1.000000000000000056e-01" ID="WGUFPBCVOUL"/>
+          <FeaMaterialIndex Value="-1.000000000000000000e+00" ID="EZOUBFYRAIB"/>
+          <FeaPropertyType Value="0.000000000000000000e+00" ID="ZOMKIVDYMUE"/>
+          <Ixx Value="1.000000000000000056e-01" ID="UMZNRSTQXVW"/>
+          <Ixx_FEM Value="1.000000000000000056e-01" ID="ZCXCDLHISMN"/>
+          <Iyy Value="1.000000000000000056e-01" ID="ETLFWBWVOXI"/>
+          <Iyy_FEM Value="1.000000000000000056e-01" ID="GDBPQRAXPIQ"/>
+          <Izy Value="1.000000000000000056e-01" ID="NYKOGRSWXRR"/>
+          <Izy_FEM Value="1.000000000000000056e-01" ID="REVYBLQMOCH"/>
+          <Izz Value="1.000000000000000056e-01" ID="DYDUXBAYCEH"/>
+          <Izz_FEM Value="1.000000000000000056e-01" ID="ZDPWOMVFKRO"/>
+          <LengthUnit Value="3.000000000000000000e+00" ID="VAMSDQYLGIZ"/>
+          <Thickness Value="1.000000000000000056e-01" ID="JCGZFHTOSVC"/>
+          <Thickness_FEM Value="1.000000000000000056e-01" ID="IJPHUXAABNP"/>
+        </FeaProperty>
+      </ParmContainer>
+      <FeaMaterialID>_Al6061T6</FeaMaterialID>
+    </FeaPropertyInfo>
+    <FeaPropertyInfo>
+      <ParmContainer>
+        <ID>IESQWYZWCV</ID>
+        <Name>DefaultBeam</Name>
+        <FeaProperty>
+          <CrossSecArea Value="1.000000000000000056e-01" ID="BQLWMADNGDS"/>
+          <CrossSecArea_FEM Value="1.000000000000000056e-01" ID="TPWKZHJYBQP"/>
+          <CrossSectType Value="0.000000000000000000e+00" ID="KKCEWHWXFII"/>
+          <Dim1 Value="1.000000000000000056e-01" ID="SWYALWJLLQM"/>
+          <Dim1_FEM Value="1.000000000000000056e-01" ID="LPISWUBKRBR"/>
+          <Dim2 Value="1.000000000000000056e-01" ID="LYGVUVUKLMV"/>
+          <Dim2_FEM Value="1.000000000000000056e-01" ID="ELGQUYTXECC"/>
+          <Dim3 Value="1.000000000000000056e-01" ID="FLNJZTTCDEY"/>
+          <Dim3_FEM Value="1.000000000000000056e-01" ID="BROXBWSVGDB"/>
+          <Dim4 Value="1.000000000000000056e-01" ID="WMLWEPDSDIM"/>
+          <Dim4_FEM Value="1.000000000000000056e-01" ID="KYAUMCHQRBB"/>
+          <Dim5 Value="1.000000000000000056e-01" ID="FFZPENYPFZP"/>
+          <Dim5_FEM Value="1.000000000000000056e-01" ID="XCVPWPETNNQ"/>
+          <Dim6 Value="1.000000000000000056e-01" ID="MPIKIISJFCF"/>
+          <Dim6_FEM Value="1.000000000000000056e-01" ID="AWKBOKHNMKP"/>
+          <FeaMaterialIndex Value="-1.000000000000000000e+00" ID="VRYQYLVOXZZ"/>
+          <FeaPropertyType Value="1.000000000000000000e+00" ID="ZWURSUOAWFH"/>
+          <Ixx Value="1.000000000000000056e-01" ID="IMXJHEGPTCW"/>
+          <Ixx_FEM Value="1.000000000000000056e-01" ID="MJRFULXRLQL"/>
+          <Iyy Value="1.000000000000000056e-01" ID="EKVHPXTCFAL"/>
+          <Iyy_FEM Value="1.000000000000000056e-01" ID="BQCJISQIEZB"/>
+          <Izy Value="1.000000000000000056e-01" ID="KTOMVDQHFON"/>
+          <Izy_FEM Value="1.000000000000000056e-01" ID="RORVOBRPTIZ"/>
+          <Izz Value="1.000000000000000056e-01" ID="ZKTHEXZGSLL"/>
+          <Izz_FEM Value="1.000000000000000056e-01" ID="QEBOYDZNEEA"/>
+          <LengthUnit Value="3.000000000000000000e+00" ID="FJBPHTXXXAI"/>
+          <Thickness Value="1.000000000000000056e-01" ID="WCKCEZLZHQD"/>
+          <Thickness_FEM Value="1.000000000000000056e-01" ID="RJGGUWCNXQC"/>
+        </FeaProperty>
+      </ParmContainer>
+      <FeaMaterialID>_Al6061T6</FeaMaterialID>
+    </FeaPropertyInfo>
+  </StructureMgr>
+  <ClippingMgr>
+    <ParmContainer>
+      <ID>FIESETKTGT</ID>
+      <Name>ClippingMgr</Name>
+      <Clipping>
+        <XGTClip Value="1.000000000000000000e+00" ID="ZXRFBHLHKNM"/>
+        <XGTClipFlag Value="0.000000000000000000e+00" ID="PHUELPEJDDU"/>
+        <XLTClip Value="-1.000000000000000000e+00" ID="MGCTNNZFVVP"/>
+        <XLTClipFlag Value="0.000000000000000000e+00" ID="QGEKUPAPERZ"/>
+        <YGTClip Value="1.000000000000000000e+00" ID="DGMHZMSNYEL"/>
+        <YGTClipFlag Value="0.000000000000000000e+00" ID="XGOQGHAHPED"/>
+        <YLTClip Value="-1.000000000000000000e+00" ID="AQARRMLXUOL"/>
+        <YLTClipFlag Value="0.000000000000000000e+00" ID="ZNCPQGFCHJO"/>
+        <ZGTClip Value="1.000000000000000000e+00" ID="LEQPQEEFWBL"/>
+        <ZGTClipFlag Value="0.000000000000000000e+00" ID="LTYXZNAOGCO"/>
+        <ZLTClip Value="-1.000000000000000000e+00" ID="MDPCLBKFQCW"/>
+        <ZLTClipFlag Value="0.000000000000000000e+00" ID="TEUIWHVKXKV"/>
+      </Clipping>
+    </ParmContainer>
+  </ClippingMgr>
+  <WaveDragMgr>
+    <ParmContainer>
+      <ID>ESFEOBAAVG</ID>
+      <Name>WaveDragSettings</Name>
+      <WaveDrag>
+        <AreaPlotType Value="0.000000000000000000e+00" ID="WJPCSBVBGTF"/>
+        <MachNumber Value="1.500000000000000000e+00" ID="MFOMNFMBXCF"/>
+        <NumRotSects Value="1.000000000000000000e+01" ID="TLTGTSIGCIF"/>
+        <NumSlices Value="2.000000000000000000e+01" ID="FKFBTQAGPAD"/>
+        <PlaneFlag Value="0.000000000000000000e+00" ID="GYKBOAZJTXE"/>
+        <PointPlotFlag Value="1.000000000000000000e+00" ID="YNXZJONMHFU"/>
+        <RefFlag Value="0.000000000000000000e+00" ID="TAPTPFHWHAZ"/>
+        <SelBodyIndex Value="0.000000000000000000e+00" ID="EXRRMYBWZKK"/>
+        <SelSetIndex Value="1.000000000000000000e+00" ID="XQPUNEPHDPR"/>
+        <SlicingLoc Value="0.000000000000000000e+00" ID="SSGNQULGBKR"/>
+        <Sref Value="1.000000000000000000e+02" ID="CEWDIABAPDV"/>
+        <SymmFlag Value="1.000000000000000000e+00" ID="OWUHKQHHAEV"/>
+        <ThetaIndex Value="1.000000000000000000e+00" ID="YKBJIMUIGWL"/>
+      </WaveDrag>
+    </ParmContainer>
+    <ReferenceGeomID/>
+    <FlowSS_List/>
+  </WaveDragMgr>
+  <ParasiteDragMgr>
+    <ParmContainer>
+      <ID>CGOQIJTRIH</ID>
+      <Name>ParasiteDragSettings</Name>
+      <ParasiteDrag>
+        <Alt Value="2.000000000000000000e+04" ID="UPWNKTQBEEX"/>
+        <AltLengthUnit Value="0.000000000000000000e+00" ID="HEVNPWPNCLG"/>
+        <DeltaTemp Value="0.000000000000000000e+00" ID="OAEILLAOYVU"/>
+        <Density Value="7.646999999999999631e-02" ID="EKTOEBYRVDO"/>
+        <DynaVisc Value="9.999999999999999799e-13" ID="MQNNFAFSPFL"/>
+        <ExcresType Value="0.000000000000000000e+00" ID="AZBRYTWAZBG"/>
+        <ExcresVal Value="0.000000000000000000e+00" ID="UWODSCRMBVK"/>
+        <ExportSubCompFlag Value="0.000000000000000000e+00" ID="ILGTLVRJDWF"/>
+        <FreestreamType Value="0.000000000000000000e+00" ID="TLXLSYBAXGX"/>
+        <LamCfEqnType Value="0.000000000000000000e+00" ID="FZXDCHHOWCT"/>
+        <LengthUnit Value="4.000000000000000000e+00" ID="MECYNYTZRUE"/>
+        <Mach Value="0.000000000000000000e+00" ID="LLOAWPTXOFT"/>
+        <Pres Value="2.116221000000000004e+03" ID="GWDCHHIPVAH"/>
+        <Re_L Value="0.000000000000000000e+00" ID="RXFCLTTBZDE"/>
+        <RefFlag Value="0.000000000000000000e+00" ID="MFOXNKZOGQR"/>
+        <Set Value="1.000000000000000000e+00" ID="GSXOMUSTGME"/>
+        <SortBy Value="0.000000000000000000e+00" ID="NRZHRWTGRJN"/>
+        <SpecificHeatRatio Value="1.399999999999999911e+00" ID="UBOXONDGBBX"/>
+        <Sref Value="1.000000000000000000e+02" ID="LIMFFUUMWCB"/>
+        <Temp Value="2.881499999999999773e+02" ID="GAFFCBYZYXW"/>
+        <TempUnit Value="2.000000000000000000e+00" ID="QALJVCNODPV"/>
+        <TurbCfEqnType Value="1.000000000000000000e+01" ID="HGHCPXOFCOV"/>
+        <Vinf Value="5.000000000000000000e+02" ID="HFIIXYPLQHE"/>
+        <VinfUnitType Value="0.000000000000000000e+00" ID="VHQNGJLHVZB"/>
+      </ParasiteDrag>
+    </ParmContainer>
+    <ReferenceGeomID/>
+    <Excrescence>
+      <NumExcres>0</NumExcres>
+    </Excrescence>
+  </ParasiteDragMgr>
+  <AeroStructMgr>
+    <ParmContainer>
+      <ID>YGOOJUXQQM</ID>
+      <Name>AeroStructSettings</Name>
+      <AeroStructure>
+        <CurrStructAssyIndex Value="-1.000000000000000000e+00" ID="ZIRIYFSBFCW"/>
+        <DynamicPressure Value="0.000000000000000000e+00" ID="XNNPEQGPPDF"/>
+      </AeroStructure>
+    </ParmContainer>
+  </AeroStructMgr>
+  <Background3D>
+    <Num_of_Background3Ds>0</Num_of_Background3Ds>
+  </Background3D>
+  <SetNames>
+    <Set>All</Set>
+    <Set>Shown</Set>
+    <Set>Not_Shown</Set>
+    <Set>Set_0</Set>
+    <Set>Set_1</Set>
+    <Set>Set_2</Set>
+    <Set>Set_3</Set>
+    <Set>Set_4</Set>
+    <Set>Set_5</Set>
+    <Set>Set_6</Set>
+    <Set>Set_7</Set>
+    <Set>Set_8</Set>
+    <Set>Set_9</Set>
+    <Set>Set_10</Set>
+    <Set>Set_11</Set>
+    <Set>Set_12</Set>
+    <Set>Set_13</Set>
+    <Set>Set_14</Set>
+    <Set>Set_15</Set>
+    <Set>Set_16</Set>
+    <Set>Set_17</Set>
+    <Set>Set_18</Set>
+    <Set>Set_19</Set>
+  </SetNames>
+</Vsp_Geometry>

--- a/oc_fly/example/test_evtol_params.json5
+++ b/oc_fly/example/test_evtol_params.json5
@@ -22,9 +22,28 @@
 		r_0: [0.9, 0.9, 0.9, 0.9],
 		a1: 1.0e-5,
 	},
+	results: {
+        inflow_slices: [
+			{
+				resolution: [256, 256, 101],
+				slice_start: [-2.5, -2.5, -1.0],
+				slice_size: [5, 5, 2.0]
+			}
+		],
+		wake_slices: [
+			{
+				resolution: [456, 152, 80],
+				slice_start: [-3.0, -3.0, -1],
+				slice_size: [18, 6, 3]
+			}
+		],
+		spanwise_time_series: [
+			0.87
+		],
+	},
 	flight_conditions: [
 		{
-			name: "Forward_flight",
+			name: "Farward_flight",
 			aoa: 0,
 			density: 1.2055,
 			sos: 341.7,
@@ -42,10 +61,10 @@
             //     268.8,
             //     0
             // ],
-			V_inf: 5.0,
+			V_inf: 32.5,
 			observer_file: "helinovi_observers_climb.json5",
 			acoustics_file: "acoustics_total_noise.json",
-			run_for: 0.0,
+			run_for: 1.0,
 			// Indicates that this frame is used to trim the rotor.
 			// Will use the provided axis as the trim axis.
 			// If an axis angle function has been also specified, then
@@ -58,9 +77,9 @@
 					omega: 200
 				},
 				{
-					frame: "LiftRotor_symmetry",
+					frame: "LiftRotor_2",
 					blade_element_func: "rotation",
-					omega: -200
+					omega: 200
 				},
 				{
 					frame: "CruiseProp",
@@ -68,9 +87,9 @@
 					omega: -200
 				},
                 {
-					frame: "CruiseProp_symmetry",
+					frame: "CruiseProp_2",
 					blade_element_func: "rotation",
-					omega: 200
+					omega: -200
 				},
 				{
 					frame: "HingeGeom",
@@ -78,7 +97,7 @@
 					angle: 30
 				},
 				{
-					frame: "HingeGeom_symmetry",
+					frame: "HingeGeom_2",
 					axis_angle_function: "static",
 					angle: 30
 				},

--- a/oc_fly/source/simulate_aircraft.py
+++ b/oc_fly/source/simulate_aircraft.py
@@ -80,8 +80,17 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 	vtk_rotors = [build_base_vtu_rotor(vehicle.aircraft.rotors[rotor_idx]) for rotor_idx in range(num_rotors)]
 	vtk_wake = build_base_vtu_wake(vehicle.wake_history.history[0])
 	vtk_wing = [build_base_vtu_wing(vehicle.aircraft.wings[w_idx]) for w_idx in range(num_wings)]
-	
-	#C_T_len = int(round(2.0*math.pi/(dt*max(abs(omegas)))))
+
+	for rotor_idx in range(num_rotors):
+		print("writing rotor and wake vtu")
+		origin = vehicle.aircraft.rotors[rotor_idx].frame.global_position()
+		print(f'{vehicle.aircraft.rotors[rotor_idx].frame.name} location: {origin[0]}, {origin[1]}, {origin[2]}')
+			
+	for wing_idx in range(num_wings):
+		print("writing wing vtu")
+		origin = vehicle.aircraft.wings[wing_idx].frame.global_position()
+		print(f'{vehicle.aircraft.wings[wing_idx].frame.name} location: {origin[0]}, {origin[1]}, {origin[2]}')
+		
 	C_T_len = np.round(2.0*math.pi/(dt*np.abs(omegas))).astype(dtype=np.int64)
 
 	num_rotors = vehicle.input_state.rotor_inputs.length()
@@ -552,6 +561,7 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 		while not sim_done:
 
 			if (iteration > 0) and (iteration % int(convergence_rev_multiple*iter_per_rev) == 0):
+				
 				max_l2 = 1000
 				for rotor_idx in range(num_rotors):
 					if convergence_type == 'wake':

--- a/source/opencopter/bladeelement.d
+++ b/source/opencopter/bladeelement.d
@@ -163,7 +163,7 @@ void compute_blade_properties(BG, BS, RG, RIS, RS, AS, W)   (auto ref BG blade, 
 		blade_state.chunks[chunk_idx].shed_u_p[] = -shed_projected_vel[2][]/(rotor.radius*abs(rotor_input.angular_velocity));
 		blade_state.chunks[chunk_idx].u_p[] = u_p[];
 
-		immutable Chunk mu_sin_azimuth = -rotor_state.advance_ratio*sin_azimuth[];
+		immutable Chunk mu_sin_azimuth = rotor_state.advance_ratio*sin_azimuth[];
 
 		immutable Chunk u_t = (blade.chunks[chunk_idx].r[] + std.math.sgn(rotor_input.angular_velocity)*mu_sin_azimuth[])*cos_sweep[];
 		
@@ -277,6 +277,7 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 	rotor_state.C_Q = 0.0;
 	rotor_state.C_Mx = 0.0;
 	rotor_state.C_My = 0.0;
+	bool calc_dynamic_inflow_wake = false;
 
 	import std.math : cos, sin, abs;
 	import std.stdio : writeln;
@@ -295,7 +296,8 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 
 	foreach(blade_idx; 0..rotor.blades.length) {
 
-		if(iteration > 0) {
+		if(calc_dynamic_inflow_wake){
+			if(iteration > 0) {
 			//writeln("\n blade properites for blade ", blade_idx);
 			rotor.blades[blade_idx].compute_blade_properties(
 				rotor_state.blade_states[blade_idx],
@@ -328,18 +330,18 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 			
 			rotor_state.C_Mx += rotor_frame_moments[0];
 			rotor_state.C_My += rotor_frame_moments[1];
-		}
+			}
 
-		foreach(chunk_idx, ref blade_chunk; rotor_state.blade_states[blade_idx].chunks) {
-			backup_CT[chunk_idx][] = blade_chunk.dC_T[];
-			blade_chunk.dynamic_u_p[] = blade_chunk.u_p[];
-			blade_chunk.dynamic_dC_Db_induced[] = blade_chunk.dC_Db_induced[];
-			blade_chunk.dynamic_dC_Db_profile[] = blade_chunk.dC_Db_profile[];
-			blade_chunk.aoa_eff[] = blade_chunk.aoa[];
-		}
-
-		//writeln("\n blade properites for blade ", blade_idx);
-		rotor.blades[blade_idx].compute_blade_properties(
+			foreach(chunk_idx, ref blade_chunk; rotor_state.blade_states[blade_idx].chunks) {
+				backup_CT[chunk_idx][] = blade_chunk.dC_T[];
+				blade_chunk.dynamic_u_p[] = blade_chunk.u_p[];
+				blade_chunk.dynamic_dC_Db_induced[] = blade_chunk.dC_Db_induced[];
+				blade_chunk.dynamic_dC_Db_profile[] = blade_chunk.dC_Db_profile[];
+				blade_chunk.aoa_eff[] = blade_chunk.aoa[];
+			}
+		}else{
+			//writeln("\n blade properites for blade ", blade_idx);
+			rotor.blades[blade_idx].compute_blade_properties(
 			rotor_state.blade_states[blade_idx],
 			rotor,
 			rotor_input,
@@ -352,14 +354,13 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 			atmo, 
 			trackBWIevents,
 			converged
-		);
-		//writeln("blade state calculation done \n");
+			);
+			//writeln("blade state calculation done \n");
 
-		foreach(chunk_idx, ref blade_chunk; rotor_state.blade_states[blade_idx].chunks) {
-			blade_chunk.dC_T[] = backup_CT[chunk_idx][];
-		}
+			/*foreach(chunk_idx, ref blade_chunk; rotor_state.blade_states[blade_idx].chunks) {
+				blade_chunk.dC_T[] = backup_CT[chunk_idx][];
+			}*/
 
-		if(iteration == 0) {
 			auto blade_frame_forces = Vec4(0, 0, rotor_state.blade_states[blade_idx].C_T, 0);
 			auto blade_frame_moments = Vec4(0.0, rotor_state.blade_states[blade_idx].C_My, rotor_state.blade_states[blade_idx].C_Mz, 0.0);
 			
@@ -375,6 +376,7 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 			rotor_state.C_Mx += rotor_frame_moments[0];
 			rotor_state.C_My += rotor_frame_moments[1];
 		}
+		
 	}
 
 	rotor_state.C_T = C_T;
@@ -386,7 +388,7 @@ void print_frame(F)(F frame, int depth = 0) {
 	import std.stdio : writeln;
 	import std.range : repeat;
 
-	writeln("\t".repeat(depth).join, " ", frame.name, ": ", frame.local_matrix);
+	writeln("\t".repeat(depth).join, " ", frame.name, ": ", frame.local_matrix, "global_matrix = ", frame.global_matrix);
 
 	foreach(ref child; frame.children) {
 		print_frame(child, depth + 1);

--- a/source/opencopter/io.d
+++ b/source/opencopter/io.d
@@ -279,6 +279,17 @@ double[] cubic_bezier_approx(double[], double[], double[]) {
 	return new double[0];
 }
 
+void print_frame(F)(F frame, int depth = 0) {
+	import std.stdio : writeln;
+	import std.range : repeat;
+
+	writeln("\t".repeat(depth).join, " ", frame.name, ": ", frame.local_matrix, "\t global matrix: ", frame.global_matrix);
+
+	foreach(ref child; frame.children) {
+		print_frame(child, depth + 1);
+	}
+}
+
 AircraftT!AC create_aircraft_from_vsp(ArrayContainer AC)(string filename, size_t elements = 48, size_t span_elements = 8, size_t chord_elements = 4) {
 
 	AircraftT!AC ac;
@@ -466,6 +477,10 @@ AircraftT!AC create_aircraft_from_vsp(ArrayContainer AC)(string filename, size_t
 
 		foreach(child_id; frame_data.child_ids) {
 			writeln("\tGoing into__foreach(child_id; frame_data.child_ids)__loop ");
+			if ((frame_data.frame.frame_type == FrameType.wing) && (frame_data.symmetry != PlanarSymetry.none)){
+				writeln("changeing wing symmetry to none");
+				frame_data.symmetry = PlanarSymetry.none;
+			}
 			if((frame_data.symmetry != PlanarSymetry.none) && !symmetry_applied) {
 				auto frame = geom_dict[child_id].frame;
 

--- a/source/opencopter/python.d
+++ b/source/opencopter/python.d
@@ -67,8 +67,9 @@ void basic_aircraft_rotor_dynamics(PyAircraftInputState* ac_input, double dt) {
 		// Keep the azimuth between 0 and 2*PI so we don't
 		// lose fp precicion as the sim marches in time and
 		// the azimuth grows unbounded.
-		if(rotor.azimuth > 2.0*PI) {
-			rotor.azimuth = fmod(abs(rotor.azimuth), 2.0*PI);
+		rotor.azimuth = fmod(rotor.azimuth, 2.0*PI);
+		if(rotor.azimuth < 0.0){
+			rotor.azimuth += 2.0*PI;
 		}
 	}
 }


### PR DESCRIPTION
The simulation produced NaNs in rotor thrust for high forward flight velocity. Resolved this issue. 
Additionally, the enabled symmetry in the OpenVSP geometry was creating an issue, making the wake structure incorrect, i.e., it was producing non-symmetrical wake structure for counter-rotating right and left rotor pairs for test_evtol. Therefore, added the OpenVSP geometry constructed without symmetry in the rotors (also included in this commit), and made a small change in io.d to take care of the wing symmetry (as we can't make a full wing without using symmetry in OpenVSP. 
Changes in python.d in the function basic_aircraft_rotor_dynamics(), which was producing rotor azimuth out of the bounds of [0,360]. 
The major thing to note is that the symmetry option in OpenVSP is currently not recommended, as it produces incorrect results and will need to be fixed later.

Tested two cases: the hart and test_evto (without symmetry enabled in OpenVSP geometry).
Both cases run well. The results for the test_evtol case are now correct (Getting the same results that were discussed with Dr. Greenwood during the meetings that were approved.)