### PR TITLE
Add HART-II validation scripts

### DIFF
--- a/validation/HART_II/validate_hart_mat.py
+++ b/validation/HART_II/validate_hart_mat.py
@@ -1,0 +1,93 @@
+import sys
+import argparse
+import numpy as np
+from scipy.io import loadmat
+
+
+class ValidationResult:
+    def __init__(self, error_value, threshold, passed):
+        self.error_value = error_value
+        self.threshold = threshold
+        self.passed = passed
+
+
+class L2Validator:
+    def __init__(self, threshold=0.15):
+        self.threshold = threshold
+
+    def l2_norm(self, signal):
+        return float(np.sqrt(np.sum(signal * signal)))
+
+    def normalized_l2_error(self, new_signal, baseline_signal):
+
+        new_signal = np.ravel(new_signal)
+        baseline_signal = np.ravel(baseline_signal)
+
+        n = min(len(new_signal), len(baseline_signal))
+
+        new_signal = new_signal[:n]
+        baseline_signal = baseline_signal[:n]
+
+        difference = new_signal - baseline_signal
+
+        numerator = self.l2_norm(difference)
+        denominator = self.l2_norm(baseline_signal) + 1e-12
+
+        return numerator / denominator
+
+    def validate(self, new_signal, baseline_signal):
+        error = self.normalized_l2_error(new_signal, baseline_signal)
+        passed = error <= self.threshold
+        return ValidationResult(error, self.threshold, passed)
+
+
+def load_mat_signal(mat_path, key):
+
+    data = loadmat(mat_path)
+
+    if key not in data:
+        raise KeyError(f"{key} not found in {mat_path}")
+
+    return np.asarray(data[key], dtype=np.float64)
+
+
+def main():
+
+    parser = argparse.ArgumentParser(
+        description="Validate OpenCOPTER MAT outputs using normalized L2 error"
+    )
+
+    parser.add_argument("--baseline", required=True)
+    parser.add_argument("--new", required=True)
+    parser.add_argument("--key", required=True)
+    parser.add_argument("--threshold", type=float, default=0.15)
+
+    args = parser.parse_args()
+
+    baseline_signal = load_mat_signal(args.baseline, args.key)
+    new_signal = load_mat_signal(args.new, args.key)
+
+    print("Baseline file:", args.baseline)
+    print("New file:", args.new)
+    print("Key:", args.key)
+
+    print("Baseline shape:", baseline_signal.shape)
+    print("New shape:", new_signal.shape)
+
+    validator = L2Validator(threshold=args.threshold)
+
+    result = validator.validate(new_signal, baseline_signal)
+
+    print("Normalized L2 error:", result.error_value)
+    print("Threshold:", result.threshold)
+
+    if result.passed:
+        print("PASS")
+        return 0
+    else:
+        print("FAIL")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/validation/HART_II/validate_hart_oop.py
+++ b/validation/HART_II/validate_hart_oop.py
@@ -1,0 +1,85 @@
+# validation script for HART-II
+# this will compare a new predicted signal to a baseline signal using normalized L2 error
+#not the FINAL VERSION-prot1
+
+import sys
+import numpy as np
+
+
+
+
+class ValidationResult:
+    # object to hold the final validation result
+    def __init__(self, error_value, threshold, passed):
+        self.error_value = error_value
+        self.threshold = threshold
+        self.passed = passed
+
+
+class L2Validator:
+    # object that computes L2 error and decides pass/fail
+    def __init__(self, threshold=0.02):
+        self.threshold = threshold
+
+    def l2_norm(self, signal):
+        # L2 norm = sqrt(sum(signal_i^2))
+        squared_values = signal * signal
+        total = np.sum(squared_values)
+        return float(np.sqrt(total))
+
+    def normalized_l2_error(self, new_signal, baseline_signal):
+        # making  both signals the same length before comparing
+        n = min(len(new_signal), len(baseline_signal))
+
+        new_signal = new_signal[:n]
+        baseline_signal = baseline_signal[:n]
+
+        difference = new_signal - baseline_signal
+
+        numerator = self.l2_norm(difference)
+        denominator = self.l2_norm(baseline_signal) + 1e-12
+
+        return numerator / denominator
+
+    def validate(self, new_signal, baseline_signal):
+        error = self.normalized_l2_error(new_signal, baseline_signal)
+
+        if error <= self.threshold:
+            passed = True
+        else:
+            passed = False
+
+        return ValidationResult(error, self.threshold, passed)
+
+
+class HartIIDemo:
+    # demo class using placeholder arrays until real HART-II files can be loaded
+    def __init__(self):
+        self.baseline_signal = np.array([1.1, 2.0, 2.9, 4.2])
+        self.new_signal = np.array([1.0, 2.0, 3.0, 4.0])
+
+        self.validator = L2Validator(threshold=0.15)
+
+    def run(self):
+        result = self.validator.validate(self.new_signal, self.baseline_signal)
+
+        print("HART-II validation demo")
+        print("Normalized L2 error:", result.error_value)
+        print("Threshold:", result.threshold)
+
+        if result.passed:
+            print("PASS")
+            return 0
+        else:
+            print("FAIL")
+            return 1
+
+
+def main():
+    demo = HartIIDemo()
+    return demo.run()
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+

