### PR TITLE
Fixes and changes courtesy of BRRC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ oc_fly/example/hart_ii/*.pdf
 oc_fly/example/helinovi/*.pdf
 *.svg
 .DS_Store
+oc_fly/example/helinovi/ID*
+oc_fly/example/hart_ii/BL
+oc_fly/example/hart_ii/MN
+oc_fly/example/hart_ii/MV

--- a/oc_fly/example/hart_ii/plot_hart.py
+++ b/oc_fly/example/hart_ii/plot_hart.py
@@ -628,14 +628,13 @@ def plot_acoustic_contours(plot_name: str, presentation: bool):
 	y.reverse()
 
 	#print(x)
-	offset = x[0] - -4.0
-
+	#offset = x[0] - -4.0
 	#clevels = np.linspace(85, 119, 18)
 	clevels = np.linspace(86, 118, 17)
 
 	#light_rainbow = cmap_map(lambda x: x/2 + 0.5, matplotlib.cm.rainbow)
 
-	print([(_x - offset)/R for _x in x])
+	print([(_x)/R for _x in x])
 	print([_y/R for _y in y])
 	print(x_grid[0,:])
 	print(y_grid[:,0])
@@ -658,7 +657,7 @@ def plot_acoustic_contours(plot_name: str, presentation: bool):
 	ax0 = plt.subplot(121)
 	plt.plot(rotor_x, rotor_z, 'k', linewidth=1.5)
 	#plt2 = plt.contour([-_y/R for _y in y], [-(_x - offset)/R for _x in x], oaspl_db, levels=clevels, cmap=cmap_lines, linewidths=0.5)
-	plt1 = plt.contourf([-_y/R for _y in y], [-(_x - offset)/R for _x in x], oaspl_db, levels=clevels, cmap=hart_cmap)
+	plt1 = plt.contourf([-_y/R for _y in y], [-_x/R for _x in x], oaspl_db, levels=clevels, cmap=hart_cmap)
 	#plt.plot(mic_y, mic_x, 'k.', markersize=7)
 	#plt.clabel(plt2, clevels, inline=True, colors='k', fontsize=5)
 	#clabels = plt.clabel(plt2, clevels, colors='k', fontsize=font_size35)
@@ -1994,11 +1993,11 @@ if __name__ == "__main__":
 
 	#plot_spectrum('BL')
 
-	plot_acoustic_contours_all("BL", args.p)
-	plot_acoustic_contours_all("MN", args.p)
-	plot_acoustic_contours_all("MV", args.p)
+	# plot_acoustic_contours_all("BL", args.p)
+	# plot_acoustic_contours_all("MN", args.p)
+	# plot_acoustic_contours_all("MV", args.p)
 
-	# plot_acoustic_contours("BL", args.p)
+	plot_acoustic_contours("BL", args.p)
 	# plot_acoustic_contours_cfd("BL", args.p)
 	# plot_acoustic_contours_charm("BL", args.p)
 	# #plot_blade_twist('BL', args.p)

--- a/oc_fly/example/hart_ii_observers.json5
+++ b/oc_fly/example/hart_ii_observers.json5
@@ -7,7 +7,7 @@
 		radii_relative: true,
 		// Rotor 0 is the rotor to be relative to
 		reference_rotor: 0,
-		nb: [23, 17, 1],
+		nb: [13, 17, 1],
 		//"nb": [2, 2, 1],
 		min: [-2, -1.345, -1.1075],
 		max: [2, 1.345, -1.1075]

--- a/oc_fly/example/helinovi_params.json5
+++ b/oc_fly/example/helinovi_params.json5
@@ -6,7 +6,7 @@
 		shed_release_angle: 2,
 
 		convergence_criteria: 5.0e-5,
-		post_conv_revolutions: 6,
+		post_conv_revolutions: 2,
 		wake_trail_distance: [15, 4],
 
 		//wake_trail_distance: [, 1],
@@ -19,8 +19,7 @@
 		convergence_rotor: 0,
 		convergence_rev_multiple: 5,
 		r_0: [0.9, 1.0],
-		a1: 1.0e-5,
-		
+		a1: 1.0e-5
 	},
 	flight_conditions: [
 		// {

--- a/oc_fly/source/simulate_aircraft.py
+++ b/oc_fly/source/simulate_aircraft.py
@@ -73,7 +73,10 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 	d_psi = computational_parameters['d_psi']
 
 	dt = d_psi*(math.pi/180.0)/np.max(np.abs(omegas))
-	iter_per_rev = 360/d_psi
+
+	# rescale iter_per_rev to be based off slowest rotor in the system
+	min_max_omega_ratio = np.max(np.abs(omegas))/np.min(np.abs(omegas))
+	iter_per_rev = 360/d_psi*int(np.round(min_max_omega_ratio))
 
 	d_psi = d_psi*np.abs(omegas)/np.max(np.abs(omegas))
 
@@ -1395,8 +1398,8 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 
 		min_omega = np.min(np.abs(omegas))
 
-		tau_min = 0.5*(1.0*math.pi/min_omega)
-		tau_max = tau_min + (post_conv_revolutions - 0.5)*(2.0*math.pi/min_omega)
+		#tau_min = 0.5*(1.0*math.pi/min_omega)
+		#tau_max = tau_min + (post_conv_revolutions - 0.5)*(2.0*math.pi/min_omega)
 
 		min_obs_dist = math.inf
 		max_obs_dist = -math.inf
@@ -1456,9 +1459,16 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 
 					min_obs_dist = min(min_obs_dist, dist)
 					max_obs_dist = max(max_obs_dist, dist)
-			
-		t_min = tau_min + min_obs_dist/flight_condition["sos"]
-		t_max = tau_max + max_obs_dist/flight_condition["sos"]
+
+		min_propagation_time_to_observer = min_obs_dist/flight_condition["sos"]
+		max_propagation_time_to_observer = max_obs_dist/flight_condition["sos"]
+		ref_revolution_time = 2.0*math.pi/min_omega
+		revolution_offset = np.ceil(ref_revolution_time / min_propagation_time_to_observer)
+		t_min = min_propagation_time_to_observer
+		if(revolution_offset > post_conv_revolutions):
+			t_max = t_min + post_conv_revolutions*ref_revolution_time + max_propagation_time_to_observer
+		else:
+			t_max = t_min + (post_conv_revolutions - revolution_offset)*ref_revolution_time
 
 		nt = int(round((t_max - t_min)/dt))
 

--- a/oc_fly/source/simulate_aircraft.py
+++ b/oc_fly/source/simulate_aircraft.py
@@ -1466,7 +1466,7 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 		revolution_offset = np.ceil(ref_revolution_time / min_propagation_time_to_observer)
 		t_min = min_propagation_time_to_observer
 		if(revolution_offset > post_conv_revolutions):
-			t_max = t_min + post_conv_revolutions*ref_revolution_time + max_propagation_time_to_observer
+			t_max = t_min + post_conv_revolutions*ref_revolution_time
 		else:
 			t_max = t_min + (post_conv_revolutions - revolution_offset)*ref_revolution_time
 

--- a/oc_fly/source/wopwop_input_files_generator.py
+++ b/oc_fly/source/wopwop_input_files_generator.py
@@ -331,7 +331,11 @@ def generate_wopwop_namelist(atmo, dt, V_inf, iterations, aoa, t_min, t_max, nt,
 		else:
 			observer.highPassFrequency = observer_config["high_pass_cutoff"]
 
-	observer.cobs = [aircraft_cob]
+	observer.cobs = wopwop_aircraft.cobs
+
+	if ("attached_to_aircraft" in observer_config) and observer_config["attached_to_aircraft"]:
+		observer.cobs = []
+		observer.attachedTo = wopwop_aircraft.Title
 
 	if "frequency_ranges" in observer_config:
 


### PR DESCRIPTION
Fixed long standing issue with observers following the vehicle being backwards.

Fixed another issue where we were basing the iter_per_rev and the observer time range on the fastest rotor in the system. This is good for setting the timestep, but not the total run time. Now we base iter_per_rev and all other per rev things off the slowest rotor so that we ensure we always capture the minimum amount of data for the slowest rotor in the system.