### PR TITLE
Bug fixes and BWI modifications

### DIFF
--- a/oc_fly/source/simulate_aircraft.py
+++ b/oc_fly/source/simulate_aircraft.py
@@ -399,21 +399,21 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 
 	# Nitya: checking if these gets stored in the matlab file!
 
-	wake_idx =  [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	bladeSec_idx = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	#wake_miss_dist = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	blade_directionVec = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	directionVec_bv = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	vortex_directionVec = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]for _ in range(num_rotors)] for _ in range(num_rotors)]
-	normalVec = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	missDist = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	gammaSec =[[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	gammaVortex = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	r_c = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	C_d = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	l = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	secLen =[[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
-	#TKE = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
+	# wake_idx =  [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# bladeSec_idx = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# #wake_miss_dist = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
+	# blade_directionVec = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# directionVec_bv = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# vortex_directionVec = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# normalVec = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# missDist = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# gammaSec =[[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# gammaVortex = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# r_c = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# C_d = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# l = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# secLen =[[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	# #TKE = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
 	
 	class Interaction:
 		def __init__(self):
@@ -675,11 +675,12 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 
 			step_start = time.perf_counter_ns()
 
-			print('before step iteration:', iteration)
+			# print('before step iteration:', iteration)
 
 			step(vehicle.ac_state, vehicle.aircraft, vehicle.input_state, vehicle.wake_history, atmo, iteration, dt, trackBWIevents, converged)
 			average_step = average_step + (time.perf_counter_ns() - step_start)
-			print('after step iteration:', iteration)
+			# print('after step iteration:', iteration)
+			
 			# for rotor_idx in range(num_rotors):
 			# 	for blade_idx in range(num_rotors):
 			# 		for rotor_idx_2 in range(num_rotors):
@@ -865,8 +866,11 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 
 				#if not converged:
 				dt = computational_parameters['d_psi']*(math.pi/180.0)/np.max(np.abs(np.asarray(omegas)))
-
+			numBladesArray = np.zeros(num_rotors, dtype=int)
 			for rotor_idx, rotor_state in enumerate(vehicle.ac_state.rotor_states):
+				
+				numBladesArray[rotor_idx] = rotor_state.blade_states.length()
+				# print(numBladesArray)
 				if ((rotor_idx == 1) and (vehicle.name == "helinovi")) or ((rotor_idx == 0) and (vehicle.name == "helinovi_tr")):
 					net_blade_moment = rotor_state.blade_states[0].C_My
 					# for _, blade_state in enumerate(rotor_state.blade_states):
@@ -903,7 +907,7 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 			loading_data.time = dt*acoustic_iteration
 
 			if converged:
-				print('converged: acoustic_iteration:', acoustic_iteration);
+				# print('converged: acoustic_iteration:', acoustic_iteration);
 				if write_wake and (converged_revolutions >= (post_conv_revolutions - 1)):
 					for rotor_idx in range(num_rotors):
 						print("writing rotor and wake vtu")
@@ -923,8 +927,23 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 				if acoustic_iteration == 0:
 					for rotor_idx in range(num_rotors):
 						rotor_phases[rotor_idx] = vehicle.input_state.rotor_inputs[rotor_idx].azimuth
+				
 
 				for rotor_idx, rotor in enumerate(vehicle.ac_state.rotor_states):
+
+					wake_idx =  [[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+					bladeSec_idx = [[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+					blade_directionVec = [[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+					directionVec_bv = [[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+					vortex_directionVec = [[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))]for _ in range(num_rotors)] for _ in range(num_rotors)]
+					normalVec = [[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+					missDist = [[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+					gammaSec =[[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+					gammaVortex = [[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+					r_c = [[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+					C_d = [[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+					l = [[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+					secLen =[[[[[] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
 
 					blade_idx = 2
 					if (rotor_idx > 0) or ((rotor_idx == 0) and (vehicle.name == "helinovi_tr")):
@@ -1028,26 +1047,44 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 						# Nitya, 09.16
 						
 						if(trackBWIevents):
-							print('1. acoustic_iteration:', acoustic_iteration)
+							# print('1. acoustic_iteration:', acoustic_iteration)
 							for rotor_idx_2 in range(num_rotors):
 								#print(vehicle.wake_history.history[0].rotor_wakes[rotor_idx].interaction_perRotor[rotor_idx_2].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length())
 								for blade_idx2 in range(0,vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length()):
-									#lenDebug = len(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction)
-									#print('1. blade_idx2:', blade_idx2, 'rotor_idx_2:', rotor_idx_2, 'blade_idx:', blade_idx, 'rotor_idx:', rotor_idx)
-									wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append( get_interactionPt_wake_idx(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									bladeSec_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interactionPt_bladeSec_idx(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									blade_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_blade(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									directionVec_bv[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_blade_v(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									vortex_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_vortex(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									normalVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_blade_normal(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									missDist[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_miss_dist(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									gammaSec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_gamma_sec(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									gammaVortex[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_gamma_w(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									r_c[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_c(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									C_d[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_C_d(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									l[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_l(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									secLen[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_secLen(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-									#TKE[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_TKE(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append( get_interactionPt_wake_idx(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# bladeSec_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interactionPt_bladeSec_idx(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# blade_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_r_blade(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# directionVec_bv[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_r_blade_v(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# vortex_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_r_vortex(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# normalVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_blade_normal(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# missDist[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_miss_dist(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# gammaSec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_gamma_sec(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# gammaVortex[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_gamma_w(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# r_c[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_r_c(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# C_d[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_C_d(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# l[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_l(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									# secLen[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_secLen(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									
+									tvi = vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]
+									temp_out = []
+									tmep_out2 = []
+									fill_interactionPt_wake_idx(tvi, wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2])
+
+									tmep_out2 = get_interactionPt_wake_idx(tvi)
+
+									wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interactionPt_wake_idx(tvi))
+									bladeSec_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interactionPt_bladeSec_idx(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									blade_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_r_blade(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									directionVec_bv[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_r_blade_v(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									vortex_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_r_vortex(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									normalVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_blade_normal(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									missDist[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_miss_dist(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									gammaSec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_gamma_sec(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									gammaVortex[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_gamma_w(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									r_c[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_r_c(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									C_d[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_C_d(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									l[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_l(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									secLen[rotor_idx][rotor_idx_2][blade_idx][blade_idx2].append(get_interaction_point_secLen(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
 									
 														 
 						fill_aoaf(blade, aoa_array)
@@ -1065,29 +1102,30 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 						K2 = 0.11
 
 						for rotor_idx_2 in range(num_rotors):
-							for blade_idx2 in range(len(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration])):
-								for blade_idx in range(0,rotor.blade_states.length()):
+							size2 = len(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2])
+							for blade_idx2 in range(numBladesArray[rotor_idx_2]):
+								for blade_idx in range(numBladesArray[rotor_idx]):
 								
-									if len(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration])>1:
+									if len(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2])>1:
 										print('change the logic')
-									size = len(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0])
+									size = len(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0])
 
 									for i in range (0,size):
-										if wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i] > 2:
+										if wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i] > 2:
 											interaction[blade_idx2].blade_idx.extend([blade_idx])
-											interaction[blade_idx2].wake_idx.append(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
-											interaction[blade_idx2].directionVec_bv.append(directionVec_bv[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
-											interaction[blade_idx2].secIdx.append(bladeSec_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
-											interaction[blade_idx2].vortex_directionVec.append(vortex_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
-											interaction[blade_idx2].blade_directionVec.append(blade_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
-											interaction[blade_idx2].normalVec.append(normalVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
-											interaction[blade_idx2].missDist.append(missDist[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
-											interaction[blade_idx2].gamma.append(gammaVortex[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
-											interaction[blade_idx2].Cd.append(C_d[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
-											interaction[blade_idx2].r_c.append(r_c[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
-											interaction[blade_idx2].l.append(l[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+											interaction[blade_idx2].wake_idx.append(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i])
+											interaction[blade_idx2].directionVec_bv.append(directionVec_bv[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i])
+											interaction[blade_idx2].secIdx.append(bladeSec_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i])
+											interaction[blade_idx2].vortex_directionVec.append(vortex_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i])
+											interaction[blade_idx2].blade_directionVec.append(blade_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i])
+											interaction[blade_idx2].normalVec.append(normalVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i])
+											interaction[blade_idx2].missDist.append(missDist[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i])
+											interaction[blade_idx2].gamma.append(gammaVortex[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i])
+											interaction[blade_idx2].Cd.append(C_d[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i])
+											interaction[blade_idx2].r_c.append(r_c[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i])
+											interaction[blade_idx2].l.append(l[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i])
 										else:
-											interaction[blade_idx2].gamma0 = gammaVortex[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i]
+											interaction[blade_idx2].gamma0 = gammaVortex[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][0][i]
 
 									
 										#append_bwi_data(bwi_files[rotor_idx][blade_idx], loading_data.time, aoa_array, 2.0*math.pi, u)
@@ -1260,8 +1298,9 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 								b_e = [b_e_full[i] for i in filtered_indices]
 								Uref = [Uref_full[i] for i in filtered_indices]
 								#print('b_e:', b_e)
-							print('writing rotor_idx:', rotor_idx, 'blade_idxx:', blade_idxx)
+							# print('writing rotor_idx:', rotor_idx, 'blade_idxx:', blade_idxx)
 							append_bwi_data(bwi_files[rotor_idx][blade_idxx], loading_data.time, nInteractions, ID, psi, sec_idx, wake_angle, missDist2, vortex_len, L0, b_e, Uref)		
+							
 
 				spanwise_element_iteration = spanwise_element_iteration + 1
 				

--- a/oc_fly/source/simulate_aircraft.py
+++ b/oc_fly/source/simulate_aircraft.py
@@ -399,20 +399,20 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 
 	# Nitya: checking if these gets stored in the matlab file!
 
-	wake_idx =  [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	bladeSec_idx = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
+	wake_idx =  [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	bladeSec_idx = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
 	#wake_miss_dist = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	blade_directionVec = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	directionVec_bv = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	vortex_directionVec = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	normalVec = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	missDist = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	gammaSec =[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	gammaVortex = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	r_c = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	C_d = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	l = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
-	secLen =[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
+	blade_directionVec = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	directionVec_bv = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	vortex_directionVec = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]for _ in range(num_rotors)] for _ in range(num_rotors)]
+	normalVec = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	missDist = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	gammaSec =[[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	gammaVortex = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	r_c = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	C_d = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	l = [[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
+	secLen =[[[[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))] for _ in range(num_rotors)] for _ in range(num_rotors)]
 	#TKE = [[[[] for _ in range(int(round(post_conv_revolutions*iter_per_rev)) + 1)] for _ in range(max(num_blades))] for _ in range(max(num_blades))]
 	
 	class Interaction:
@@ -675,9 +675,18 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 
 			step_start = time.perf_counter_ns()
 
+			print('before step iteration:', iteration)
+
 			step(vehicle.ac_state, vehicle.aircraft, vehicle.input_state, vehicle.wake_history, atmo, iteration, dt, trackBWIevents, converged)
 			average_step = average_step + (time.perf_counter_ns() - step_start)
+			print('after step iteration:', iteration)
+			# for rotor_idx in range(num_rotors):
+			# 	for blade_idx in range(num_rotors):
+			# 		for rotor_idx_2 in range(num_rotors):
 
+			# 			len1 = vehicle.wake_history.history[0].rotor_wakes[rotor_idx].interaction_perRotor[rotor_idx_2].blade_vortex_interaction.length()
+			# 			len2 = vehicle.wake_history.history[0].rotor_wakes[rotor_idx].interaction_perRotor[rotor_idx_2].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length()
+			
 			if math.isnan(vehicle.ac_state.rotor_states[0].C_T):
 				raise FloatingPointError("Simulation failed: Encountered NaN in rotor thrust")
 			
@@ -894,7 +903,7 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 			loading_data.time = dt*acoustic_iteration
 
 			if converged:
-
+				print('converged: acoustic_iteration:', acoustic_iteration);
 				if write_wake and (converged_revolutions >= (post_conv_revolutions - 1)):
 					for rotor_idx in range(num_rotors):
 						print("writing rotor and wake vtu")
@@ -1017,24 +1026,29 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 
 						real_c = radii[rotor_idx]*np.asarray(get_chord(vehicle.aircraft.rotors[rotor_idx].blades[blade_idx]), dtype=np.single)
 						# Nitya, 09.16
+						
 						if(trackBWIevents):
-							for blade_idx2 in range(0,rotor.blade_states.length()):
-								#lenDebug = len(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction)
-								wake_idx[blade_idx][blade_idx2][acoustic_iteration].append( get_interactionPt_wake_idx(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								bladeSec_idx[blade_idx][blade_idx2][acoustic_iteration].append(get_interactionPt_bladeSec_idx(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								blade_directionVec[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_blade(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								directionVec_bv[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_blade_v(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								vortex_directionVec[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_vortex(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								normalVec[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_blade_normal(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								missDist[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_miss_dist(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								gammaSec[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_gamma_sec(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								gammaVortex[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_gamma_w(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								r_c[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_c(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								C_d[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_C_d(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								l[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_l(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								secLen[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_secLen(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								#TKE[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_TKE(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
-								
+							print('1. acoustic_iteration:', acoustic_iteration)
+							for rotor_idx_2 in range(num_rotors):
+								#print(vehicle.wake_history.history[0].rotor_wakes[rotor_idx].interaction_perRotor[rotor_idx_2].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length())
+								for blade_idx2 in range(0,vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length()):
+									#lenDebug = len(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction)
+									#print('1. blade_idx2:', blade_idx2, 'rotor_idx_2:', rotor_idx_2, 'blade_idx:', blade_idx, 'rotor_idx:', rotor_idx)
+									wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append( get_interactionPt_wake_idx(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									bladeSec_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interactionPt_bladeSec_idx(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									blade_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_blade(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									directionVec_bv[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_blade_v(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									vortex_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_vortex(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									normalVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_blade_normal(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									missDist[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_miss_dist(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									gammaSec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_gamma_sec(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									gammaVortex[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_gamma_w(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									r_c[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_r_c(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									C_d[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_C_d(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									l[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_l(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									secLen[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_secLen(vehicle.wake_history.history[0].rotor_wakes[rotor_idx_2].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									#TKE[blade_idx][blade_idx2][acoustic_iteration].append(get_interaction_point_TKE(vehicle.wake_history.history[0].rotor_wakes[0].blade_vortex_interaction[blade_idx].tip_vortex_interaction[blade_idx2]))
+									
 														 
 						fill_aoaf(blade, aoa_array)
 						fill_u_tf(blade, u_t)
@@ -1049,31 +1063,35 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 
 						K1 = 0.09
 						K2 = 0.11
-						for blade_idx2 in range(0,rotor.blade_states.length()):
-							for blade_idx in range(0,rotor.blade_states.length()):
+
+						for rotor_idx_2 in range(num_rotors):
+							for blade_idx2 in range(len(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration])):
+								for blade_idx in range(0,rotor.blade_states.length()):
 								
-								if len(wake_idx[blade_idx][blade_idx2][acoustic_iteration])>1:
-									print('change the logic')
-								size = len(wake_idx[blade_idx][blade_idx2][acoustic_iteration][0])
+									if len(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration])>1:
+										print('change the logic')
+									size = len(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0])
 
-								for i in range (0,size):
-									if wake_idx[blade_idx][blade_idx2][acoustic_iteration][0][i] > 2:
-										interaction[blade_idx2].blade_idx.extend([blade_idx])
-										interaction[blade_idx2].wake_idx.append(wake_idx[blade_idx][blade_idx2][acoustic_iteration][0][i])
-										interaction[blade_idx2].directionVec_bv.append(directionVec_bv[blade_idx][blade_idx2][acoustic_iteration][0][i])
-										interaction[blade_idx2].secIdx.append(bladeSec_idx[blade_idx][blade_idx2][acoustic_iteration][0][i])
-										interaction[blade_idx2].vortex_directionVec.append(vortex_directionVec[blade_idx][blade_idx2][acoustic_iteration][0][i])
-										interaction[blade_idx2].blade_directionVec.append(blade_directionVec[blade_idx][blade_idx2][acoustic_iteration][0][i])
-										interaction[blade_idx2].normalVec.append(normalVec[blade_idx][blade_idx2][acoustic_iteration][0][i])
-										interaction[blade_idx2].missDist.append(missDist[blade_idx][blade_idx2][acoustic_iteration][0][i])
-										interaction[blade_idx2].gamma.append(gammaVortex[blade_idx][blade_idx2][acoustic_iteration][0][i])
-										interaction[blade_idx2].Cd.append(C_d[blade_idx][blade_idx2][acoustic_iteration][0][i])
-										interaction[blade_idx2].r_c.append(r_c[blade_idx][blade_idx2][acoustic_iteration][0][i])
-										interaction[blade_idx2].l.append(l[blade_idx][blade_idx2][acoustic_iteration][0][i])
-									else:
-										interaction[blade_idx2].gamma0 = gammaVortex[blade_idx][blade_idx2][acoustic_iteration][0][i]
+									for i in range (0,size):
+										if wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i] > 2:
+											interaction[blade_idx2].blade_idx.extend([blade_idx])
+											interaction[blade_idx2].wake_idx.append(wake_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+											interaction[blade_idx2].directionVec_bv.append(directionVec_bv[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+											interaction[blade_idx2].secIdx.append(bladeSec_idx[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+											interaction[blade_idx2].vortex_directionVec.append(vortex_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+											interaction[blade_idx2].blade_directionVec.append(blade_directionVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+											interaction[blade_idx2].normalVec.append(normalVec[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+											interaction[blade_idx2].missDist.append(missDist[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+											interaction[blade_idx2].gamma.append(gammaVortex[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+											interaction[blade_idx2].Cd.append(C_d[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+											interaction[blade_idx2].r_c.append(r_c[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+											interaction[blade_idx2].l.append(l[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i])
+										else:
+											interaction[blade_idx2].gamma0 = gammaVortex[rotor_idx][rotor_idx_2][blade_idx][blade_idx2][acoustic_iteration][0][i]
 
-									#append_bwi_data(bwi_files[rotor_idx][blade_idx], loading_data.time, aoa_array, 2.0*math.pi, u)
+									
+										#append_bwi_data(bwi_files[rotor_idx][blade_idx], loading_data.time, aoa_array, 2.0*math.pi, u)
+									#print('2. blade_idx2:', blade_idx2, 'rotor_idx_2:', rotor_idx_2, 'blade_idx:', blade_idx, 'rotor_idx:', rotor_idx)
 
 							
 							#flat_wake_idx = [w[0] if isinstance(w, list) else w for w in interaction[blade_idx].wake_idx]
@@ -1135,6 +1153,7 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 									#perpInteraction[tipV_idx].secLength.append(np.sqrt(secLen[i]))
 							
 						for tipV_idx in range(0,rotor.blade_states.length()):
+							#print('tipV_idx:', tipV_idx)
 							if perpInteraction[tipV_idx].wake_idx:
 								a = perpInteraction[tipV_idx].blade_directionVec
 								b = perpInteraction[tipV_idx].vortex_directionVec
@@ -1189,7 +1208,10 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 										L0_2 = 0.32 * theta[1] * np.sqrt(l_values[1] / theta[1] + 380)
 										value = K1 * np.sqrt(l_values[0]/real_c[0]) + abs(K2*gamma0)/(Uref*real_c[0])*((l_values[0] * L0_1)/real_c[0]**2 + (l_values[1]*L0_2)/real_c[0]**2)
 										perpInteraction_perBlade[blade_idxx].a0.append(value)
-										perpInteraction_perBlade[blade_idxx].b_e.append(np.sqrt(value**2 - missDist2[i]**2))
+										if (value**2 - missDist2[i]**2) > 0.0:
+											perpInteraction_perBlade[blade_idxx].b_e.append(np.sqrt(value**2 - missDist2[i]**2))
+										else:
+											perpInteraction_perBlade[blade_idxx].b_e.append(0.0)
 									else:
 										perpInteraction_perBlade[blade_idxx].a0.append(r_c_values[i]) 
 										perpInteraction_perBlade[blade_idxx].b_e.append(r_c_values[i])
@@ -1200,6 +1222,7 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 										# else:
 										# 	value = 0.0
 										# 	perpInteraction_perBlade[blade_idxx].b_e.append(r_c_values[i])
+									
 						
 						for blade_idxx in range(0,rotor.blade_states.length()): 
 							
@@ -1236,7 +1259,8 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 								L0 = [L0_full[i] for i in filtered_indices]
 								b_e = [b_e_full[i] for i in filtered_indices]
 								Uref = [Uref_full[i] for i in filtered_indices]
-
+								#print('b_e:', b_e)
+							print('writing rotor_idx:', rotor_idx, 'blade_idxx:', blade_idxx)
 							append_bwi_data(bwi_files[rotor_idx][blade_idxx], loading_data.time, nInteractions, ID, psi, sec_idx, wake_angle, missDist2, vortex_len, L0, b_e, Uref)		
 
 				spanwise_element_iteration = spanwise_element_iteration + 1
@@ -1298,6 +1322,7 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 				acoustic_iteration = acoustic_iteration + 1
 
 			iteration = iteration + 1
+			print('iteration:', iteration, 'acoustic_iteration:', acoustic_iteration)
 		for rotor_idx in range(num_rotors):
 			for blade_idx in range(num_blades[rotor_idx]):
 				close_loading_file(loading_files[rotor_idx][blade_idx])
@@ -1324,20 +1349,20 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 			raise FileExistsError("Failed to find results.mat from previous run")
 
 	# Nitya, 09.16
-	if trackBWIevents:
-		result_dictionary['wake_idx'] = np.asarray(wake_idx, dtype=object)
-		result_dictionary['bladeSec_idx'] = np.asarray(bladeSec_idx, dtype=object)
-		result_dictionary['wake_miss_dist'] = np.asarray(missDist, dtype=object)
-		result_dictionary['r_c'] = np.asarray(r_c, dtype=object)
-		result_dictionary['gamma_sec'] = np.asarray(gammaSec, dtype=object)
-		result_dictionary['gamma_vortex'] = np.asarray(gammaVortex, dtype=object)
-		result_dictionary['C_d'] = np.asarray(C_d, dtype=object)
-		result_dictionary['l'] = np.asarray(l, dtype=object)
-		result_dictionary['secLen'] = np.asarray(secLen, dtype=object)
-		result_dictionary['blade_directionVec'] = np.asarray(blade_directionVec, dtype=object)
-		result_dictionary['vortex_directionVec'] = np.asarray(vortex_directionVec, dtype=object)
-		result_dictionary['directionVec_bv'] = np.asarray(directionVec_bv, dtype=object)
-		result_dictionary['normalVec'] = np.asarray(normalVec, dtype=object)
+	# if trackBWIevents:
+	# 	result_dictionary['wake_idx'] = np.asarray(wake_idx, dtype=object)
+	# 	result_dictionary['bladeSec_idx'] = np.asarray(bladeSec_idx, dtype=object)
+	# 	result_dictionary['wake_miss_dist'] = np.asarray(missDist, dtype=object)
+	# 	result_dictionary['r_c'] = np.asarray(r_c, dtype=object)
+	# 	result_dictionary['gamma_sec'] = np.asarray(gammaSec, dtype=object)
+	# 	result_dictionary['gamma_vortex'] = np.asarray(gammaVortex, dtype=object)
+	# 	result_dictionary['C_d'] = np.asarray(C_d, dtype=object)
+	# 	result_dictionary['l'] = np.asarray(l, dtype=object)
+	# 	result_dictionary['secLen'] = np.asarray(secLen, dtype=object)
+	# 	result_dictionary['blade_directionVec'] = np.asarray(blade_directionVec, dtype=object)
+	# 	result_dictionary['vortex_directionVec'] = np.asarray(vortex_directionVec, dtype=object)
+	# 	result_dictionary['directionVec_bv'] = np.asarray(directionVec_bv, dtype=object)
+	# 	result_dictionary['normalVec'] = np.asarray(normalVec, dtype=object)
 
 	if elastic_twist is not None:
 		result_dictionary['elastic_twist_array'] = elastic_twist_array

--- a/oc_fly/source/simulate_aircraft.py
+++ b/oc_fly/source/simulate_aircraft.py
@@ -1361,7 +1361,7 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 				acoustic_iteration = acoustic_iteration + 1
 
 			iteration = iteration + 1
-			print('iteration:', iteration, 'acoustic_iteration:', acoustic_iteration)
+			# print('iteration:', iteration, 'acoustic_iteration:', acoustic_iteration)
 		for rotor_idx in range(num_rotors):
 			for blade_idx in range(num_blades[rotor_idx]):
 				close_loading_file(loading_files[rotor_idx][blade_idx])

--- a/oc_fly/source/simulate_aircraft.py
+++ b/oc_fly/source/simulate_aircraft.py
@@ -1555,6 +1555,7 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 				vehicle.input_state,
 				wopwop_case_path,
 				[rotor_phases[rotor_idx]],
+				rotor_idx,
 				geom_directory
 			)
 
@@ -1584,6 +1585,7 @@ def simulate_aircraft(log_file, vehicle: SimulatedVehicle, atmo, elements, write
 			vehicle.input_state,
 			wopwop_case_path,
 			rotor_phases,
+			rotor_idx,
 			geom_directory
 		)
 

--- a/oc_fly/source/wopwop_input_files_generator.py
+++ b/oc_fly/source/wopwop_input_files_generator.py
@@ -167,7 +167,7 @@ def build_rotor_cntr(rotor, rotor_idx, environment_in, wopwop_motion, rotor_phas
 def flatten(xss):
 	return [x for xs in xss for x in xs]
 
-def generate_wopwop_namelist(atmo, dt, V_inf, iterations, aoa, t_min, t_max, nt, observer_config, acoustics_config, wopwop_data_path, sos, aircraft, rotors, wopwop_motion, ac_input, wopwop_case_path, rotor_phases, geom_directory):
+def generate_wopwop_namelist(atmo, dt, V_inf, iterations, aoa, t_min, t_max, nt, observer_config, acoustics_config, wopwop_data_path, sos, aircraft, rotors, wopwop_motion, ac_input, wopwop_case_path, rotor_phases, rotor_idx2, geom_directory):
 
 	aircraft_cob = CB()
 	aircraft_cob.Title = "Forward Velocity"
@@ -237,8 +237,12 @@ def generate_wopwop_namelist(atmo, dt, V_inf, iterations, aoa, t_min, t_max, nt,
 	environment_in.broadbandFlag = acoustics_config["broadband_flag"] if "broadband_flag" in acoustics_config else False
 	environment_in.BWINoiseFlag = acoustics_config["BWI_flag"] if "BWI_flag" in acoustics_config else False
 
-	wopwop_aircraft.children = flatten([build_rotor_cntr(rotor, rotor_idx, environment_in, wopwop_motion, rotor_phases[rotor_idx], environment_in.broadbandFlag, environment_in.BWINoiseFlag) for rotor_idx, rotor in enumerate(rotors)])
-
+	num_rotors = len(rotor_phases)
+	if (num_rotors>1):
+		wopwop_aircraft.children = flatten([build_rotor_cntr(rotor, rotor_idx, environment_in, wopwop_motion, rotor_phases[rotor_idx], environment_in.broadbandFlag, environment_in.BWINoiseFlag) for rotor_idx, rotor in enumerate(rotors)])
+	else :
+		wopwop_aircraft.children = flatten([build_rotor_cntr(rotor, rotor_idx2, environment_in, wopwop_motion, rotor_phases[rotor_idx], environment_in.broadbandFlag, environment_in.BWINoiseFlag) for rotor_idx, rotor in enumerate(rotors)])
+	
 	R = 1
 	num_blades = 1
 	ref_omega = 1

--- a/source/opencopter/bladeelement.d
+++ b/source/opencopter/bladeelement.d
@@ -64,7 +64,7 @@ InducedVelocities compute_wake_induced_velocities(W, AS)(auto ref W wake, immuta
 	return ret;
 }
 //extern (C++) void compute_blade_properties(BG, BS, RG, RIS, RS, AS, I, W)(auto ref BG blade, auto ref BS blade_state, auto ref RG rotor, auto ref RIS rotor_input, auto ref RS rotor_state, auto ref AS ac_state, I inflow, auto ref W wake, double time, double dt, size_t rotor_idx, size_t blade_idx, immutable Atmosphere atmo, bool trackBWIevents, bool converged)
-void compute_blade_properties(BG, BS, RG, RIS, RS, AS, W)   (auto ref BG blade, auto ref BS blade_state, auto ref RG rotor, auto ref RIS rotor_input, auto ref RS rotor_state, auto ref AS ac_state, auto ref W wake, double dt, size_t rotor_idx, size_t blade_idx, immutable Atmosphere atmo, bool trackBWIevents, bool converged)
+void compute_blade_properties(BG, BS, RG, RIS, RS, AS, W)   (auto ref BG blade, auto ref BS blade_state, auto ref RG rotor, auto ref RIS rotor_input, auto ref RS rotor_state, auto ref AS ac_state, auto ref W wake, double dt, size_t rotor_idx, size_t blade_idx, immutable Atmosphere atmo, size_t iteration, bool trackBWIevents, bool converged)
 	if(is_blade_geometry!BG && is_blade_state!BS && is_rotor_geometry!RG && is_rotor_input_state!RIS && is_rotor_state!RS && is_aircraft_state!AS && is_wake!W)
 {
 	version(LDC) pragma(inline, true);
@@ -254,10 +254,20 @@ void compute_blade_properties(BG, BS, RG, RIS, RS, AS, W)   (auto ref BG blade, 
 			normalVec[1] = updated_normal[1][0];
 			normalVec[2] = updated_normal[2][0];
 			//double[] r = get_geometry_array!"r"(blade);
-			foreach (i_blade_idx; 0..rotor.blades.length) {
-				wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.clear();
-			} 
+			writeln("1. bladeElement, before  iteration:", iteration);
+			foreach (i_rotor_idx; 0..wake.rotor_wakes.length){
+				//writeln("wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length:", wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length);
+				foreach (i_blade_idx; 0..wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length) {
+					/*if(wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.empty){
+						writeln("no interaction point");
+					} else{
+						wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.clear();
+					}*/
+					wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.clear();
+				} 
+			}
 			calculate_BWI_points(wake, blade_state, rotor_idx, blade_idx, blade, normalVec);
+			writeln("1. bladeElement, after iteration:", iteration);
 		}
 	}
 }
@@ -281,8 +291,8 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 	import std.math : cos, sin, abs;
 	import std.stdio : writeln;
 
-	debug writeln("wing geometry frame: ", wings[0].frame);
-	debug writeln("wing geometry frame: ", wings[0].frame.name);
+	//debug writeln("wing geometry frame: ", wings[0].frame);
+	//debug writeln("wing geometry frame: ", wings[0].frame.name);
 
 	foreach(blade_idx; 0..rotor.blades.length) {
 		rotor_state.blade_states[blade_idx].azimuth = rotor_input.azimuth + rotor.blades[blade_idx].azimuth_offset;
@@ -296,6 +306,7 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 	foreach(blade_idx; 0..rotor.blades.length) {
 
 		if(iteration > 0) {
+			debug writeln("1. iteration:", iteration);
 			//writeln("\n blade properites for blade ", blade_idx);
 			rotor.blades[blade_idx].compute_blade_properties(
 				rotor_state.blade_states[blade_idx],
@@ -308,6 +319,7 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 				rotor_idx,
 				blade_idx,
 				atmo,
+				iteration,
 				trackBWIevents,
 				converged
 			);
@@ -337,7 +349,8 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 			blade_chunk.dynamic_dC_Db_profile[] = blade_chunk.dC_Db_profile[];
 			blade_chunk.aoa_eff[] = blade_chunk.aoa[];
 		}
-
+		debug writeln("2. iteration:", iteration);
+		debug writeln("blade_idx:", blade_idx, "rotor_idx:", rotor_idx);
 		//writeln("\n blade properites for blade ", blade_idx);
 		rotor.blades[blade_idx].compute_blade_properties(
 			rotor_state.blade_states[blade_idx],
@@ -350,6 +363,7 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 			rotor_idx,
 			blade_idx,
 			atmo, 
+			iteration,
 			trackBWIevents,
 			converged
 		);

--- a/source/opencopter/bladeelement.d
+++ b/source/opencopter/bladeelement.d
@@ -254,20 +254,20 @@ void compute_blade_properties(BG, BS, RG, RIS, RS, AS, W)   (auto ref BG blade, 
 			normalVec[1] = updated_normal[1][0];
 			normalVec[2] = updated_normal[2][0];
 			//double[] r = get_geometry_array!"r"(blade);
-			writeln("1. bladeElement, before  iteration:", iteration);
-			foreach (i_rotor_idx; 0..wake.rotor_wakes.length){
-				//writeln("wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length:", wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length);
-				foreach (i_blade_idx; 0..wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length) {
-					/*if(wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.empty){
-						writeln("no interaction point");
-					} else{
-						wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.clear();
-					}*/
-					wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.clear();
-				} 
-			}
-			calculate_BWI_points(wake, blade_state, rotor_idx, blade_idx, blade, normalVec);
-			writeln("1. bladeElement, after iteration:", iteration);
+			//writeln("1. bladeElement, before  iteration:", iteration);
+			// foreach (i_rotor_idx; 0..wake.rotor_wakes.length){
+			// 	//writeln("wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length:", wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length);
+			// 	foreach (i_blade_idx; 0..wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length) {
+			// 		/*if(wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.empty){
+			// 			writeln("no interaction point");
+			// 		} else{
+			// 			wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.clear();
+			// 		}*/
+			// 		wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.clear();
+			// 	} 
+			// }
+			calculate_BWI_points(wake, blade_state, rotor_idx, blade_idx, blade, normalVec, iteration);
+			// writeln("1. bladeElement, after iteration:", iteration);
 		}
 	}
 }
@@ -306,7 +306,7 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 	foreach(blade_idx; 0..rotor.blades.length) {
 
 		if(iteration > 0) {
-			debug writeln("1. iteration:", iteration);
+			//debug writeln("1. iteration:", iteration);
 			//writeln("\n blade properites for blade ", blade_idx);
 			rotor.blades[blade_idx].compute_blade_properties(
 				rotor_state.blade_states[blade_idx],
@@ -349,8 +349,8 @@ void compute_rotor_properties(RG, RS, RIS, AS, WIS, WG, W)(auto ref RG rotor, au
 			blade_chunk.dynamic_dC_Db_profile[] = blade_chunk.dC_Db_profile[];
 			blade_chunk.aoa_eff[] = blade_chunk.aoa[];
 		}
-		debug writeln("2. iteration:", iteration);
-		debug writeln("blade_idx:", blade_idx, "rotor_idx:", rotor_idx);
+		//debug writeln("2. iteration:", iteration);
+		//debug writeln("blade_idx:", blade_idx, "rotor_idx:", rotor_idx);
 		//writeln("\n blade properites for blade ", blade_idx);
 		rotor.blades[blade_idx].compute_blade_properties(
 			rotor_state.blade_states[blade_idx],
@@ -416,6 +416,8 @@ void step(ArrayContainer AC = ArrayContainer.None)(ref AircraftStateT!AC ac_stat
 	import std.math : PI, cos, sin;
 	import std.numeric : findRoot;
 	import std.stdio : writeln;
+
+	//GC.collect();
 	
 	aircraft.root_frame.update(Mat4.identity);
 	//aircraft.root_frame.print_frame;

--- a/source/opencopter/bwi.d
+++ b/source/opencopter/bwi.d
@@ -9,18 +9,19 @@ import opencopter.bladeelement;
 import opencopter.aircraft;
 
 import std.math;
-import std.container: DList ;
+import std.container : DList;
 import std.range;
 import std.stdio : writeln;
 
 immutable size_t nPoints = 6;
-immutable double BWI_factor = 9.0; // 2.0^2 as we are comparing distance^2
+immutable double BWI_factor = 4.0; // 2.0^2 as we are comparing distance^2
 
-extern (C++) struct BWIinputsChunk {
+extern (C++) struct BWIinputsChunk
+{
     Chunk miss_dist;
     Chunk r_c_ave;
     Chunk gamma_w;
-	Chunk gamma_sec;
+    Chunk gamma_sec;
     size_t[chunk_size] bladeSec_idx;
     Vec3[chunk_size] r_vortex;
     Vec3[chunk_size] pos_v;
@@ -28,13 +29,14 @@ extern (C++) struct BWIinputsChunk {
     Chunk dl;
 }
 
-extern (C++) struct InteractionPoints {
+extern (C++) struct InteractionPoints
+{
     size_t wake_idx;
     size_t bladeSec_idx;
     double miss_dist;
     double r_c;
     double gamma_w;
-    double gamma_sec; 
+    double gamma_sec;
     double[3] r_blade;
     double[3] r_vortex;
     double[3] r_blade_v;
@@ -42,108 +44,188 @@ extern (C++) struct InteractionPoints {
     double C_d;
     // double TKE;
     double l;
-    double[3] normal; 
+    double[3] normal;
 }
 
-extern (C++) struct TipVortexInteractionT(ArrayContainer AC){
-    
+extern (C++) struct TipVortexInteractionT(ArrayContainer AC)
+{
+
     mixin ArrayDeclMixin!(AC, BWIinputsChunk, "BWI_inputs");
 
-    auto interaction_pts = DList!InteractionPoints();
+    DList!InteractionPoints interaction_pts;
     size_t length;
 
-	this(size_t wake_history, size_t blade_elements) {
+    this(size_t wake_history, size_t blade_elements)
+    {
 
-		assert(wake_history % chunk_size == 0);
-		immutable num_chunks = wake_history/chunk_size;
-        
-		mixin(array_ctor_mixin!(AC, "BWIinputsChunk", "BWI_inputs", "num_chunks"));
+        assert(wake_history % chunk_size == 0);
+        immutable num_chunks = wake_history / chunk_size;
+
+        mixin(array_ctor_mixin!(AC, "BWIinputsChunk", "BWI_inputs", "num_chunks"));
+        interaction_pts = DList!InteractionPoints(); 
 
         length = 0;
-	}
-    
+    }
+
 }
 
-extern (C++) struct VortexInteractionT(ArrayContainer AC){
+extern (C++) struct VortexInteractionT(ArrayContainer AC)
+{
     mixin ArrayDeclMixin!(AC, TipVortexInteractionT!(AC), "tip_vortex_interaction");
 
     size_t length;
 
-	this(size_t num_blades, size_t wake_history, size_t blade_elements) {
+    this(size_t num_blades, size_t wake_history, size_t blade_elements)
+    {
+
+        mixin(array_ctor_mixin!(AC, "TipVortexInteractionT!(AC)", "tip_vortex_interaction", "num_blades"));
+
+        //writeln(mixin(array_ctor_mixin!(AC, "TipVortexInteractionT!(AC)", "tip_vortex_interaction", "num_blades")));
+
+        foreach (ref interaction; tip_vortex_interaction)
+        {
+            interaction = TipVortexInteractionT!AC(wake_history, blade_elements);
+        }
+
+    }
+
+}
+
+struct VortexInteraction_multiRotorT(ArrayContainer AC)
+{
+    mixin ArrayDeclMixin!(AC, VortexInteractionT!(AC), "blade_vortex_interaction");
+
+    this(size_t num_blades1, size_t num_blades2, size_t wake_history, size_t blade_elements)
+    {
+        //writeln( mixin(array_ctor_mixin!(AC, "VortexInteractionT!(AC)", "blade_vortex_interaction", "num_blades[idx]")));
+        mixin(array_ctor_mixin!(AC, "VortexInteractionT!(AC)", "blade_vortex_interaction", "num_blades2"));
+
+        //writeln(mixin(array_ctor_mixin!(AC, "TipVortexInteractionT!(AC)", "tip_vortex_interaction", "num_blades")));
+        //writeln("blade_vortex_interaction.length:", blade_vortex_interaction.length);
+        foreach (ref interaction; blade_vortex_interaction)
+        {
+            interaction = VortexInteractionT!AC(num_blades1, wake_history, blade_elements);
+        }
+
+    }
+
+    /*this(size_t num_blades, size_t wake_history, size_t blade_elements) {
         
-		mixin(array_ctor_mixin!(AC, "TipVortexInteractionT!(AC)", "tip_vortex_interaction", "num_blades"));
-        foreach(ref interaction; tip_vortex_interaction) {
-			interaction = TipVortexInteractionT!AC(wake_history, blade_elements);
+		mixin(array_ctor_mixin!(AC, "VortexInteractionT!(AC)", "blade_vortex_interaction", "num_blades"));
+
+        //writeln(mixin(array_ctor_mixin!(AC, "TipVortexInteractionT!(AC)", "tip_vortex_interaction", "num_blades")));
+        
+        foreach(r_idx, ref interaction; blade_vortex_interaction) {
+			interaction = VortexInteractionT!AC(num_blades, wake_history, blade_elements);
 		}
         
-	}
-    
+	}*/
+
 }
 
 alias TipVortexInteraction = TipVortexInteractionT!(ArrayContainer.none);
 
-double[] get_BWIinputs(string value, BWI)(auto ref BWI VortexInteraction) {
-	
-	immutable elements = VortexInteraction.BWI_inputs.length * chunk_size;
+double[] get_BWIinputs(string value, BWI)(auto ref BWI VortexInteraction)
+{
 
-	double[] d = new double[elements];
+    immutable elements = VortexInteraction.BWI_inputs.length * chunk_size;
 
-	foreach(c_idx, ref chunk; VortexInteraction.BWI_inputs) {
-		immutable out_start_idx = c_idx*chunk_size;
+    double[] d = new double[elements];
 
-		immutable remaining = elements - out_start_idx;
-		
-		immutable out_end_idx = remaining > chunk_size ? (c_idx + 1)*chunk_size : out_start_idx + remaining;
-		immutable in_end_idx = remaining > chunk_size ? chunk_size : remaining;
+    foreach (c_idx, ref chunk; VortexInteraction.BWI_inputs)
+    {
+        immutable out_start_idx = c_idx * chunk_size;
 
-		mixin("d[out_start_idx..out_end_idx] = chunk."~value~"[0..in_end_idx];");
-	}
-	return d;
+        immutable remaining = elements - out_start_idx;
+
+        immutable out_end_idx = remaining > chunk_size ? (c_idx + 1) * chunk_size
+            : out_start_idx + remaining;
+        immutable in_end_idx = remaining > chunk_size ? chunk_size : remaining;
+
+        mixin("d[out_start_idx..out_end_idx] = chunk." ~ value ~ "[0..in_end_idx];");
+    }
+    return d;
 }
 
+size_t[] get_blade_sec_idx(string value, BWI)(auto ref BWI VortexInteraction)
+{
 
-size_t[] get_blade_sec_idx(string value, BWI)(auto ref BWI VortexInteraction) {
-	
-	immutable elements = VortexInteraction.BWI_inputs.length * chunk_size;
+    immutable elements = VortexInteraction.BWI_inputs.length * chunk_size;
 
-	size_t[] d = new size_t[elements];
+    size_t[] d = new size_t[elements];
 
-	foreach(c_idx, ref chunk; VortexInteraction.BWI_inputs) {
-		immutable out_start_idx = c_idx*chunk_size;
+    foreach (c_idx, ref chunk; VortexInteraction.BWI_inputs)
+    {
+        immutable out_start_idx = c_idx * chunk_size;
 
-		immutable remaining = elements - out_start_idx;
-		
-		immutable out_end_idx = remaining > chunk_size ? (c_idx + 1)*chunk_size : out_start_idx + remaining;
-		immutable in_end_idx = remaining > chunk_size ? chunk_size : remaining;
+        immutable remaining = elements - out_start_idx;
 
-		mixin("d[out_start_idx..out_end_idx] = chunk."~value~"[0..in_end_idx];");
-	}
-	return d;
+        immutable out_end_idx = remaining > chunk_size ? (c_idx + 1) * chunk_size
+            : out_start_idx + remaining;
+        immutable in_end_idx = remaining > chunk_size ? chunk_size : remaining;
+
+        mixin("d[out_start_idx..out_end_idx] = chunk." ~ value ~ "[0..in_end_idx];");
+    }
+    return d;
 }
 
-size_t[] get_interaction_points(string value, BWI)(auto ref BWI VortexInteraction){
+size_t[] get_interaction_points(string value, BWI)(auto ref BWI VortexInteraction)
+{
 
     size_t[] d;
-    foreach (ref elem; VortexInteraction.interaction_pts) {
-        mixin("d ~= elem."~value~";");
+    //assert(VortexInteraction !is null, "VortexInteraction is null");
+    //assert(VortexInteraction.interaction_pts.length > 0, "interaction_pts is empty or uninitialized");
+    //if (VortexInteraction is null || VortexInteraction.interaction_pts.length == 0){
+      //  return [];
+    //} else{
+    foreach (ref elem; VortexInteraction.interaction_pts)
+    {
+        mixin("d ~= elem." ~ value ~ ";");
     }
     return d;
-}
+    //}
+} 
 
-double[] get_interaction_point_components(string value, BWI)(auto ref BWI VortexInteraction){
+/*size_t[] get_interaction_points(string value, BWI)(auto ref BWI VortexInteraction)
+{
+    size_t[] d;
+
+    //writeln("VortexInteraction.length:", VortexInteraction.length);
+
+    // Check if interaction_pts is initialized and not empty
+    static if (is(typeof(VortexInteraction.interaction_pts)))
+    {
+        if (VortexInteraction.interaction_pts.empty)
+            return [];
+
+        foreach (ref elem; VortexInteraction.interaction_pts)
+        {
+            mixin("d ~= elem." ~ value ~ ";");
+        }
+    }
+
+    return d;
+}*/
+
+
+double[] get_interaction_point_components(string value, BWI)(auto ref BWI VortexInteraction)
+{
     double[] d;
-    foreach (ref elem; VortexInteraction.interaction_pts) {
-        mixin("d ~= elem."~value~";");
+    foreach (ref elem; VortexInteraction.interaction_pts)
+    {
+        mixin("d ~= elem." ~ value ~ ";");
     }
     return d;
 }
 
-double[][] get_interaction_point_directionVec(string value, BWI)(auto ref BWI VortexInteraction){
+double[][] get_interaction_point_directionVec(string value, BWI)(auto ref BWI VortexInteraction)
+{
     Vec3[] vec;
     double[][] d;
-    foreach (ref elem; VortexInteraction.interaction_pts) {
-        mixin("d ~= elem."~value~";");
-        
+    foreach (ref elem; VortexInteraction.interaction_pts)
+    {
+        mixin("d ~= elem." ~ value ~ ";");
+
         /* foreach(idx; 0..2){
             mixin("d[][idx] ~= elem"~value~".[idx];");
         }  */
@@ -152,8 +234,8 @@ double[][] get_interaction_point_directionVec(string value, BWI)(auto ref BWI Vo
     return d;
 }
 
-
-void calculate_BWI_points (W, BS, BG)(auto ref W wake, auto ref BS blade_state, size_t rotor_idx, size_t blade_idx, auto ref BG bladeGeom, double[3] normalVec){
+void calculate_BWI_points(W, BS, BG)(auto ref W wake, auto ref BS blade_state, size_t rotor_idx, size_t blade_idx, auto ref BG bladeGeom, double[3] normalVec)
+{
     // What we need
     // 1. Wake: x, y, z 
     // 2. r_c and miss distance
@@ -162,7 +244,7 @@ void calculate_BWI_points (W, BS, BG)(auto ref W wake, auto ref BS blade_state, 
 
     double[] miss_dist;
     double[] r_c;
-    size_t i_pt=0;
+    size_t i_pt = 0;
     InteractionPoints interaction;
     double[] C_d = get_wake_component!"dC_D"(blade_state);
     double[] r = get_wake_component!"r"(bladeGeom);
@@ -173,122 +255,187 @@ void calculate_BWI_points (W, BS, BG)(auto ref W wake, auto ref BS blade_state, 
     debug writeln("y:", y);
     debug writeln("z:", z);
 
-    foreach (i_blade_idx; 0..wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length){
-        miss_dist = get_BWIinputs!"miss_dist"(wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx]);
-        r_c = get_BWIinputs!"r_c_ave"(wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx]);
-        auto bladeSec_idx = get_blade_sec_idx!"bladeSec_idx"(wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx]);
-        auto gamma_w = get_BWIinputs!"gamma_w"(wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx]); 
-        auto r_vortex = get_directionVec!"r_vortex"(wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx]);
-        auto r_b = get_directionVec!"pos_v"(wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx]);
-        double[] gamma = get_wake_component!"gamma"(blade_state);
-        
-        
-        double[] dl = get_BWIinputs!"dl"(wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx]);
-        double l = 0.0;
-        //auto u_ind = get_directionVec!"u_ind"(wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx]);
-        
-        i_pt = 0;
-        double local_min = miss_dist[0];
-        foreach(idx; 0..miss_dist.length-1){
-            if(idx == 0) {
-                l = 0.0;
-                if(miss_dist[idx]<miss_dist[idx+1]){
-                    local_min = miss_dist[idx];
-                    if((i_pt < nPoints) && (local_min < BWI_factor*r_c[idx]*r_c[idx])){
-                        interaction.wake_idx = idx;
-                        interaction.miss_dist = miss_dist[idx];
-                        interaction.r_c = r_c[idx];
-                        interaction.bladeSec_idx = bladeSec_idx[idx];
-                        interaction.gamma_w = gamma_w[idx];
-                        interaction.r_vortex[0] = r_vortex[idx][0];
-                        interaction.r_vortex[1] = r_vortex[idx][1];
-                        interaction.r_vortex[2] = r_vortex[idx][2]; 
-                        interaction.gamma_sec = gamma[bladeSec_idx[idx]];
-                        interaction.r_blade[0] = x[bladeSec_idx[idx]]-x[bladeSec_idx[idx]-1];
-                        interaction.r_blade[1] = y[bladeSec_idx[idx]]-y[bladeSec_idx[idx]-1];
-                        interaction.r_blade[2] = z[bladeSec_idx[idx]]-z[bladeSec_idx[idx]-1];
-                        interaction.r_blade_v[0] = r_b[idx][0]-x[bladeSec_idx[idx]];
-                        interaction.r_blade_v[1] = r_b[idx][1]-y[bladeSec_idx[idx]];
-                        interaction.r_blade_v[2] = r_b[idx][2]-z[bladeSec_idx[idx]]; 
-                        interaction.secLen = (x[bladeSec_idx[idx]]-x[0])*(x[bladeSec_idx[idx]]-x[0])+(y[bladeSec_idx[idx]]-y[0])*(y[bladeSec_idx[idx]]-y[0])+(z[bladeSec_idx[idx]]-z[0])*(z[bladeSec_idx[idx]]-z[0]);
-                        interaction.l = l;    
-                        if(bladeSec_idx[idx]==0){
-                            interaction.C_d = C_d[0]/(r[1]-r[0]);
-                        } else{
-                            double dr = r[bladeSec_idx[idx]]-r[bladeSec_idx[idx]-1];
-                            interaction.C_d = 0.5*(C_d[bladeSec_idx[idx]]+C_d[bladeSec_idx[idx]-1])/dr;
+    foreach (i_rotor_idx; 0 .. wake.rotor_wakes.length)
+    {
+        foreach (i_blade_idx; 0 .. wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx]
+            .blade_vortex_interaction[blade_idx].tip_vortex_interaction.length)
+        {
+            miss_dist = get_BWIinputs!"miss_dist"(
+                wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
+                    .tip_vortex_interaction[i_blade_idx]);
+            r_c = get_BWIinputs!"r_c_ave"(
+                wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
+                    .tip_vortex_interaction[i_blade_idx]);
+            auto bladeSec_idx = get_blade_sec_idx!"bladeSec_idx"(
+                wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
+                    .tip_vortex_interaction[i_blade_idx]);
+            //writeln("bladeSec_idx:", bladeSec_idx);
+            auto gamma_w = get_BWIinputs!"gamma_w"(
+                wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
+                    .tip_vortex_interaction[i_blade_idx]);
+            auto r_vortex = get_directionVec!"r_vortex"(
+                wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
+                    .tip_vortex_interaction[i_blade_idx]);
+            auto r_b = get_directionVec!"pos_v"(
+                wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
+                    .tip_vortex_interaction[i_blade_idx]);
+            double[] gamma = get_wake_component!"gamma"(blade_state);
+
+            double[] dl = get_BWIinputs!"dl"(
+                wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
+                    .tip_vortex_interaction[i_blade_idx]);
+            double l = 0.0;
+            //auto u_ind = get_directionVec!"u_ind"(wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx]);
+
+            i_pt = 0;
+            double local_min = miss_dist[0];
+            foreach (idx; 0 .. miss_dist.length - 1)
+            {
+                if (idx == 0)
+                {
+                    l = 0.0;
+                    if (miss_dist[idx] < miss_dist[idx + 1])
+                    {
+                        local_min = miss_dist[idx];
+                        if ((i_pt < nPoints) && (local_min < BWI_factor * r_c[idx] * r_c[idx]))
+                        {
+                            interaction.wake_idx = idx;
+                            interaction.miss_dist = miss_dist[idx];
+                            interaction.r_c = r_c[idx];
+                            interaction.bladeSec_idx = bladeSec_idx[idx];
+                            interaction.gamma_w = gamma_w[idx];
+                            interaction.r_vortex[0] = r_vortex[idx][0];
+                            interaction.r_vortex[1] = r_vortex[idx][1];
+                            interaction.r_vortex[2] = r_vortex[idx][2];
+                            interaction.gamma_sec = gamma[bladeSec_idx[idx]];
+                            if(bladeSec_idx[idx]==0) {
+                                interaction.r_blade[0] = x[bladeSec_idx[idx]] - x[bladeSec_idx[idx] + 1];
+                                interaction.r_blade[1] = y[bladeSec_idx[idx]] - y[bladeSec_idx[idx] + 1];
+                                interaction.r_blade[2] = z[bladeSec_idx[idx]] - z[bladeSec_idx[idx] + 1];
+                            } else{
+                                interaction.r_blade[0] = x[bladeSec_idx[idx]] - x[bladeSec_idx[idx] - 1];
+                                interaction.r_blade[1] = y[bladeSec_idx[idx]] - y[bladeSec_idx[idx] - 1];
+                                interaction.r_blade[2] = z[bladeSec_idx[idx]] - z[bladeSec_idx[idx] - 1];
+                            }
+                            interaction.r_blade_v[0] = r_b[idx][0] - x[bladeSec_idx[idx]];
+                            interaction.r_blade_v[1] = r_b[idx][1] - y[bladeSec_idx[idx]];
+                            interaction.r_blade_v[2] = r_b[idx][2] - z[bladeSec_idx[idx]];
+                            interaction.secLen = (x[bladeSec_idx[idx]] - x[0]) * (
+                                x[bladeSec_idx[idx]] - x[0]) + (y[bladeSec_idx[idx]] - y[0]) * (
+                                y[bladeSec_idx[idx]] - y[0]) + (z[bladeSec_idx[idx]] - z[0]) * (
+                                z[bladeSec_idx[idx]] - z[0]);
+                            interaction.l = l;
+                            if (bladeSec_idx[idx] == 0)
+                            {
+                                interaction.C_d = C_d[0] / (r[1] - r[0]);
+                            }
+                            else
+                            {
+                                double dr = r[bladeSec_idx[idx]] - r[bladeSec_idx[idx] - 1];
+                                interaction.C_d = 0.5 * (
+                                    C_d[bladeSec_idx[idx]] + C_d[bladeSec_idx[idx] - 1]) / dr;
+                            }
+                            //interaction.C_d = sumC_d(C_d); 
+                            interaction.normal = normalVec;
+                            i_pt++;
+                            wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
+                                .tip_vortex_interaction[i_blade_idx].interaction_pts.insertBack(
+                                    interaction);
                         }
-                        //interaction.C_d = sumC_d(C_d); 
-                        interaction.normal = normalVec;
-                        i_pt++;
-                        wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.insertBack(interaction);
                     }
                 }
-            } else{
-                l = l + dl[idx-1];
-                if((miss_dist[idx]<miss_dist[idx-1]) && (miss_dist[idx]<miss_dist[idx+1])){
-                    local_min = miss_dist[idx];
-                    if((i_pt < nPoints) && (local_min < BWI_factor*r_c[idx]*r_c[idx])){
-                        interaction.wake_idx = idx;
-                        interaction.miss_dist = miss_dist[idx];
-                        interaction.r_c = r_c[idx];
-                        interaction.bladeSec_idx = bladeSec_idx[idx];
-                        interaction.gamma_w = gamma_w[idx];
-                        interaction.r_vortex[0] = r_vortex[idx][0];
-                        interaction.r_vortex[1] = r_vortex[idx][1];
-                        interaction.r_vortex[2] = r_vortex[idx][2]; 
-                        interaction.gamma_sec = gamma[bladeSec_idx[idx]];
-                        interaction.r_blade[0] = x[bladeSec_idx[idx]]-x[bladeSec_idx[idx]-1];
-                        interaction.r_blade[1] = y[bladeSec_idx[idx]]-y[bladeSec_idx[idx]-1];
-                        interaction.r_blade[2] = z[bladeSec_idx[idx]]-z[bladeSec_idx[idx]-1]; 
-                        interaction.r_blade_v[0] = r_b[idx][0]-x[bladeSec_idx[idx]];
-                        interaction.r_blade_v[1] = r_b[idx][1]-y[bladeSec_idx[idx]];
-                        interaction.r_blade_v[2] = r_b[idx][2]-z[bladeSec_idx[idx]]; 
-                        interaction.secLen = (x[bladeSec_idx[idx]]-x[0])*(x[bladeSec_idx[idx]]-x[0])+(y[bladeSec_idx[idx]]-y[0])*(y[bladeSec_idx[idx]]-y[0])+(z[bladeSec_idx[idx]]-z[0])*(z[bladeSec_idx[idx]]-z[0]);
-                        interaction.l = l;        
-                        if(bladeSec_idx[idx]==0){
-                            interaction.C_d = C_d[0]/(r[1]-r[0]);
-                        } else{
-                            double dr = r[bladeSec_idx[idx]]-r[bladeSec_idx[idx]-1];
-                            interaction.C_d = 0.5*(C_d[bladeSec_idx[idx]]+C_d[bladeSec_idx[idx]-1])/dr;
-                        } 
-                        //interaction.C_d = sumC_d(C_d);  
-                        interaction.normal = normalVec;
-                        i_pt++;
-                        wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].interaction_pts.insertBack(interaction);
+                else
+                {
+                    l = l + dl[idx - 1];
+                    if ((miss_dist[idx] < miss_dist[idx - 1]) && (miss_dist[idx] < miss_dist[idx + 1]))
+                    {
+                        local_min = miss_dist[idx];
+                        if ((i_pt < nPoints) && (local_min < BWI_factor * r_c[idx] * r_c[idx]))
+                        {
+                            interaction.wake_idx = idx;
+                            interaction.miss_dist = miss_dist[idx];
+                            interaction.r_c = r_c[idx];
+                            interaction.bladeSec_idx = bladeSec_idx[idx];
+                            //writeln("bladeSec_idx[idx]:", bladeSec_idx[idx]);
+                            interaction.gamma_w = gamma_w[idx];
+                            interaction.r_vortex[0] = r_vortex[idx][0];
+                            interaction.r_vortex[1] = r_vortex[idx][1];
+                            interaction.r_vortex[2] = r_vortex[idx][2];
+                            interaction.gamma_sec = gamma[bladeSec_idx[idx]];
+                            if(bladeSec_idx[idx]==0) {
+                                interaction.r_blade[0] = x[bladeSec_idx[idx]] - x[bladeSec_idx[idx] + 1];
+                                interaction.r_blade[1] = y[bladeSec_idx[idx]] - y[bladeSec_idx[idx] + 1];
+                                interaction.r_blade[2] = z[bladeSec_idx[idx]] - z[bladeSec_idx[idx] + 1];
+                            } else{
+                                interaction.r_blade[0] = x[bladeSec_idx[idx]] - x[bladeSec_idx[idx] - 1];
+                                interaction.r_blade[1] = y[bladeSec_idx[idx]] - y[bladeSec_idx[idx] - 1];
+                                interaction.r_blade[2] = z[bladeSec_idx[idx]] - z[bladeSec_idx[idx] - 1];
+                            }                            
+                            interaction.r_blade_v[0] = r_b[idx][0] - x[bladeSec_idx[idx]];
+                            interaction.r_blade_v[1] = r_b[idx][1] - y[bladeSec_idx[idx]];
+                            interaction.r_blade_v[2] = r_b[idx][2] - z[bladeSec_idx[idx]];
+                            interaction.secLen = (x[bladeSec_idx[idx]] - x[0]) * (
+                                x[bladeSec_idx[idx]] - x[0]) + (y[bladeSec_idx[idx]] - y[0]) * (
+                                y[bladeSec_idx[idx]] - y[0]) + (z[bladeSec_idx[idx]] - z[0]) * (
+                                z[bladeSec_idx[idx]] - z[0]);
+                            interaction.l = l;
+                            if (bladeSec_idx[idx] == 0)
+                            {
+                                interaction.C_d = C_d[0] / (r[1] - r[0]);
+                            }
+                            else
+                            {
+                                double dr = r[bladeSec_idx[idx]] - r[bladeSec_idx[idx] - 1];
+                                interaction.C_d = 0.5 * (
+                                    C_d[bladeSec_idx[idx]] + C_d[bladeSec_idx[idx] - 1]) / dr;
+                            }
+                            //interaction.C_d = sumC_d(C_d);  
+                            interaction.normal = normalVec;
+                            i_pt++;
+                            wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
+                                .tip_vortex_interaction[i_blade_idx].interaction_pts.insertBack(
+                                    interaction);
+                            //writeln("i_rotor_idx:", i_rotor_idx, "rotor_idx:", rotor_idx, "blade_idx", blade_idx, "i_blade_idx", i_blade_idx);
+                            writeln("2. bwi, interaction point added ");
+                        }
                     }
                 }
+
             }
-            
         }
-    }   
-} 
+    }
+}
 
-Vec3[] get_directionVec(string value, BWI)(auto ref BWI VortexInteraction) {
-	
-	immutable elements = VortexInteraction.BWI_inputs.length * chunk_size;
+Vec3[] get_directionVec(string value, BWI)(auto ref BWI VortexInteraction)
+{
 
-	Vec3[] d = new Vec3[elements];
+    immutable elements = VortexInteraction.BWI_inputs.length * chunk_size;
 
-	foreach(c_idx, ref chunk; VortexInteraction.BWI_inputs) {
-		immutable out_start_idx = c_idx*chunk_size;
+    Vec3[] d = new Vec3[elements];
 
-		immutable remaining = elements - out_start_idx;
-		
-		//immutable out_end_idx = remaining > chunk_size ? (c_idx + 1)*chunk_size : out_start_idx + remaining;
-		immutable in_end_idx = remaining > chunk_size ? chunk_size : remaining;
+    foreach (c_idx, ref chunk; VortexInteraction.BWI_inputs)
+    {
+        immutable out_start_idx = c_idx * chunk_size;
 
-        foreach(idx; 0..in_end_idx){
-            mixin("d[out_start_idx + idx] = chunk."~value~"[idx];");
+        immutable remaining = elements - out_start_idx;
+
+        //immutable out_end_idx = remaining > chunk_size ? (c_idx + 1)*chunk_size : out_start_idx + remaining;
+        immutable in_end_idx = remaining > chunk_size ? chunk_size : remaining;
+
+        foreach (idx; 0 .. in_end_idx)
+        {
+            mixin("d[out_start_idx + idx] = chunk." ~ value ~ "[idx];");
         }
-		
-	} 
-	return d;
-} 
 
-double sumC_d(double[] arr) {
+    }
+    return d;
+}
+
+double sumC_d(double[] arr)
+{
     double result = 0.0;
-    foreach (elem; arr) {
+    foreach (elem; arr)
+    {
         result += elem;
     }
     return result;

--- a/source/opencopter/bwi.d
+++ b/source/opencopter/bwi.d
@@ -13,6 +13,8 @@ import std.container : DList;
 import std.range;
 import std.stdio : writeln;
 
+import core.memory; // for GC.collect
+
 immutable size_t nPoints = 6;
 immutable double BWI_factor = 4.0; // 2.0^2 as we are comparing distance^2
 
@@ -62,7 +64,7 @@ extern (C++) struct TipVortexInteractionT(ArrayContainer AC)
         immutable num_chunks = wake_history / chunk_size;
 
         mixin(array_ctor_mixin!(AC, "BWIinputsChunk", "BWI_inputs", "num_chunks"));
-        interaction_pts = DList!InteractionPoints(); 
+        interaction_pts = DList!InteractionPoints();
 
         length = 0;
     }
@@ -147,6 +149,28 @@ double[] get_BWIinputs(string value, BWI)(auto ref BWI VortexInteraction)
     return d;
 }
 
+void fill_BWIinputs(string value, BWI)(
+    auto ref BWI VortexInteraction,
+    ref double[] outBuf)
+{
+    immutable elements = VortexInteraction.BWI_inputs.length * chunk_size;
+    if (outBuf.length < elements)
+        outBuf.length = elements; // reuse allocation if possible
+
+    foreach (c_idx, ref chunk; VortexInteraction.BWI_inputs)
+    {
+        immutable out_start_idx = c_idx * chunk_size;
+
+        immutable remaining = elements - out_start_idx;
+
+        immutable out_end_idx = remaining > chunk_size ? (c_idx + 1) * chunk_size
+            : out_start_idx + remaining;
+        immutable in_end_idx = remaining > chunk_size ? chunk_size : remaining;
+
+        mixin("outBuf[out_start_idx..out_end_idx] = chunk." ~ value ~ "[0..in_end_idx];");
+    }
+}
+
 size_t[] get_blade_sec_idx(string value, BWI)(auto ref BWI VortexInteraction)
 {
 
@@ -176,7 +200,7 @@ size_t[] get_interaction_points(string value, BWI)(auto ref BWI VortexInteractio
     //assert(VortexInteraction !is null, "VortexInteraction is null");
     //assert(VortexInteraction.interaction_pts.length > 0, "interaction_pts is empty or uninitialized");
     //if (VortexInteraction is null || VortexInteraction.interaction_pts.length == 0){
-      //  return [];
+    //  return [];
     //} else{
     foreach (ref elem; VortexInteraction.interaction_pts)
     {
@@ -184,7 +208,21 @@ size_t[] get_interaction_points(string value, BWI)(auto ref BWI VortexInteractio
     }
     return d;
     //}
-} 
+}
+
+void fill_indexArray(string value, BWI)(
+    auto ref BWI VortexInteraction,
+    ref size_t[] outIdx)
+{
+    //immutable elements = VortexInteraction.interaction_pts.length();
+    //if (outIdx.length < elements)
+    //    outIdx.length = elements;
+
+    foreach (ref elem; VortexInteraction.interaction_pts)
+    {
+        mixin("outIdx ~= elem." ~ value ~ ";");
+    }
+}
 
 /*size_t[] get_interaction_points(string value, BWI)(auto ref BWI VortexInteraction)
 {
@@ -207,7 +245,6 @@ size_t[] get_interaction_points(string value, BWI)(auto ref BWI VortexInteractio
     return d;
 }*/
 
-
 double[] get_interaction_point_components(string value, BWI)(auto ref BWI VortexInteraction)
 {
     double[] d;
@@ -216,6 +253,20 @@ double[] get_interaction_point_components(string value, BWI)(auto ref BWI Vortex
         mixin("d ~= elem." ~ value ~ ";");
     }
     return d;
+}
+
+void fill_interaction_point_components(string value, BWI)(
+    auto ref BWI VortexInteraction,
+    ref double[] outArray)
+{
+    // immutable elements = VortexInteraction.interaction_pts.length;
+    // if (outArray.length < elements)
+    //     outArray.length = elements;
+
+    foreach (ref elem; VortexInteraction.interaction_pts)
+    {
+        mixin("outArray ~= elem." ~ value ~ ";");
+    }
 }
 
 double[][] get_interaction_point_directionVec(string value, BWI)(auto ref BWI VortexInteraction)
@@ -234,7 +285,20 @@ double[][] get_interaction_point_directionVec(string value, BWI)(auto ref BWI Vo
     return d;
 }
 
-void calculate_BWI_points(W, BS, BG)(auto ref W wake, auto ref BS blade_state, size_t rotor_idx, size_t blade_idx, auto ref BG bladeGeom, double[3] normalVec)
+void fill_interaction_point_directionVec(string value, BWI)(
+    auto ref BWI VortexInteraction, double[][] outArray)
+{
+    // immutable elements = VortexInteraction.interaction_pts.length;
+    // if (outArray.length < elements)
+    //     outArray.length = elements;
+
+    foreach (ref elem; VortexInteraction.interaction_pts)
+    {
+        mixin("outArray ~= elem." ~ value ~ ";");
+    }
+}
+
+void calculate_BWI_points(W, BS, BG)(auto ref W wake, auto ref BS blade_state, size_t rotor_idx, size_t blade_idx, auto ref BG bladeGeom, double[3] normalVec, size_t iteration)
 {
     // What we need
     // 1. Wake: x, y, z 
@@ -242,8 +306,6 @@ void calculate_BWI_points(W, BS, BG)(auto ref W wake, auto ref BS blade_state, s
     // 3. local airfoil points: vehicle.aircraft.rotors.blades.chuncks (vtk.d ln340), it's calculated in bladeelement.d too!
     // Wake history is stored every 1 deg., therefore 1st interaction should be around 90 deg. 
 
-    double[] miss_dist;
-    double[] r_c;
     size_t i_pt = 0;
     InteractionPoints interaction;
     double[] C_d = get_wake_component!"dC_D"(blade_state);
@@ -251,15 +313,36 @@ void calculate_BWI_points(W, BS, BG)(auto ref W wake, auto ref BS blade_state, s
     double[] x = get_wake_component!"x"(blade_state);
     double[] y = get_wake_component!"y"(blade_state);
     double[] z = get_wake_component!"z"(blade_state);
-    debug writeln("x:", x);
-    debug writeln("y:", y);
-    debug writeln("z:", z);
+    // debug writeln("x:", x);
+    // debug writeln("y:", y);
+    // debug writeln("z:", z);
+
+    //GC.collect();
+    //auto  stats1 = GC.stats();
+    //writeln("1. GC used bytes: ", stats1.usedSize);
+    // writeln("1. GC free bytes: ", stats1.freeSize);
+    // writeln("1. GC total bytes: ", stats1.usedSize + stats1.freeSize);
+    //writeln("1. GC page total: ", GC.Stats.pageSize);
 
     foreach (i_rotor_idx; 0 .. wake.rotor_wakes.length)
     {
         foreach (i_blade_idx; 0 .. wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx]
             .blade_vortex_interaction[blade_idx].tip_vortex_interaction.length)
         {
+            wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
+                .tip_vortex_interaction[i_blade_idx].interaction_pts.clear();
+
+            // GC.collect();
+            // auto  stats2 = GC.stats();
+            // writeln("iteration:", iteration, "2. GC used bytes: ", stats2.usedSize);
+            // writeln("rotor_idx:", rotor_idx, "blade_idx:", blade_idx, "i_rotor_idx:", i_rotor_idx," i_blade_idx:", i_blade_idx);
+            // writeln("2. GC free bytes: ", stats2.freeSize);
+            // writeln("2. GC total bytes: ", stats2.usedSize + stats2.freeSize);
+            //writeln("2. GC page total: ", GC.Stats.pageSize);
+
+            double[] miss_dist;
+            double[] r_c;
+
             miss_dist = get_BWIinputs!"miss_dist"(
                 wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
                     .tip_vortex_interaction[i_blade_idx]);
@@ -284,8 +367,48 @@ void calculate_BWI_points(W, BS, BG)(auto ref W wake, auto ref BS blade_state, s
             double[] dl = get_BWIinputs!"dl"(
                 wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx]
                     .tip_vortex_interaction[i_blade_idx]);
+
+            // double[] dl;
+            // fill_BWIinputs!"dl"(
+            //     wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx]
+            //         .blade_vortex_interaction[blade_idx]
+            //         .tip_vortex_interaction[i_blade_idx], dl);
+
             double l = 0.0;
             //auto u_ind = get_directionVec!"u_ind"(wake.rotor_wakes[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx]);
+            // double[] miss_dist;
+            // double[] r_c;
+            // fill_BWIinputs!"miss_dist"(
+            //     wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx]
+            //         .blade_vortex_interaction[blade_idx]
+            //         .tip_vortex_interaction[i_blade_idx], miss_dist);
+
+            // fill_BWIinputs!"r_c_ave"(
+            //     wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx]
+            //         .blade_vortex_interaction[blade_idx]
+            //         .tip_vortex_interaction[i_blade_idx], r_c);
+            // auto bladeSec_idx = get_blade_sec_idx!"bladeSec_idx"(
+            //     wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx]
+            //         .blade_vortex_interaction[blade_idx]
+            //         .tip_vortex_interaction[i_blade_idx]);
+            // //writeln("bladeSec_idx:", bladeSec_idx);
+            // double[] gamma_w;
+            // fill_BWIinputs!"gamma_w"(
+            //     wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx]
+            //         .blade_vortex_interaction[blade_idx]
+            //         .tip_vortex_interaction[i_blade_idx], gamma_w);
+            // Vec3[] r_vortex;
+
+            // fill_directionVec!"r_vortex"(
+            //     wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx]
+            //         .blade_vortex_interaction[blade_idx]
+            //         .tip_vortex_interaction[i_blade_idx], r_vortex);
+            // Vec3[] r_b;
+            // fill_directionVec!"pos_v"(
+            //     wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx]
+            //         .blade_vortex_interaction[blade_idx]
+            //         .tip_vortex_interaction[i_blade_idx], r_b);
+            // double[] gamma = get_wake_component!"gamma"(blade_state);
 
             i_pt = 0;
             double local_min = miss_dist[0];
@@ -308,11 +431,14 @@ void calculate_BWI_points(W, BS, BG)(auto ref W wake, auto ref BS blade_state, s
                             interaction.r_vortex[1] = r_vortex[idx][1];
                             interaction.r_vortex[2] = r_vortex[idx][2];
                             interaction.gamma_sec = gamma[bladeSec_idx[idx]];
-                            if(bladeSec_idx[idx]==0) {
+                            if (bladeSec_idx[idx] == 0)
+                            {
                                 interaction.r_blade[0] = x[bladeSec_idx[idx]] - x[bladeSec_idx[idx] + 1];
                                 interaction.r_blade[1] = y[bladeSec_idx[idx]] - y[bladeSec_idx[idx] + 1];
                                 interaction.r_blade[2] = z[bladeSec_idx[idx]] - z[bladeSec_idx[idx] + 1];
-                            } else{
+                            }
+                            else
+                            {
                                 interaction.r_blade[0] = x[bladeSec_idx[idx]] - x[bladeSec_idx[idx] - 1];
                                 interaction.r_blade[1] = y[bladeSec_idx[idx]] - y[bladeSec_idx[idx] - 1];
                                 interaction.r_blade[2] = z[bladeSec_idx[idx]] - z[bladeSec_idx[idx] - 1];
@@ -347,7 +473,8 @@ void calculate_BWI_points(W, BS, BG)(auto ref W wake, auto ref BS blade_state, s
                 else
                 {
                     l = l + dl[idx - 1];
-                    if ((miss_dist[idx] < miss_dist[idx - 1]) && (miss_dist[idx] < miss_dist[idx + 1]))
+                    if ((miss_dist[idx] < miss_dist[idx - 1]) && (
+                            miss_dist[idx] < miss_dist[idx + 1]))
                     {
                         local_min = miss_dist[idx];
                         if ((i_pt < nPoints) && (local_min < BWI_factor * r_c[idx] * r_c[idx]))
@@ -362,15 +489,18 @@ void calculate_BWI_points(W, BS, BG)(auto ref W wake, auto ref BS blade_state, s
                             interaction.r_vortex[1] = r_vortex[idx][1];
                             interaction.r_vortex[2] = r_vortex[idx][2];
                             interaction.gamma_sec = gamma[bladeSec_idx[idx]];
-                            if(bladeSec_idx[idx]==0) {
+                            if (bladeSec_idx[idx] == 0)
+                            {
                                 interaction.r_blade[0] = x[bladeSec_idx[idx]] - x[bladeSec_idx[idx] + 1];
                                 interaction.r_blade[1] = y[bladeSec_idx[idx]] - y[bladeSec_idx[idx] + 1];
                                 interaction.r_blade[2] = z[bladeSec_idx[idx]] - z[bladeSec_idx[idx] + 1];
-                            } else{
+                            }
+                            else
+                            {
                                 interaction.r_blade[0] = x[bladeSec_idx[idx]] - x[bladeSec_idx[idx] - 1];
                                 interaction.r_blade[1] = y[bladeSec_idx[idx]] - y[bladeSec_idx[idx] - 1];
                                 interaction.r_blade[2] = z[bladeSec_idx[idx]] - z[bladeSec_idx[idx] - 1];
-                            }                            
+                            }
                             interaction.r_blade_v[0] = r_b[idx][0] - x[bladeSec_idx[idx]];
                             interaction.r_blade_v[1] = r_b[idx][1] - y[bladeSec_idx[idx]];
                             interaction.r_blade_v[2] = r_b[idx][2] - z[bladeSec_idx[idx]];
@@ -396,7 +526,7 @@ void calculate_BWI_points(W, BS, BG)(auto ref W wake, auto ref BS blade_state, s
                                 .tip_vortex_interaction[i_blade_idx].interaction_pts.insertBack(
                                     interaction);
                             //writeln("i_rotor_idx:", i_rotor_idx, "rotor_idx:", rotor_idx, "blade_idx", blade_idx, "i_blade_idx", i_blade_idx);
-                            writeln("2. bwi, interaction point added ");
+                            //writeln("2. bwi, interaction point added ");
                         }
                     }
                 }
@@ -404,6 +534,12 @@ void calculate_BWI_points(W, BS, BG)(auto ref W wake, auto ref BS blade_state, s
             }
         }
     }
+    //GC.collect();
+    //auto  stats3 = GC.stats();
+    //writeln(rotor_idx, blade_idx, "iteration:", iteration, "3. GC used bytes: ", stats3.usedSize);
+    // writeln("3. GC free bytes: ", stats3.freeSize);
+    // writeln("3. GC total bytes: ", stats3.usedSize + stats3.freeSize);
+    //writeln("3. GC page total: ", GC.Stats.pageSize);
 }
 
 Vec3[] get_directionVec(string value, BWI)(auto ref BWI VortexInteraction)
@@ -429,6 +565,31 @@ Vec3[] get_directionVec(string value, BWI)(auto ref BWI VortexInteraction)
 
     }
     return d;
+}
+
+void fill_directionVec(string value, BWI)(
+    auto ref BWI VortexInteraction,
+    ref Vec3[] outVec)
+{
+    immutable elements = VortexInteraction.BWI_inputs.length;
+    if (outVec.length < elements)
+        outVec.length = elements;
+
+    foreach (c_idx, ref chunk; VortexInteraction.BWI_inputs)
+    {
+        immutable out_start_idx = c_idx * chunk_size;
+
+        immutable remaining = elements - out_start_idx;
+
+        //immutable out_end_idx = remaining > chunk_size ? (c_idx + 1)*chunk_size : out_start_idx + remaining;
+        immutable in_end_idx = remaining > chunk_size ? chunk_size : remaining;
+
+        foreach (idx; 0 .. in_end_idx)
+        {
+            mixin("outVec[out_start_idx + idx] = chunk." ~ value ~ "[idx];");
+        }
+
+    }
 }
 
 double sumC_d(double[] arr)

--- a/source/opencopter/python.d
+++ b/source/opencopter/python.d
@@ -206,6 +206,7 @@ alias PyVortexFilament = opencopter.wake.VortexFilamentT!(ArrayContainer.array);
 alias PyBWIinputs = opencopter.bwi.TipVortexInteractionT!(ArrayContainer.array);
 alias PyBladeVortexInteraction = opencopter.bwi.VortexInteractionT!(ArrayContainer.array);
 alias PyShedVortex = opencopter.wake.ShedVortexT!(ArrayContainer.array);
+alias PyInteractionPerRotor = opencopter.bwi.VortexInteraction_multiRotorT!(ArrayContainer.array);
 
 alias PyVortexLattice = opencopter.vortexlattice.VortexLatticeT!(ArrayContainer.array);
 alias PyWingLiftSurf = opencopter.vortexlattice.WingLiftSurfT!(ArrayContainer.array);
@@ -1995,6 +1996,14 @@ extern(C) void PydMain() {
 	);
 
 	wrap_struct!(
+		PyInteractionPerRotor,
+		PyName!"VortexInteractionMultiRotor",
+		Init!(size_t, size_t, size_t, size_t),
+		Member!("blade_vortex_interaction", Docstring!q{An array of :class:`VortexInteraction`}),
+	);
+
+
+	wrap_struct!(
 		PyShedVortex,
 		PyName!"ShedVortex",
 		//Init!(size_t, size_t),
@@ -2004,10 +2013,10 @@ extern(C) void PydMain() {
 	wrap_struct!(
 		PyRotorWake,
 		PyName!"RotorWake",
-		Init!(size_t, size_t, size_t),
+		Init!(size_t, size_t, size_t, size_t),
 		Member!("tip_vortices", Docstring!q{An array of :class:`VortexFilament`}),
 		Member!("shed_vortices", Docstring!q{An array of :class:`ShedVortex`}),
-		Member!("blade_vortex_interaction", Docstring!q{An array of :class:`VortexInteraction`}),
+		Member!("interaction_perRotor", Docstring!q{An array of :class:`VortexInteractionMultiRotor`}),
 	);
 
 	wrap_struct!(
@@ -2629,6 +2638,7 @@ extern(C) void PydMain() {
 	wrap_array!PyWingVortexFilament;
 	wrap_array!PyShedVortex;
 	wrap_array!PyBladeVortexInteraction;
+	wrap_array!PyInteractionPerRotor;
 	wrap_array!PyBWIinputs;
 	wrap_array!(opencopter.bwi.BWIinputsChunk);
 	wrap_array!(opencopter.bwi.InteractionPoints);

--- a/source/opencopter/python.d
+++ b/source/opencopter/python.d
@@ -504,8 +504,16 @@ size_t[] get_interactionPt_wake_idx(ref PyBWIinputs VortexInteraction) {
 	return opencopter.bwi.get_interaction_points!"wake_idx"(VortexInteraction);
 }
 
+void fill_interactionPt_wake_idx(ref PyBWIinputs VortexInteraction, size_t[] outArray) {
+	return opencopter.bwi.fill_indexArray!"wake_idx"(VortexInteraction, outArray);
+}
+
 size_t[] get_interactionPt_bladeSec_idx(ref PyBWIinputs VortexInteraction) {
 	return opencopter.bwi.get_interaction_points!"bladeSec_idx"(VortexInteraction);
+}
+
+void fill_interactionPt_bladeSec_idx(ref PyBWIinputs VortexInteraction, size_t[] outArray) {
+	return opencopter.bwi.fill_indexArray!"bladeSec_idx"(VortexInteraction, outArray);
 }
 
 double[][] get_interaction_point_r_blade(ref PyBWIinputs VortexInteraction) {
@@ -522,6 +530,22 @@ double[][] get_interaction_point_blade_normal(ref PyBWIinputs VortexInteraction)
 
 double[][] get_interaction_point_r_vortex(ref PyBWIinputs VortexInteraction) {
  	return opencopter.bwi.get_interaction_point_directionVec!("r_vortex")(VortexInteraction);
+}
+
+void fill_interaction_point_r_blade(ref PyBWIinputs VortexInteraction, double[][] outArray) {
+ 	return opencopter.bwi.fill_interaction_point_directionVec!("r_blade")(VortexInteraction, outArray);
+}
+
+void fill_interaction_point_r_blade_v(ref PyBWIinputs VortexInteraction, double[][] outArray) {
+ 	return opencopter.bwi.fill_interaction_point_directionVec!("r_blade_v")(VortexInteraction, outArray);
+}
+
+void fill_interaction_point_blade_normal(ref PyBWIinputs VortexInteraction, double[][] outArray) {
+ 	return opencopter.bwi.fill_interaction_point_directionVec!("normal")(VortexInteraction, outArray);
+}
+
+void fill_interaction_point_r_vortex(ref PyBWIinputs VortexInteraction, double[][] outArray) {
+ 	return opencopter.bwi.fill_interaction_point_directionVec!("r_vortex")(VortexInteraction, outArray);
 }
 
 double[] get_interaction_point_gamma_w(ref PyBWIinputs VortexInteraction) {
@@ -551,6 +575,31 @@ double[] get_interaction_point_C_d(ref PyBWIinputs VortexInteraction) {
 double[] get_interaction_point_l(ref PyBWIinputs VortexInteraction) {
  	return opencopter.bwi.get_interaction_point_components!"l"(VortexInteraction);
 }
+
+
+void fill_interaction_point_gamma_w(ref PyBWIinputs VortexInteraction, double[] outArray) {
+ 	return opencopter.bwi.fill_interaction_point_components!"gamma_w"(VortexInteraction, outArray);
+}
+
+void fill_interaction_point_secLen(ref PyBWIinputs VortexInteraction, double[] outArray) {
+ 	return opencopter.bwi.fill_interaction_point_components!"secLen"(VortexInteraction, outArray);
+}
+void fill_interaction_point_r_c(ref PyBWIinputs VortexInteraction, double[] outArray) {
+ 	return opencopter.bwi.fill_interaction_point_components!"r_c"(VortexInteraction, outArray);
+}
+void fill_interaction_point_miss_dist(ref PyBWIinputs VortexInteraction, double[] outArray) {
+ 	return opencopter.bwi.fill_interaction_point_components!"miss_dist"(VortexInteraction, outArray);
+}
+void fill_interaction_point_gamma_sec(ref PyBWIinputs VortexInteraction, double[] outArray) {
+ 	return opencopter.bwi.fill_interaction_point_components!"gamma_sec"(VortexInteraction, outArray);
+}
+void fill_interaction_point_C_d(ref PyBWIinputs VortexInteraction, double[] outArray) {
+ 	return opencopter.bwi.fill_interaction_point_components!"C_d"(VortexInteraction, outArray);
+}
+void fill_interaction_point_l(ref PyBWIinputs VortexInteraction, double[] outArray) {
+ 	return opencopter.bwi.fill_interaction_point_components!"l"(VortexInteraction, outArray);
+}
+
 /*double[] get_interaction_point_TKE(ref PyBWIinputs VortexInteraction) {
  	return opencopter.bwi.get_interaction_point_components!"TKE"(VortexInteraction);
 }*/
@@ -1583,6 +1632,99 @@ extern(C) void PydMain() {
 	});
 
 	def!(get_interaction_point_l, double[] function(ref PyBWIinputs), Docstring!q{
+		Extract vortex length at the point of interaction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract vortex length from
+		:return: List of vortex length
+	});
+
+
+	def!(fill_interactionPt_wake_idx, void function(ref PyBWIinputs, size_t[]), Docstring!q{
+		Extract wake index corresponding to vortex blade interaction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract the wake index from
+		:return: List of wake_idx corresponding to the interactions
+	});
+ 
+	def!(fill_interactionPt_bladeSec_idx, void function(ref PyBWIinputs, size_t[]), Docstring!q{
+		Extract blade section index corresponding to vortex blade interaction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract the blade section index from
+		:return: List of wake_idx corresponding to the interactions
+	});
+
+	def!(fill_interaction_point_r_blade, void function(ref PyBWIinputs, double[][]), Docstring!q{
+		Extract the direction vector of blade segment at the point of interaction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract the direction vector from
+		:return: List of the direction vector of blade segment
+	});
+
+	def!(fill_interaction_point_r_blade_v, void function(ref PyBWIinputs, double[][]), Docstring!q{
+		Extract the direction vector of blade segment at the point of interaction in the inflow direction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract the direction vector from
+		:return: List of the direction vector of blade segment
+	});
+
+	def!(fill_interaction_point_blade_normal, void function(ref PyBWIinputs, double[][]), Docstring!q{
+		Extract the direction vector of blade segment at the point of interaction in the inflow direction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract the direction vector from
+		:return: List of the direction vector of blade segment
+	});
+
+
+	def!(fill_interaction_point_r_vortex, void function(ref PyBWIinputs, double[][]), Docstring!q{
+		Extract the direction vector of the vortex segment at the point of interaction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract the direction vector from
+		:return: List of the direction vector of the vortex segment
+	});
+
+	def!(fill_interaction_point_miss_dist, void function(ref PyBWIinputs, double[]), Docstring!q{
+		Extract miss distance at the point of interaction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract miss distance from
+		:return: List of miss distance
+	});
+
+	def!(fill_interaction_point_gamma_w, void function(ref PyBWIinputs, double[]), Docstring!q{
+		Extract vortex gamma at the point of interaction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract vortex gamma from
+		:return: List of vortex gamma
+	});
+
+	def!(fill_interaction_point_secLen, void function(ref PyBWIinputs, double[]), Docstring!q{
+		Extract section length point of interaction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract section length from
+		:return: List of secLen
+	});
+
+	def!(fill_interaction_point_r_c, void function(ref PyBWIinputs, double[]), Docstring!q{
+		Extract vortex core radius at the point of interaction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract vortex core radius from
+		:return: List of vortex core radius
+	});
+
+	def!(fill_interaction_point_gamma_sec, void function(ref PyBWIinputs, double[]), Docstring!q{
+		Extract blade section gamma at the point of interaction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract blade section gamma from
+		:return: List of blade section gamma
+	});
+
+	def!(fill_interaction_point_C_d, void function(ref PyBWIinputs, double[]), Docstring!q{
+		Extract blade C_d at the point of interaction to a linear array.
+
+		:param BWI_input: the :class:`TipVortexInteraction` to extract blade C_d
+		:return: List of blade C_d
+	});
+
+	def!(fill_interaction_point_l, void function(ref PyBWIinputs, double[]), Docstring!q{
 		Extract vortex length at the point of interaction to a linear array.
 
 		:param BWI_input: the :class:`TipVortexInteraction` to extract vortex length from

--- a/source/opencopter/wake.d
+++ b/source/opencopter/wake.d
@@ -108,7 +108,7 @@ extern(C++) struct RotorWakeT(ArrayContainer AC) {
 	mixin ArrayDeclMixin!(AC, VortexFilamentT!(AC), "tip_vortices");
 	mixin ArrayDeclMixin!(AC, ShedVortexT!(AC), "shed_vortices");
 	// 09/02: Nitya
-	mixin ArrayDeclMixin!(AC, VortexInteractionT!(AC), "blade_vortex_interaction");
+	mixin ArrayDeclMixin!(AC, VortexInteraction_multiRotorT!(AC), "interaction_perRotor");
 
 	Chunk[][] last_gammas;
 
@@ -117,12 +117,13 @@ extern(C++) struct RotorWakeT(ArrayContainer AC) {
 
 	size_t shed_update_rate;
 
-	this(size_t num_blades, size_t radial_elements, size_t _shed_update_rate) {
+	this(size_t num_blades, size_t radial_elements, size_t _shed_update_rate, size_t num_rotors) {
 
 		mixin(array_ctor_mixin!(AC, "VortexFilamentT!(AC)", "tip_vortices", "num_blades"));
 		mixin(array_ctor_mixin!(AC, "ShedVortexT!(AC)", "shed_vortices", "num_blades"));
 		// 09/02: Nitya
-		mixin(array_ctor_mixin!(AC, "VortexInteractionT!(AC)", "blade_vortex_interaction", "num_blades"));
+		mixin(array_ctor_mixin!(AC, "VortexInteraction_multiRotorT!(AC)", "interaction_perRotor", "num_rotors"));
+		debug writeln("interaction_perRotor.length:", interaction_perRotor.length);
 
 		last_gammas = new Chunk[][num_blades];
 
@@ -169,7 +170,7 @@ struct WakeT(ArrayContainer AC) {
 
 		mixin(array_ctor_mixin!(AC, "RotorWakeT!(AC)", "rotor_wakes", "num_rotors"));
 		foreach(r_idx, ref rotor_wake; rotor_wakes) {
-			rotor_wake = RotorWakeT!AC(num_blades, actual_radial_elements, shed_release[r_idx]);
+			rotor_wake = RotorWakeT!AC(num_blades, actual_radial_elements, shed_release[r_idx], num_rotors);
 			foreach(ref filament; rotor_wake.tip_vortices) {
 				filament = VortexFilamentT!AC(actual_wake_history);
 			}
@@ -179,8 +180,12 @@ struct WakeT(ArrayContainer AC) {
 			}
 
 			// 09/02: Nitya
-			foreach(ref interaction; rotor_wake.blade_vortex_interaction) {
-			 	interaction = VortexInteractionT!AC(num_blades, actual_wake_history, actual_radial_elements);
+			debug writeln("1. rotor_wake.interaction_perRotor.length:", rotor_wake.interaction_perRotor.length);
+			debug writeln("r_idx:", r_idx, num_blades);
+			size_t[] num_blades_array;
+			num_blades_array[0] = num_blades;
+			foreach(ref interaction; rotor_wake.interaction_perRotor) {
+			 	interaction = VortexInteraction_multiRotorT!AC(num_blades, num_blades, actual_wake_history, actual_radial_elements);
 			}
 
 			smoothing_buffer ~= new double[actual_wake_history];
@@ -198,7 +203,7 @@ struct WakeT(ArrayContainer AC) {
 		mixin(array_ctor_mixin!(AC, "RotorWakeT!(AC)", "rotor_wakes", "num_rotors"));
 		foreach(r_idx, ref rotor_wake; rotor_wakes) {
 
-			rotor_wake = RotorWakeT!AC(num_blades, actual_radial_elements, shed_release[r_idx]);
+			rotor_wake = RotorWakeT!AC(num_blades, actual_radial_elements, shed_release[r_idx], num_rotors);
 			foreach(ref filament; rotor_wake.tip_vortices) {
 				filament = VortexFilamentT!AC(actual_wake_history[r_idx]);
 			}
@@ -206,10 +211,13 @@ struct WakeT(ArrayContainer AC) {
 			foreach(ref shed_vortex; rotor_wake.shed_vortices) {
 				shed_vortex = ShedVortexT!AC(actual_radial_elements, shed_history[r_idx]);
 			}
-
+			size_t[] num_blades_array;
+			num_blades_array[0] = num_blades;
+			debug writeln("2. rotor_wake.interaction_perRotor.length:", rotor_wake.interaction_perRotor.length);
+			debug writeln("r_idx:", r_idx, num_blades);
 			// 09/02: Nitya
-			foreach(ref interaction; rotor_wake.blade_vortex_interaction) {
-			 	interaction = VortexInteractionT!AC(num_blades, actual_wake_history[r_idx], actual_radial_elements);
+			foreach(ref interaction; rotor_wake.interaction_perRotor) {
+			 	interaction = VortexInteraction_multiRotorT!AC(num_blades, num_blades, actual_wake_history[r_idx], actual_radial_elements);
 			}
 
 			smoothing_buffer ~= new double[actual_wake_history[r_idx]];
@@ -224,7 +232,7 @@ struct WakeT(ArrayContainer AC) {
 
 		mixin(array_ctor_mixin!(AC, "RotorWakeT!(AC)", "rotor_wakes", "num_rotors"));
 		foreach(r_idx, ref rotor_wake; rotor_wakes) {
-			rotor_wake = RotorWakeT!AC(num_blades[r_idx], actual_radial_elements, shed_release[r_idx]);
+			rotor_wake = RotorWakeT!AC(num_blades[r_idx], actual_radial_elements, shed_release[r_idx], num_rotors);
 			foreach(ref filament; rotor_wake.tip_vortices) {
 				filament = VortexFilamentT!AC(actual_wake_history);
 			}
@@ -232,10 +240,11 @@ struct WakeT(ArrayContainer AC) {
 			foreach(ref shed_vortex; rotor_wake.shed_vortices) {
 				shed_vortex = ShedVortexT!AC(actual_radial_elements, shed_history[r_idx]);
 			}
-
+			writeln("3. rotor_wake.interaction_perRotor.length:", rotor_wake.interaction_perRotor.length);
+			writeln("r_idx:", r_idx, num_blades);
 			// 09/02: Nitya
-			foreach(ref interaction; rotor_wake.blade_vortex_interaction) {
-			 	interaction = VortexInteractionT!AC(num_blades[r_idx], actual_wake_history, actual_radial_elements);
+			foreach(r_idx2, ref interaction; rotor_wake.interaction_perRotor) {
+			 	interaction = VortexInteraction_multiRotorT!AC(num_blades[r_idx], num_blades[r_idx2], actual_wake_history, actual_radial_elements);
 			}
 
 			smoothing_buffer ~= new double[actual_wake_history];
@@ -252,7 +261,7 @@ struct WakeT(ArrayContainer AC) {
 		mixin(array_ctor_mixin!(AC, "RotorWakeT!(AC)", "rotor_wakes", "num_rotors"));
 		foreach(r_idx, ref rotor_wake; rotor_wakes) {
 
-			rotor_wake = RotorWakeT!AC(num_blades[r_idx], actual_radial_elements, shed_release[r_idx]);
+			rotor_wake = RotorWakeT!AC(num_blades[r_idx], actual_radial_elements, shed_release[r_idx], num_rotors);
 			foreach(ref filament; rotor_wake.tip_vortices) {
 				debug writeln("filament:", filament);
 				filament = VortexFilamentT!AC(actual_wake_history[r_idx]);
@@ -261,12 +270,12 @@ struct WakeT(ArrayContainer AC) {
 			foreach(ref shed_vortex; rotor_wake.shed_vortices) {
 				shed_vortex = ShedVortexT!AC(actual_radial_elements, shed_history[r_idx]);
 			}
-
+			debug writeln("4. rotor_wake.interaction_perRotor.length:", rotor_wake.interaction_perRotor.length);
+			debug writeln("r_idx:", r_idx, num_blades);
 			// 09/02: Nitya
 			debug writeln("r_idx:", r_idx);
-			foreach(ref interaction; rotor_wake.blade_vortex_interaction) {
-				debug writeln("interaction:", interaction);
-			 	interaction = VortexInteractionT!AC(num_blades[r_idx], actual_wake_history[r_idx], actual_radial_elements);
+			foreach(r_idx2, ref interaction; rotor_wake.interaction_perRotor) {
+			 	interaction = VortexInteraction_multiRotorT!AC(num_blades[r_idx], num_blades[r_idx2], actual_wake_history[r_idx], actual_radial_elements);
 			}
 
 			smoothing_buffer ~= new double[actual_wake_history[r_idx]];
@@ -465,7 +474,7 @@ InducedVelocities compute_filament_induced_velocities(FC, BWI)(auto ref FC chunk
 		v_y[n_idx][] = 0;
 		v_z[n_idx][] = 0;
 	}
-	debug writeln("chunks.length:", chunks.length);
+	//debug writeln("chunks.length:", chunks.length);
 	foreach(i_c_idx, ref chunk_i; chunks[chunk_offset..$]) {
 
 		i_c_idx += chunk_offset;
@@ -790,8 +799,8 @@ InducedVelocities compute_wake_induced_velocities(W, AS)(auto ref W wake, immuta
 
 	if(single_rotor) {
 		foreach(i_blade_idx; 0..ac_state.rotor_states[rotor_idx].blade_states.length) {
-
-			auto ind_vel = compute_filament_induced_velocities(wake.rotor_wakes[rotor_idx].tip_vortices[i_blade_idx].chunks, x, y, z, chunk_offset, wake.rotor_wakes[rotor_idx].blade_vortex_interaction[i_blade_idx].tip_vortex_interaction[i_blade_idx].BWI_inputs, x_old, y_old, z_old, false);
+			BWIinputsChunk[] dummy_chunks;
+			auto ind_vel = compute_filament_induced_velocities(wake.rotor_wakes[rotor_idx].tip_vortices[i_blade_idx].chunks, x, y, z, chunk_offset, dummy_chunks, x_old, y_old, z_old, false);
 			ret.v_x[] += ind_vel.v_x[];
 			ret.v_y[] += ind_vel.v_y[];
 			ret.v_z[] += ind_vel.v_z[];
@@ -801,8 +810,10 @@ InducedVelocities compute_wake_induced_velocities(W, AS)(auto ref W wake, immuta
 		foreach(i_rotor_idx, ref i_rotor; ac_state.rotor_states) {
 			foreach(i_blade_idx; 0..ac_state.rotor_states[i_rotor_idx].blade_states.length) {
 
+				BWIinputsChunk[] dummy_chunks;
+
 				if((i_rotor_idx != rotor_idx) || ((i_rotor_idx == rotor_idx) && (i_blade_idx != blade_idx))) {
-					auto ind_vel = compute_filament_induced_velocities(ac_state.rotor_states[i_rotor_idx].blade_states[i_blade_idx].chunks, x, y, z, 0, wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction[i_blade_idx].tip_vortex_interaction[i_blade_idx].BWI_inputs, x_old, y_old, z_old, false);
+					auto ind_vel = compute_filament_induced_velocities(ac_state.rotor_states[i_rotor_idx].blade_states[i_blade_idx].chunks, x, y, z, 0, dummy_chunks, x_old, y_old, z_old, false);
 					ret_shed.v_x[] += ind_vel.v_x[];
 					ret_shed.v_y[] += ind_vel.v_y[];
 					ret_shed.v_z[] += ind_vel.v_z[];
@@ -811,7 +822,7 @@ InducedVelocities compute_wake_induced_velocities(W, AS)(auto ref W wake, immuta
 				if(!tip_only) {
 					foreach(fil_idx, ref shed_filament; wake.rotor_wakes[i_rotor_idx].shed_vortices[i_blade_idx].shed_filaments) {
 						
-						auto ind_vel = compute_filament_induced_velocities(shed_filament.chunks, x, y, z, 0, wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction[i_blade_idx].tip_vortex_interaction[i_blade_idx].BWI_inputs, x_old, y_old, z_old, false);
+						auto ind_vel = compute_filament_induced_velocities(shed_filament.chunks, x, y, z, 0, dummy_chunks, x_old, y_old, z_old, false);
 						ret_shed.v_x[] += ind_vel.v_x[];
 						ret_shed.v_y[] += ind_vel.v_y[];
 						ret_shed.v_z[] += ind_vel.v_z[];
@@ -826,11 +837,26 @@ InducedVelocities compute_wake_induced_velocities(W, AS)(auto ref W wake, immuta
 					x_old = i_rotor.blade_states[i_blade_idx].chunks[blade_chunk_idx].x_old;
 					y_old = i_rotor.blade_states[i_blade_idx].chunks[blade_chunk_idx].y_old;
 					z_old = i_rotor.blade_states[i_blade_idx].chunks[blade_chunk_idx].z_old;
-					auto ind_vel = compute_filament_induced_velocities(wake.rotor_wakes[i_rotor_idx].tip_vortices[i_blade_idx].chunks, x, y, z, chunk_offset, wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].BWI_inputs, x_old, y_old, z_old, blade_chunk_idx, trackBWIevents);
+
+					auto ind_vel = compute_filament_induced_velocities(wake.rotor_wakes[i_rotor_idx].tip_vortices[i_blade_idx].chunks, x, y, z, chunk_offset, wake.rotor_wakes[i_rotor_idx].interaction_perRotor[rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].BWI_inputs, x_old, y_old, z_old, blade_chunk_idx, trackBWIevents);
 					ret.v_x[] += ind_vel.v_x[];
 					ret.v_y[] += ind_vel.v_y[];
 					ret.v_z[] += ind_vel.v_z[];
-
+					/*
+					if(rotor_idx == i_rotor_idx) {
+						debug writeln("wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction.length:", wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction.length);
+						debug writeln("wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length:" , wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length);
+						auto ind_vel = compute_filament_induced_velocities(wake.rotor_wakes[i_rotor_idx].tip_vortices[i_blade_idx].chunks, x, y, z, chunk_offset, wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].BWI_inputs, x_old, y_old, z_old, blade_chunk_idx, trackBWIevents);
+						ret.v_x[] += ind_vel.v_x[];
+						ret.v_y[] += ind_vel.v_y[];
+						ret.v_z[] += ind_vel.v_z[];
+					} else{
+						BWIinputsChunk[] dummy_chunks;
+						auto ind_vel = compute_filament_induced_velocities(wake.rotor_wakes[i_rotor_idx].tip_vortices[i_blade_idx].chunks, x, y, z, chunk_offset, dummy_chunks, x_old, y_old, z_old, blade_chunk_idx, false);
+						ret.v_x[] += ind_vel.v_x[];
+						ret.v_y[] += ind_vel.v_y[];
+						ret.v_z[] += ind_vel.v_z[];
+					}*/
 				}
 			}
 		}

--- a/source/opencopter/wake.d
+++ b/source/opencopter/wake.d
@@ -180,8 +180,7 @@ struct WakeT(ArrayContainer AC) {
 			}
 
 			// 09/02: Nitya
-			debug writeln("1. rotor_wake.interaction_perRotor.length:", rotor_wake.interaction_perRotor.length);
-			debug writeln("r_idx:", r_idx, num_blades);
+			
 			size_t[] num_blades_array;
 			num_blades_array[0] = num_blades;
 			foreach(ref interaction; rotor_wake.interaction_perRotor) {
@@ -213,8 +212,6 @@ struct WakeT(ArrayContainer AC) {
 			}
 			size_t[] num_blades_array;
 			num_blades_array[0] = num_blades;
-			debug writeln("2. rotor_wake.interaction_perRotor.length:", rotor_wake.interaction_perRotor.length);
-			debug writeln("r_idx:", r_idx, num_blades);
 			// 09/02: Nitya
 			foreach(ref interaction; rotor_wake.interaction_perRotor) {
 			 	interaction = VortexInteraction_multiRotorT!AC(num_blades, num_blades, actual_wake_history[r_idx], actual_radial_elements);
@@ -240,8 +237,6 @@ struct WakeT(ArrayContainer AC) {
 			foreach(ref shed_vortex; rotor_wake.shed_vortices) {
 				shed_vortex = ShedVortexT!AC(actual_radial_elements, shed_history[r_idx]);
 			}
-			writeln("3. rotor_wake.interaction_perRotor.length:", rotor_wake.interaction_perRotor.length);
-			writeln("r_idx:", r_idx, num_blades);
 			// 09/02: Nitya
 			foreach(r_idx2, ref interaction; rotor_wake.interaction_perRotor) {
 			 	interaction = VortexInteraction_multiRotorT!AC(num_blades[r_idx], num_blades[r_idx2], actual_wake_history, actual_radial_elements);
@@ -270,10 +265,8 @@ struct WakeT(ArrayContainer AC) {
 			foreach(ref shed_vortex; rotor_wake.shed_vortices) {
 				shed_vortex = ShedVortexT!AC(actual_radial_elements, shed_history[r_idx]);
 			}
-			debug writeln("4. rotor_wake.interaction_perRotor.length:", rotor_wake.interaction_perRotor.length);
-			debug writeln("r_idx:", r_idx, num_blades);
+			
 			// 09/02: Nitya
-			debug writeln("r_idx:", r_idx);
 			foreach(r_idx2, ref interaction; rotor_wake.interaction_perRotor) {
 			 	interaction = VortexInteraction_multiRotorT!AC(num_blades[r_idx], num_blades[r_idx2], actual_wake_history[r_idx], actual_radial_elements);
 			}
@@ -474,7 +467,7 @@ InducedVelocities compute_filament_induced_velocities(FC, BWI)(auto ref FC chunk
 		v_y[n_idx][] = 0;
 		v_z[n_idx][] = 0;
 	}
-	//debug writeln("chunks.length:", chunks.length);
+	
 	foreach(i_c_idx, ref chunk_i; chunks[chunk_offset..$]) {
 
 		i_c_idx += chunk_offset;
@@ -744,7 +737,6 @@ InducedVelocities compute_filament_induced_velocities(FC, BWI)(auto ref FC chunk
 							dx_b = x[n_idx] - x_old[n_idx];
 							dy_b = y[n_idx] - y_old[n_idx];
 							dz_b = z[n_idx] - z_old[n_idx];
-							// BWIinputs[i_c_idx].r_blade_v[bwi_idx] = Vec3(dx_b, dy_b, dz_b);
 							BWIinputs[i_c_idx].pos_v[bwi_idx] = Vec3(x_a[bwi_idx], y_a[bwi_idx], z_a[bwi_idx]);
 						}
 					}
@@ -754,11 +746,7 @@ InducedVelocities compute_filament_induced_velocities(FC, BWI)(auto ref FC chunk
 					foreach(bwi_idx;0..Chunk.length){
 						dl = (dx[bwi_idx]*dx[bwi_idx] + dy[bwi_idx]*dy[bwi_idx] + dz[bwi_idx]*dz[bwi_idx]);
 						dl = sqrt(dl);
-						BWIinputs[i_c_idx].dl[bwi_idx] = dl;
-						/*if(bwi_idx==Chunk.length-1) {
-							debug writeln("i_c_idx:", i_c_idx, "BWIinputs[i_c_idx].dl:", BWIinputs[i_c_idx].dl);
-						}*/
-                                            
+						BWIinputs[i_c_idx].dl[bwi_idx] = dl;                                            
 					}
 				}
 			}
@@ -842,21 +830,6 @@ InducedVelocities compute_wake_induced_velocities(W, AS)(auto ref W wake, immuta
 					ret.v_x[] += ind_vel.v_x[];
 					ret.v_y[] += ind_vel.v_y[];
 					ret.v_z[] += ind_vel.v_z[];
-					/*
-					if(rotor_idx == i_rotor_idx) {
-						debug writeln("wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction.length:", wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction.length);
-						debug writeln("wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length:" , wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction.length);
-						auto ind_vel = compute_filament_induced_velocities(wake.rotor_wakes[i_rotor_idx].tip_vortices[i_blade_idx].chunks, x, y, z, chunk_offset, wake.rotor_wakes[i_rotor_idx].blade_vortex_interaction[blade_idx].tip_vortex_interaction[i_blade_idx].BWI_inputs, x_old, y_old, z_old, blade_chunk_idx, trackBWIevents);
-						ret.v_x[] += ind_vel.v_x[];
-						ret.v_y[] += ind_vel.v_y[];
-						ret.v_z[] += ind_vel.v_z[];
-					} else{
-						BWIinputsChunk[] dummy_chunks;
-						auto ind_vel = compute_filament_induced_velocities(wake.rotor_wakes[i_rotor_idx].tip_vortices[i_blade_idx].chunks, x, y, z, chunk_offset, dummy_chunks, x_old, y_old, z_old, blade_chunk_idx, false);
-						ret.v_x[] += ind_vel.v_x[];
-						ret.v_y[] += ind_vel.v_y[];
-						ret.v_z[] += ind_vel.v_z[];
-					}*/
 				}
 			}
 		}


### PR DESCRIPTION
1. Fixed the issue with the namelist file of the individual rotor. The code incorrectly wrote the file number, defaulting rotor_idx = 0. As a result, all rotors referenced the first rotor’s input file.
2.BWI: The code now stores interactions from tip vortices of other rotors. This still has memory issue that we discussed earlier. Blue Ridge knows about it and they prefer a faster version even if it takes up more memory.