--- a/validation/HART_II/validate_real_hart_tec.py
+++ b/validation/HART_II/validate_real_hart_tec.py
@@ -1,0 +1,90 @@
+# Loads real HART-II .tec measurement files and computes normalized L2 error.
+# This will  tests the file-reading + L2 validation logic using actual HART-II data files.
+#not FINAL-prot2
+import sys
+import numpy as np
+
+
+class ValidationResult:
+    def __init__(self, error_value, threshold, passed):
+        self.error_value = error_value
+        self.threshold = threshold
+        self.passed = passed
+
+
+class L2Validator:
+    def __init__(self, threshold=0.15):
+        self.threshold = threshold
+
+    def l2_norm(self, signal):
+        return float(np.sqrt(np.sum(signal * signal)))
+
+    def normalized_l2_error(self, new_signal, baseline_signal):
+        n = min(len(new_signal), len(baseline_signal))
+
+        new_signal = new_signal[:n]
+        baseline_signal = baseline_signal[:n]
+
+        difference = new_signal - baseline_signal
+
+        numerator = self.l2_norm(difference)
+        denominator = self.l2_norm(baseline_signal) + 1e-12
+
+        return numerator / denominator
+
+    def validate(self, new_signal, baseline_signal):
+        error = self.normalized_l2_error(new_signal, baseline_signal)
+        passed = error <= self.threshold
+        return ValidationResult(error, self.threshold, passed)
+
+
+def load_tec_file(file_path):
+    numeric_rows = []
+
+    with open(file_path, "r") as file:
+        for line in file:
+            parts = line.split()
+
+            try:
+                row = [float(value) for value in parts]
+                numeric_rows.append(row)
+            except ValueError:
+                # to skip header lines like TITLE, VARIABLES, ZONE
+                pass
+
+    return np.array(numeric_rows)
+
+
+def main():
+    baseline_path = "oc_fly/example/hart_ii/mn-contour-meas.tec"
+    new_path = "oc_fly/example/hart_ii/mv-contour-meas.tec"
+
+    baseline_data = load_tec_file(baseline_path)
+    new_data = load_tec_file(new_path)
+
+    print("Baseline file:", baseline_path)
+    print("New file:", new_path)
+    print("Baseline shape:", baseline_data.shape)
+    print("New shape:", new_data.shape)
+
+    baseline_signal = baseline_data[:, 5]
+    new_signal = new_data[:, 5]
+
+    validator = L2Validator(threshold=0.15)
+    result = validator.validate(new_signal, baseline_signal)
+
+    print("Compared column: OASPL1to244")
+    print("Normalized L2 error:", result.error_value)
+    print("Threshold:", result.threshold)
+
+    if result.passed:
+        print("PASS")
+        return 0
+    else:
+        print("FAIL")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+


### PR DESCRIPTION
## Summary

This PR adds initial HART-II validation scripts for OpenCOPTER outputs.

### Added

* `validate_hart_mat.py`
* `validate_hart_oop.py`
* `validate_real_hart_tec.py`

### Current status

* `validate_hart_mat.py` is the primary validation script and operates on actual OpenCOPTER `results.mat` outputs using normalized L2 error and PASS/FAIL criteria.
* `validate_hart_oop.py` is an earlier object-oriented prototype used during development.
* `validate_real_hart_tec.py` is an experimental script intended for future comparisons against experimental HART-II `.tec` data.

Initial testing using `span_element_loading` showed:

* BL vs BL → PASS
* BL vs MN → FAIL (expected)

This PR represents an initial step toward integrating HART-II validation into the existing CI workflow.
